### PR TITLE
ci: fix env value usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,11 @@ jobs:
     env:
       CRYPTEX_GIT_URL: https://${{ secrets.CI_GITHUB_PERSONAL_ACCESS_TOKEN }}@github.com/${{ secrets.CRYPTEX_GIT_REPOSITORY }}.git
       CRYPTEX_PASSWORD: ${{ secrets.CRYPTEX_PASSWORD }}
-      GIT_REF: ${{ github.events.inputs.githubRef }}
-      FASTLANE_STAGE: ${{ github.events.inputs.releaseStage }}
     steps:
       - name: Checkout tag
         uses: actions/checkout@v2
         with:
-          ref: ${{ env.GIT_REF }}
+          ref: ${{ github.events.inputs.githubRef }}
       - name: Node
         uses: actions/setup-node@v1
         with:
@@ -52,6 +50,7 @@ jobs:
         run: cd ios && bundle exec fastlane ${{ env.FASTLANE_STAGE }} build_number:"${{ env.BUILD_NUMBER }}"
         env:
           BUILD_NUMBER: ${{ github.run_number }}
+          FASTLANE_STAGE: ${{ github.events.inputs.releaseStage }}
           FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLICATION_SPECIFIC_PASSWORD }}
           MATCH_GIT_URL: ${{ env.CRYPTEX_GIT_URL }}
           MATCH_PASSWORD: ${{ env.CRYPTEX_PASSWORD }}


### PR DESCRIPTION
### Description

Manual dispatch doesn't assign the top-level ENV values the same as other triggers. Moved to the step level.