### PR TITLE
CS-385 Fix crash on "Create Account"

### DIFF
--- a/cardstack/src/components/Sheet/Sheet.tsx
+++ b/cardstack/src/components/Sheet/Sheet.tsx
@@ -20,7 +20,7 @@ export const Sheet = ({
         backgroundColor="white"
         borderTopStartRadius={borderRadius}
         borderTopEndRadius={borderRadius}
-        paddingBottom={insets.bottom - 10}
+        paddingBottom={insets.bottom / 2}
         width="100%"
       >
         <Container

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "install-pods-fast": "cd ios && bundle exec pod install && cd ..",
     "install-pods-no-flipper": "cd ios && bundle exec env SKIP_FLIPPER=true pod install --repo-update && cd ..",
     "ios": "react-native run-ios --simulator='iPhone 11'",
+    "ios:small": "react-native run-ios --simulator='iPhone SE'",
     "lint": "eslint --ext '.ts,.tsx,.js,.jsx' cardstack",
     "nodeify": "rn-nodeify --install --hack 'crypto,buffer,react-native-randombytes,vm,stream,http,https,os,url,net,fs,process'",
     "ts-check": "yarn tsc --skipLibCheck --noEmit",

--- a/src/screens/QRScannerScreen.js
+++ b/src/screens/QRScannerScreen.js
@@ -105,8 +105,8 @@ const QRScannerScreen = () => {
         <CameraDimmer>
           {initializeCamera && (
             <QRCodeScanner
-              contentPositionBottom={sheetHeight}
-              contentPositionTop={-HeaderHeight * 2}
+              contentPositionBottom={sheetHeight + HeaderHeight}
+              contentPositionTop={HeaderHeight}
               enableCamera={ios ? isFocusedIOS : isFocusedAndroid}
             />
           )}


### PR DESCRIPTION
### Description

On smaller devices, insets.bottom evaluates to 0 and there's -10 being applied to it. As a result, bottom padding is evaluating to be -10 (restyle doesn't support negative values because it bases spacing on object keys). Also, adjustments to QR Scanner Screen for smaller devices.

- [x] Completes #385

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots
### **Before**
![Simulator Screen Shot - iPhone 8 - 2021-04-23 at 11 16 37](https://user-images.githubusercontent.com/19397130/115925661-59feeb80-a436-11eb-8356-ee545de2e6b5.png)

### **After**

https://user-images.githubusercontent.com/19397130/115925250-b1508c00-a435-11eb-9121-888446137934.mov

