### PR TITLE
[CS-764] Use local storage for initial load of depots/prepaid cards

### DIFF
--- a/src/handlers/localstorage/accountLocal.js
+++ b/src/handlers/localstorage/accountLocal.js
@@ -3,6 +3,8 @@ import { NATIVE_TOKEN_SYMBOLS } from '@cardstack/utils';
 
 const assetPricesFromUniswapVersion = '0.1.0';
 const assetsVersion = '0.2.0';
+const prepaidCardsVersion = '0.1.0';
+const depotVersion = '0.1.0';
 const purchaseTransactionsVersion = '0.1.0';
 const savingsVersion = '0.2.0';
 const transactionsVersion = '0.2.5';
@@ -13,6 +15,8 @@ const ACCOUNT_INFO = 'accountInfo';
 const ACCOUNT_EMPTY = 'accountEmpty';
 const ASSET_PRICES_FROM_UNISWAP = 'assetPricesFromUniswap';
 const ASSETS = 'assets';
+const PREPAID_CARDS = 'prepaidCards';
+const DEPOTS = 'depots';
 const ACCOUNT_CHARTS = 'accountCharts';
 const OPEN_FAMILIES = 'openFamilies';
 const OPEN_INVESTMENT_CARDS = 'openInvestmentCards';
@@ -109,6 +113,54 @@ export const getAssets = (accountAddress, network) =>
  */
 export const saveAssets = (assets, accountAddress, network) =>
   saveAccountLocal(ASSETS, assets, accountAddress, network, assetsVersion);
+
+/**
+ * @desc get prepaid cards
+ * @param  {String}   [address]
+ * @param  {String}   [network]
+ * @return {Object}
+ */
+export const getPrepaidCards = (accountAddress, network) =>
+  getAccountLocal(
+    PREPAID_CARDS,
+    accountAddress,
+    network,
+    [],
+    prepaidCardsVersion
+  );
+
+/**
+ * @desc save prepaid cards
+ * @param  {Array}    [prepaidCards]
+ * @param  {String}   [address]
+ * @param  {String}   [network]
+ */
+export const savePrepaidCards = (prepaidCards, accountAddress, network) =>
+  saveAccountLocal(
+    PREPAID_CARDS,
+    prepaidCards,
+    accountAddress,
+    network,
+    prepaidCardsVersion
+  );
+
+/**
+ * @desc get depots
+ * @param  {String}   [address]
+ * @param  {String}   [network]
+ * @return {Object}
+ */
+export const getDepots = (accountAddress, network) =>
+  getAccountLocal(DEPOTS, accountAddress, network, [], depotVersion);
+
+/**
+ * @desc save depots
+ * @param  {Array}    [depots]
+ * @param  {String}   [address]
+ * @param  {String}   [network]
+ */
+export const saveDepots = (depots, accountAddress, network) =>
+  saveAccountLocal(DEPOTS, depots, accountAddress, network, depotVersion);
 
 /**
  * @desc get asset prices from Uniswap

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -33,11 +33,15 @@ import { uniswapUpdateLiquidityTokens } from './uniswapLiquidity';
 import {
   getAssetPricesFromUniswap,
   getAssets,
+  getDepots,
   getLocalTransactions,
+  getPrepaidCards,
   saveAccountEmptyState,
   saveAssetPricesFromUniswap,
   saveAssets,
+  saveDepots,
   saveLocalTransactions,
+  savePrepaidCards,
 } from '@rainbow-me/handlers/localstorage/accountLocal';
 
 import AssetTypes from '@rainbow-me/helpers/assetTypes';
@@ -114,9 +118,17 @@ export const dataLoadState = () => async (dispatch, getState) => {
   } catch (error) {}
   try {
     dispatch({ type: DATA_LOAD_ASSETS_REQUEST });
-    const assets = await getAssets(accountAddress, network);
+    const [assets, prepaidCards, depots] = await Promise.all([
+      getAssets(accountAddress, network),
+      getPrepaidCards(accountAddress, network),
+      getDepots(accountAddress, network),
+    ]);
     dispatch({
-      payload: assets,
+      payload: {
+        assets,
+        depots,
+        prepaidCards,
+      },
       type: DATA_LOAD_ASSETS_SUCCESS,
     });
   } catch (error) {
@@ -355,7 +367,8 @@ const getTokensWithPrice = async tokens => {
   );
 };
 
-export const gnosisSafesReceieved = message => async dispatch => {
+export const gnosisSafesReceieved = message => async (dispatch, getState) => {
+  const { accountAddress, network } = getState().settings;
   const isValidMeta = dispatch(checkMeta(message));
   if (!isValidMeta) return;
 
@@ -383,6 +396,9 @@ export const gnosisSafesReceieved = message => async dispatch => {
       })
     ),
   ]);
+
+  savePrepaidCards(prepaidCardsWithPrice, accountAddress, network);
+  saveDepots(depotsWithPrice, accountAddress, network);
 
   dispatch({
     payload: {
@@ -795,7 +811,9 @@ export default (state = INITIAL_STATE, action) => {
     case DATA_LOAD_ASSETS_SUCCESS:
       return {
         ...state,
-        assets: action.payload,
+        assets: action.payload.assets,
+        depots: action.payload.depots,
+        prepaidCards: action.payload.prepaidCards,
         isLoadingAssets: false,
       };
     case DATA_LOAD_ASSETS_FAILURE:


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

<!-- Include a summary of the changes. -->

On initial load, we will pull the cached values. Once the request for depots/safes finishes, along with assets, they will be updated. This is the same flow assets currently use

### Screenshots

<!-- Screenshots or animated GIFs included here -->

![LocalStorageSafes](https://user-images.githubusercontent.com/17347720/118158425-9b007500-b3d0-11eb-840d-29a2196cedeb.gif)
