### PR TITLE
Run tag workflow every Tuesday and Friday

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -6,37 +6,40 @@ on:
         description: 'Type of version bump (major, minor, patch, none)'
         required: true
         default: 'none'
+  schedule:
+    - cron: 0 0 * * 2,5
+
 jobs:
   create-new-tag:
-    name: Create new tag
-    if: ${{ github.event.inputs.versionChangeType == 'none' }}
-    runs-on: macos-latest
-    env:
-      GITHUB_AUTH_TOKEN: ${{ secrets.CI_GITHUB_PERSONAL_ACCESS_TOKEN }}
-      BASE_BRANCH: 'develop'
-      BRANCH_TO_TAG: 'develop'
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ env.BASE_BRANCH }}
-      - name: Create tag
-        run: cd ci-scripts && yarn && yarn createTag
-  create-new-tag-with-version-bump:
     name: Create new tag with version bump
-    if: ${{ github.event.inputs.versionChangeType != 'none' }}
     runs-on: macos-latest
     env:
-      VERSION_CHANGE_TYPE: ${{ github.event.inputs.versionChangeType }}
       GITHUB_AUTH_TOKEN: ${{ secrets.CI_GITHUB_PERSONAL_ACCESS_TOKEN }}
       BASE_BRANCH: 'develop'
-      BRANCH_TO_TAG: 'release/${{ github.event.inputs.versionChangeType }}-version-${{ github.run_id }}'
     steps:
+      - name: Set environment variables
+        env: 
+          DEFAULT_VERSION_CHANGE_TYPE: none
+          VERSION_CHANGE_BRANCH_TO_TAG: 'release/${{ github.event.inputs.versionChangeType }}-version-${{ github.run_id }}'
+        run: |
+          echo "VERSION_CHANGE_TYPE=${{ github.event.inputs.versionChangeType || env.DEFAULT_VERSION_CHANGE_TYPE}}" >> $GITHUB_ENV
+
+          if [$VERSION_CHANGE_TYPE != 'none']
+          then
+            echo "BRANCH_TO_TAG=${{ env.VERSION_CHANGE_BRANCH_TO_TAG }}" >> $GITHUB_ENV
+            echo "VERSION_BUMP=true"
+          else
+            echo "BRANCH_TO_TAG=develop" >> $GITHUB_ENV
+            echo "VERSION_BUMP=false"
+          fi
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.BASE_BRANCH }}
       - name: Bump iOS version
+        if: ${{ env.VERSION_BUMP == 'true'}}
         run: cd ios && bundle install && bundle exec fastlane version_bump
       - name: Create Pull Request
+        if: ${{ env.VERSION_BUMP == 'true'}}
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.CI_GITHUB_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
Needed to switch how the environment variables are set a little bit since `github.event.inputs` are not defined when the workflow is triggered on a schedule