### PR TITLE
fix:  Unblocks user from importing account on Layer 2

### DIFF
--- a/src/screens/ImportSeedPhraseSheet.js
+++ b/src/screens/ImportSeedPhraseSheet.js
@@ -222,11 +222,20 @@ export default function ImportSeedPhraseSheet() {
         return;
       }
     } else if (isValidAddress(input)) {
-      const ens = await web3Provider.lookupAddress(input);
-      if (ens && ens !== input) {
-        name = ens;
+      try {
+        // Layer 1 uses JSONRPCProvider (with lookupAddress) (ethers project - handles both mnemonic and address values)
+        // Layer 2 uses httpProvider (without lookupAddress) (web3 - limited to only address), return null
+        // TODO: Find equivalent to handle both provider types in order to reverse lookup address for either address and mnemonic values
+        const ens = web3Provider.lookupAddress
+          ? await web3Provider.lookupAddress(input)
+          : null;
+        if (ens && ens !== input) {
+          name = ens;
+        }
+        showWalletProfileModal(name);
+      } catch (error) {
+        console.log({ error });
       }
-      showWalletProfileModal(name);
     } else {
       try {
         setBusy(true);


### PR DESCRIPTION

### Description

Temporary fix for name of account if addressLookup method is undefined. Unblocks user from importing account if on Layer 2. New ticket https://linear.app/cardstack/issue/CS-674/create-ens-provider-to-handle-both-layer-1-and-layer-2 should address reverse lookup for either layer
