### PR TITLE
ci: add alternate job for tagging a non version bump release

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,13 +7,29 @@ on:
         required: true
         default: 'none'
 jobs:
-  create-tag:
-    name: Create tag
+  create-new-tag:
+    name: Create new tag
+    if: ${{ github.event.inputs.versionChangeType == 'none' }}
+    runs-on: macos-latest
+    env:
+      GITHUB_AUTH_TOKEN: ${{ secrets.CI_GITHUB_PERSONAL_ACCESS_TOKEN }}
+      BASE_BRANCH: 'develop'
+      BRANCH_TO_TAG: 'develop'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BASE_BRANCH }}
+      - name: Create tag
+        run: cd ci-scripts && yarn && yarn createTag
+  create-new-tag-with-version-bump:
+    name: Create new tag with version bump
+    if: ${{ github.event.inputs.versionChangeType != 'none' }}
     runs-on: macos-latest
     env:
       VERSION_CHANGE_TYPE: ${{ github.event.inputs.versionChangeType }}
       GITHUB_AUTH_TOKEN: ${{ secrets.CI_GITHUB_PERSONAL_ACCESS_TOKEN }}
       BASE_BRANCH: 'develop'
+      BRANCH_TO_TAG: 'release/${{ github.event.inputs.versionChangeType }}-version-${{ github.run_id }}'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -24,11 +40,13 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.CI_GITHUB_PERSONAL_ACCESS_TOKEN }}
-          branch: 'release/${{ env.VERSION_CHANGE_TYPE }}-version-${{ env.GITHUB_RUN_NUMBER }}'
-          title: 'release: ${{ env.VERSION_CHANGE_TYPE }} version release'
-          commit-message: 'release: ${{ env.VERSION_CHANGE_TYPE }} version release from ${{ env.GITHUB_RUN_NUMBER }}'
+          branch: '${{ env.BRANCH_TO_TAG }}'
+          title: 'release: ${{ github.event.inputs.versionChangeType }} version release'
+          commit-message: 'release: ${{ github.event.inputs.versionChangeType }} version release'
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          labels: |
+            release
+            automated pr
           delete-branch: true
       - name: Create tag
         run: cd ci-scripts && yarn && yarn createTag
-        env:
-          BRANCH_TO_TAG: 'release/${{ env.VERSION_CHANGE_TYPE }}-version-${{ env.GITHUB_RUN_NUMBER }}'


### PR DESCRIPTION
### Description

Adds an alternate job for the tagging workflow when the version is not bumped.
