### PR TITLE
feat: restyle network indicator component

### DIFF
--- a/src/components/toasts/TestnetToast.js
+++ b/src/components/toasts/TestnetToast.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { web3Provider } from '../../handlers/web3';
 import networkInfo from '../../helpers/networkInfo';
-import networkTypes from '../../helpers/networkTypes';
 import { useAccountSettings, useInternetStatus } from '../../hooks';
 import { Icon } from '../icons';
 import { Nbsp, Text } from '../text';
@@ -24,7 +23,7 @@ const TestnetToast = () => {
 
   return (
     <Toast isVisible={visible} testID={`testnet-toast-${networkName}`}>
-      <Icon color={color} marginHorizontal={5} marginTop={5} name="dot" />
+      <Icon color={color} marginHorizontal={5} name="dot" />
       <Text color={colors.white} size="smedium" weight="semibold">
         <Nbsp /> {networkName} <Nbsp />
       </Text>

--- a/src/components/toasts/Toast.js
+++ b/src/components/toasts/Toast.js
@@ -24,11 +24,11 @@ const Container = styled(RowWithMargins).attrs({
   margin: 5,
   self: 'center',
 })`
-  ${padding(9, 10, 11, 10)};
+  ${padding(9, 11, 11, 12)};
   ${position.centered};
   ${({ theme: { colors } }) => shadow.build(0, 6, 10, colors.shadow, 0.14)};
   background-color: ${({ color }) => color};
-  border-radius: 20;
+  border-radius: 24px;
   bottom: ${({ insets }) => (insets.bottom || 40) + 3};
   max-width: ${({ deviceWidth }) => deviceWidth - 38};
   position: absolute;
@@ -56,7 +56,7 @@ export default function Toast({
   textColor,
   ...props
 }) {
-  const { colors, isDarkMode } = useTheme();
+  const { colors } = useTheme();
   const { width: deviceWidth } = useDimensions();
   const insets = useSafeArea();
 
@@ -72,12 +72,10 @@ export default function Toast({
     outputRange: [distance, targetTranslate],
   });
 
-  const currentColor = color || isDarkMode ? colors.darkModeDark : colors.dark;
-
   return (
     <Animated.View style={{ opacity, transform: [{ translateY }] }}>
       <Container
-        color={currentColor}
+        color="black"
         deviceWidth={deviceWidth}
         insets={insets}
         testID={testID}


### PR DESCRIPTION
### Description

Restyle network indicator component

- [x] Completes #(CS-291)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<img width="433" alt="Screen Shot 2021-04-29 at 7 04 17 AM" src="https://user-images.githubusercontent.com/7504299/116563742-29490700-a8b9-11eb-9e08-8f0f800af8cc.png">
<img width="422" alt="Screen Shot 2021-04-29 at 7 04 10 AM" src="https://user-images.githubusercontent.com/7504299/116563743-29e19d80-a8b9-11eb-8fe9-e2927829254e.png">
<img width="434" alt="Screen Shot 2021-04-29 at 7 04 03 AM" src="https://user-images.githubusercontent.com/7504299/116563745-2a7a3400-a8b9-11eb-85c6-4256e0e8ab81.png">
<img width="435" alt="Screen Shot 2021-04-29 at 7 03 55 AM" src="https://user-images.githubusercontent.com/7504299/116563752-2b12ca80-a8b9-11eb-9cb7-511909ad8d47.png">
<img width="436" alt="Screen Shot 2021-04-29 at 7 03 48 AM" src="https://user-images.githubusercontent.com/7504299/116563754-2bab6100-a8b9-11eb-956f-42548782debd.png">
<img width="432" alt="Screen Shot 2021-04-29 at 7 03 35 AM" src="https://user-images.githubusercontent.com/7504299/116563757-2c43f780-a8b9-11eb-9cd2-cb769f6121e4.png">
<img width="420" alt="Screen Shot 2021-04-29 at 7 03 27 AM" src="https://user-images.githubusercontent.com/7504299/116563761-2d752480-a8b9-11eb-8b53-d861e29dd8fd.png">
