### PR TITLE
Use SPEND as face value of prepaid cards and calculate total balance correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@apollo/client": "^3.0.0-beta.34",
     "@babel/parser": "^7.13.11",
     "@bankify/react-native-animate-number": "^0.2.1",
-    "@cardstack/cardpay-sdk": "^0.19.6",
+    "@cardstack/cardpay-sdk": "^0.19.7",
     "@ethersproject/abi": "^5.0.9",
     "@ethersproject/abstract-provider": "^5.0.7",
     "@ethersproject/abstract-signer": "^5.0.9",

--- a/src/helpers/buildWalletSections.js
+++ b/src/helpers/buildWalletSections.js
@@ -421,12 +421,7 @@ const prepaidCardsSectionSelector = createSelector(
   [allPrepaidCardsSelector],
   (prepaidCards = []) => {
     const total = prepaidCards.reduce(
-      (acc, prepaidCard) =>
-        acc +
-        prepaidCard.tokens.reduce(
-          (_acc, { token }) => _acc + parseFloat(token.value),
-          0
-        ),
+      (acc, prepaidCard) => acc + Number(prepaidCard.tokens[0].native.display),
       0
     );
 
@@ -445,7 +440,7 @@ const prepaidCardsSectionSelector = createSelector(
         return (
           <Container paddingHorizontal={4}>
             <PrepaidCard
-              cpxdBalance={token.balance.display}
+              cpxdBalance={item.spendFaceValue}
               id={item.address}
               issuer="Cardstack"
               usdBalance={token.native.display}

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -342,10 +342,6 @@ const getTokensWithPrice = async tokens => {
 
       return {
         ...tokenItem,
-        balance: {
-          amount: tokenItem.token.value,
-          display: Number(tokenItem.token.value).toFixed(2),
-        },
         native: {
           amount: usdBalance,
           display: Number(usdBalance).toFixed(2),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1238,10 +1238,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cardstack/cardpay-sdk@^0.19.6":
-  version "0.19.6"
-  resolved "https://registry.yarnpkg.com/@cardstack/cardpay-sdk/-/cardpay-sdk-0.19.6.tgz#3fde909de6f6e9033d1b9a5eecc1b25de14b5eea"
-  integrity sha512-Ey0/scyy21yDhmD25eQLgQtwgseX3R1KeO4tsKRrW3YjpSFoQCuEl+E7U7tsRTt6HN0D3HkbPTcq33STFDKA+g==
+"@cardstack/cardpay-sdk@^0.19.7":
+  version "0.19.7"
+  resolved "https://registry.yarnpkg.com/@cardstack/cardpay-sdk/-/cardpay-sdk-0.19.7.tgz#b81056129c7ddcfcbb1ff49815787ec6d0698019"
+  integrity sha512-xLnaWtANcwyCV4uaLYqrhxI8a5uee5H8RBa64Zq759jNVFM8kItjYr7dpJD1cRwkcgTX4ojClNWztvyduo4r1g==
   dependencies:
     "@truffle/hdwallet-provider" "^1.2.6"
     "@trufflesuite/web3-provider-engine" "^15.0.13-1"


### PR DESCRIPTION
…correctly

<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

<!-- Include a summary of the changes. -->

After some API changes, we can now just use `spendFaceValue` as what we display on the prepaid cards

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<img width="422" alt="image" src="https://user-images.githubusercontent.com/17347720/118161963-0fd5ae00-b3d5-11eb-89c6-186246fa0108.png">
