### PR TITLE
fix: asset + transaction list spacing

### DIFF
--- a/src/components/activity-list/RecyclerActivityList.js
+++ b/src/components/activity-list/RecyclerActivityList.js
@@ -95,9 +95,9 @@ export default class RecyclerActivityList extends PureComponent {
         // This values has been hardcoded for omitting imports' cycle
         dim.width = deviceUtils.dimensions.width;
         if (type === ViewTypes.ROW) {
-          dim.height = 70;
+          dim.height = 86;
         } else if (type === ViewTypes.SWAPPED_ROW) {
-          dim.height = 70;
+          dim.height = 86;
         } else if (type === ViewTypes.FOOTER) {
           dim.height = 19;
         } else if (type === ViewTypes.HEADER) {

--- a/src/components/coin-row/CoinRow.js
+++ b/src/components/coin-row/CoinRow.js
@@ -5,10 +5,14 @@ import { Column, Row } from '../layout';
 import { useAccountSettings } from '@rainbow-me/hooks';
 import { padding } from '@rainbow-me/styles';
 
+const CoinRowVerticalMargin = 12;
 const CoinRowPaddingTop = 9;
 const CoinRowPaddingBottom = 10;
 export const CoinRowHeight =
-  CoinIconSize + CoinRowPaddingTop + CoinRowPaddingBottom;
+  CoinIconSize +
+  CoinRowPaddingTop +
+  CoinRowPaddingBottom +
+  CoinRowVerticalMargin * 2;
 
 const Container = styled(Row).attrs({
   align: 'center',


### PR DESCRIPTION

![Simulator Screen Shot - iPhone 8 - 2021-04-28 at 16 14 02](https://user-images.githubusercontent.com/7504299/116483934-f06b4c80-a83c-11eb-9259-e236a11657d6.png)
### Description

Fix spacing for the items in a transaction list and asset list.

- [x] Completes #(CS-629)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

![Simulator Screen Shot - iPhone 11 - 2021-04-28 at 15 30 04](https://user-images.githubusercontent.com/7504299/116480688-a41d0e00-a836-11eb-9d0e-1c7211670e7f.png)
![Simulator Screen Shot - iPhone 11 - 2021-04-28 at 15 27 13](https://user-images.githubusercontent.com/7504299/116480692-a54e3b00-a836-11eb-8d65-e3e3657c3fa6.png)
