### PR TITLE
[CS-737] Fix crash on assets screen when token value is a whole number

### DIFF
--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -518,7 +518,7 @@ const safesSectionSelector = createSelector(
       renderItem: ({ item }) => {
         const { token, tokenAddress } = item;
         const [int, dec] = token.value.split('.');
-        const value = `$${int}.${dec.slice(0, 2)}`;
+        const value = `$${int}.${dec ? dec.slice(0, 2) : '00'}`;
 
         return (
           <TokenItem


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

<!-- Include a summary of the changes. -->

If the value was a whole number (`1`) then the split function would return an undefined `dec` value. If this is the case, we will display the balance as `$1.00`. 

### Screenshot

![image](https://user-images.githubusercontent.com/17347720/117335443-020daf00-ae50-11eb-8564-3cabc814bc93.png)
