### PR TITLE
Isaiahgrey93/add uniswap testnet pairs

### DIFF
--- a/src/components/coin-icon/CoinIcon.js
+++ b/src/components/coin-icon/CoinIcon.js
@@ -26,8 +26,7 @@ const CoinIcon = ({
   const color = useColorForAsset({ address });
   const { colors, isDarkMode } = useTheme();
 
-  const forceFallback = !isETH(address) && isNil(tokenMetadata);
-
+  const forceFallback = !symbol && !isETH(address) && isNil(tokenMetadata);
   return (
     <Fragment>
       {(isPinned || isHidden) && <CoinIconIndicator isPinned={isPinned} />}

--- a/src/components/exchange/ExchangeAssetList.js
+++ b/src/components/exchange/ExchangeAssetList.js
@@ -34,6 +34,7 @@ const HeaderTitle = styled(Text).attrs(({ color, theme: { colors } }) => ({
   letterSpacing: 'roundedMedium',
   size: 'smedium',
   weight: 'heavy',
+  width: '100%',
 }))``;
 
 const HeaderTitleGradient = styled(GradientText).attrs({
@@ -42,10 +43,11 @@ const HeaderTitleGradient = styled(GradientText).attrs({
   size: 'smedium',
   steps: [0, 0.2867132868, 1],
   weight: 'heavy',
+  width: '100%',
 })``;
 
 const HeaderTitleWrapper = styled.View`
-  width: ${android ? '150' : '143'}px;
+  width: 100%;
 `;
 
 const ExchangeAssetSectionListHeader = ({ section }) => {

--- a/src/references/uniswap/uniswap-pairs-testnet.json
+++ b/src/references/uniswap/uniswap-pairs-testnet.json
@@ -1,39 +1,150 @@
 {
-    "rinkeby": {
-        "ETH": {
-            "address": "eth",
-            "name": "Ethereum",
-            "symbol": "ETH",
-            "decimals": 18,
-            "exchangeAddress": null
-        },
-        "0xF22e3F33768354c9805d046af3C0926f27741B43": {
-            "address": "0xF22e3F33768354c9805d046af3C0926f27741B43",
-            "name": "0x",
-            "symbol": "ZRX",
-            "decimals": 18,
-            "exchangeAddress": "0xaBD44a1D1b9Fb0F39fE1D1ee6b1e2a14916D067D"
-        },
-        "0xDA5B056Cfb861282B4b59d29c9B395bcC238D29B": {
-            "address": "0xDA5B056Cfb861282B4b59d29c9B395bcC238D29B",
-            "name": "Basic Attention Token",
-            "symbol": "BAT",
-            "decimals": 18,
-            "exchangeAddress": "0x9B913956036a3462330B0642B20D3879ce68b450"
-        },
-        "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea": {
-            "address": "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea",
-            "name": "Dai",
-            "symbol": "DAI",
-            "decimals": 18,
-            "exchangeAddress": "0xaf51baaa766b65e8b3ee0c2c33186325ed01ebd5"
-        },
-        "0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85": {
-            "address": "0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85",
-            "name": "Maker",
-            "symbol": "MKR",
-            "decimals": 18,
-            "exchangeAddress": "0x93bB63aFe1E0180d0eF100D774B473034fd60C36"
-        }
+  "rinkeby": {
+    "ETH": {
+      "address": "eth",
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "decimals": 18,
+      "exchangeAddress": null
+    },
+    "0xF22e3F33768354c9805d046af3C0926f27741B43": {
+      "address": "0xF22e3F33768354c9805d046af3C0926f27741B43",
+      "name": "0x",
+      "symbol": "ZRX",
+      "decimals": 18,
+      "exchangeAddress": "0xaBD44a1D1b9Fb0F39fE1D1ee6b1e2a14916D067D"
+    },
+    "0xDA5B056Cfb861282B4b59d29c9B395bcC238D29B": {
+      "address": "0xDA5B056Cfb861282B4b59d29c9B395bcC238D29B",
+      "name": "Basic Attention Token",
+      "symbol": "BAT",
+      "decimals": 18,
+      "exchangeAddress": "0x9B913956036a3462330B0642B20D3879ce68b450"
+    },
+    "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea": {
+      "address": "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea",
+      "name": "Dai",
+      "symbol": "DAI",
+      "decimals": 18,
+      "exchangeAddress": "0xaf51baaa766b65e8b3ee0c2c33186325ed01ebd5"
+    },
+    "0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85": {
+      "address": "0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85",
+      "name": "Maker",
+      "symbol": "MKR",
+      "decimals": 18,
+      "exchangeAddress": "0x93bB63aFe1E0180d0eF100D774B473034fd60C36"
     }
+  },
+  "kovan": {
+    "ETH": {
+      "address": "eth",
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "decimals": 18,
+      "exchangeAddress": null
+    },
+    "0xF22e3F33768354c9805d046af3C0926f27741B43": {
+      "address": "0xF22e3F33768354c9805d046af3C0926f27741B43",
+      "name": "0x",
+      "symbol": "ZRX",
+      "decimals": 18,
+      "exchangeAddress": "0xaBD44a1D1b9Fb0F39fE1D1ee6b1e2a14916D067D"
+    },
+    "0xDA5B056Cfb861282B4b59d29c9B395bcC238D29B": {
+      "address": "0xDA5B056Cfb861282B4b59d29c9B395bcC238D29B",
+      "name": "Basic Attention Token",
+      "symbol": "BAT",
+      "decimals": 18,
+      "exchangeAddress": "0x9B913956036a3462330B0642B20D3879ce68b450"
+    },
+    "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea": {
+      "address": "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea",
+      "name": "Dai",
+      "symbol": "DAI",
+      "decimals": 18,
+      "exchangeAddress": "0xaf51baaa766b65e8b3ee0c2c33186325ed01ebd5"
+    },
+    "0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85": {
+      "address": "0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85",
+      "name": "Maker",
+      "symbol": "MKR",
+      "decimals": 18,
+      "exchangeAddress": "0x93bB63aFe1E0180d0eF100D774B473034fd60C36"
+    }
+  },
+  "ropsten": {
+    "ETH": {
+      "address": "eth",
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "decimals": 18,
+      "exchangeAddress": null
+    },
+    "0xF22e3F33768354c9805d046af3C0926f27741B43": {
+      "address": "0xF22e3F33768354c9805d046af3C0926f27741B43",
+      "name": "0x",
+      "symbol": "ZRX",
+      "decimals": 18,
+      "exchangeAddress": "0xaBD44a1D1b9Fb0F39fE1D1ee6b1e2a14916D067D"
+    },
+    "0xDA5B056Cfb861282B4b59d29c9B395bcC238D29B": {
+      "address": "0xDA5B056Cfb861282B4b59d29c9B395bcC238D29B",
+      "name": "Basic Attention Token",
+      "symbol": "BAT",
+      "decimals": 18,
+      "exchangeAddress": "0x9B913956036a3462330B0642B20D3879ce68b450"
+    },
+    "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea": {
+      "address": "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea",
+      "name": "Dai",
+      "symbol": "DAI",
+      "decimals": 18,
+      "exchangeAddress": "0xaf51baaa766b65e8b3ee0c2c33186325ed01ebd5"
+    },
+    "0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85": {
+      "address": "0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85",
+      "name": "Maker",
+      "symbol": "MKR",
+      "decimals": 18,
+      "exchangeAddress": "0x93bB63aFe1E0180d0eF100D774B473034fd60C36"
+    }
+  },
+  "goerli": {
+    "ETH": {
+      "address": "eth",
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "decimals": 18,
+      "exchangeAddress": null
+    },
+    "0xF22e3F33768354c9805d046af3C0926f27741B43": {
+      "address": "0xF22e3F33768354c9805d046af3C0926f27741B43",
+      "name": "0x",
+      "symbol": "ZRX",
+      "decimals": 18,
+      "exchangeAddress": "0xaBD44a1D1b9Fb0F39fE1D1ee6b1e2a14916D067D"
+    },
+    "0xDA5B056Cfb861282B4b59d29c9B395bcC238D29B": {
+      "address": "0xDA5B056Cfb861282B4b59d29c9B395bcC238D29B",
+      "name": "Basic Attention Token",
+      "symbol": "BAT",
+      "decimals": 18,
+      "exchangeAddress": "0x9B913956036a3462330B0642B20D3879ce68b450"
+    },
+    "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea": {
+      "address": "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea",
+      "name": "Dai",
+      "symbol": "DAI",
+      "decimals": 18,
+      "exchangeAddress": "0xaf51baaa766b65e8b3ee0c2c33186325ed01ebd5"
+    },
+    "0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85": {
+      "address": "0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85",
+      "name": "Maker",
+      "symbol": "MKR",
+      "decimals": 18,
+      "exchangeAddress": "0x93bB63aFe1E0180d0eF100D774B473034fd60C36"
+    }
+  }
 }


### PR DESCRIPTION
### Description

Adds some testnet pairs for uniswap to allow uniswap testing on other networks.
Fixes the icon in the uniswap asset list
Fixes the section titles in the uniswap asset list

### Screenshots

![Simulator Screen Shot - iPhone 11 - 2021-05-05 at 13 57 21](https://user-images.githubusercontent.com/7504299/117208408-f2d42600-ada9-11eb-9714-e8d7537eb5dd.png)
![Simulator Screen Shot - iPhone 11 - 2021-05-05 at 13 57 19](https://user-images.githubusercontent.com/7504299/117208409-f4055300-ada9-11eb-9935-a20d294c3919.png)
![Simulator Screen Shot - iPhone 11 - 2021-05-05 at 13 57 15](https://user-images.githubusercontent.com/7504299/117208413-f49de980-ada9-11eb-9228-05324a717229.png)
