### PR TITLE
Rename the file DevSection to DeveloperSettings

### DIFF
--- a/src/components/settings-menu/DeveloperSettings.js
+++ b/src/components/settings-menu/DeveloperSettings.js
@@ -18,7 +18,7 @@ import { walletsUpdate } from '@rainbow-me/redux/wallets';
 import Routes from '@rainbow-me/routes';
 import logger from 'logger';
 
-const DevSection = () => {
+const DeveloperSettings = () => {
   const { navigate } = useNavigation();
   const { config, setConfig } = useContext(RainbowContext);
   const { wallets } = useWallets();
@@ -102,4 +102,4 @@ const DevSection = () => {
   );
 };
 
-export default DevSection;
+export default DeveloperSettings;

--- a/src/screens/SettingsModal.js
+++ b/src/screens/SettingsModal.js
@@ -14,7 +14,7 @@ import {
 import SettingsBackupView from '../components/settings-menu/BackupSection/SettingsBackupView';
 import ShowSecretView from '../components/settings-menu/BackupSection/ShowSecretView';
 import WalletSelectionView from '../components/settings-menu/BackupSection/WalletSelectionView';
-import DevSection from '../components/settings-menu/DevSection';
+import DeveloperSettings from '../components/settings-menu/DeveloperSettings';
 import { useTheme } from '../context/ThemeContext';
 import WalletTypes from '../helpers/walletTypes';
 import { useDimensions, useWallets } from '../hooks';
@@ -73,7 +73,7 @@ const SettingsPages = {
     title: 'Settings',
   },
   dev: {
-    component: IS_DEV ? DevSection : null,
+    component: IS_DEV ? DeveloperSettings : null,
     key: 'DevSection',
     title: 'Dev',
   },


### PR DESCRIPTION
The naming conventions used throughout this repo are pretty bad and non-descriptive. We should use best practices and name things exactly what they are going forward.

We should always favor longer, verbose naming over short, obtuse naming conventions.