### PR TITLE
fix: lookup address during seedphrase import in layer 1 network only

### DIFF
--- a/src/screens/ImportSeedPhraseSheet.js
+++ b/src/screens/ImportSeedPhraseSheet.js
@@ -244,7 +244,11 @@ export default function ImportSeedPhraseSheet() {
             input
           );
           setCheckedWallet(walletResult);
-          const ens = await web3Provider.lookupAddress(walletResult.address);
+
+          const ens = web3Provider.lookupAddress
+            ? await web3Provider.lookupAddress(walletResult.address)
+            : null;
+
           if (ens && ens !== input) {
             name = ens;
           }


### PR DESCRIPTION
### Description

Extends the fix @SparkleFaerieCoder added to avoid calling the address lookup when connected to a layer two network.
