### PR TITLE
CS-759 Copy address text

### DIFF
--- a/cardstack/src/components/Button/Button.tsx
+++ b/cardstack/src/components/Button/Button.tsx
@@ -82,6 +82,8 @@ export const Button = ({
         ) : (
           <Container
             flexDirection={iconPosition === 'left' ? 'row' : 'row-reverse'}
+            justifyContent="center"
+            alignItems="center"
           >
             {iconProps && (
               <Icon
@@ -91,7 +93,11 @@ export const Button = ({
                 {...iconProps}
               />
             )}
-            <Text {...textStyle} {...disabledTextProps}>
+            <Text
+              {...textStyle}
+              {...disabledTextProps}
+              allowFontScaling={false}
+            >
               {children}
             </Text>
           </Container>


### PR DESCRIPTION

### Description

Disables font scaling on button component to address text cut off

- [x] Completes #CS-759

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

**Before**
![Simulator Screen Shot - iPhone 8 - 2021-05-12 at 11 45 57](https://user-images.githubusercontent.com/19397130/118028188-a479d680-b317-11eb-99bc-14ffde7a52ee.png)

**After**
![Simulator Screen Shot - iPhone X - 2021-05-12 at 11 25 13](https://user-images.githubusercontent.com/19397130/118027207-865fa680-b316-11eb-91a7-63b308ceac15.png)
![Simulator Screen Shot - iPhone 8 - 2021-05-12 at 11 37 35](https://user-images.githubusercontent.com/19397130/118027211-8790d380-b316-11eb-90fc-7b3c5da08b09.png)
