### PR TITLE
fix: add background to testnet transaction history view

### DIFF
--- a/src/components/activity-list/ActivityList.js
+++ b/src/components/activity-list/ActivityList.js
@@ -132,10 +132,7 @@ const ActivityList = ({
       />
     )
   ) : (
-    <ActivityListEmptyState
-      emoji="👻"
-      label="Your testnet transaction history starts now!"
-    >
+    <ActivityListEmptyState label="Your testnet transaction history starts now!">
       {header}
     </ActivityListEmptyState>
   );

--- a/src/components/activity-list/ActivityListEmptyState.js
+++ b/src/components/activity-list/ActivityListEmptyState.js
@@ -1,15 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { View } from 'react-native';
 import styled from 'styled-components';
 
 import { deviceUtils } from '../../utils';
 import { Centered, Column } from '../layout';
-import { Text } from '@cardstack/components';
+import { Container, Text } from '@cardstack/components';
 
 const verticalOffset = (deviceUtils.dimensions.height - 420) / 3;
 
-const Container = styled(Column)`
+const Content = styled(Column)`
   align-self: center;
   margin-top: ${verticalOffset};
   width: 200;
@@ -17,14 +16,16 @@ const Container = styled(Column)`
 
 const ActivityListEmptyState = ({ children, label }) => {
   return (
-    <View>
+    <Container backgroundColor="backgroundBlue" flex={1}>
       {children}
-      <Container>
+      <Content>
         <Centered>
-          <Text color="grayText">{label}</Text>
+          <Text color="grayText" textAlign="center">
+            {label}
+          </Text>
         </Centered>
-      </Container>
-    </View>
+      </Content>
+    </Container>
   );
 };
 


### PR DESCRIPTION
### Description

- Adds a background color for testnet transaction history in an empty state.

- [x] Completes #(CS-637)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

![Simulator Screen Shot - iPhone 11 - 2021-04-29 at 07 11 27](https://user-images.githubusercontent.com/7504299/116565063-5cd86100-a8ba-11eb-84b7-90e25af5a79f.png)
![Simulator Screen Shot - iPhone 11 - 2021-04-29 at 07 11 45](https://user-images.githubusercontent.com/7504299/116565069-5d70f780-a8ba-11eb-96a7-8dbe18e0dd67.png)
![Simulator Screen Shot - iPhone 11 - 2021-04-29 at 07 11 35](https://user-images.githubusercontent.com/7504299/116565075-5ea22480-a8ba-11eb-85dc-65cc29e69eae.png)
