### PR TITLE
feat: updat recovery phrase UI theming + layout

### DIFF
--- a/src/components/secret-display/SecretDisplayCard.js
+++ b/src/components/secret-display/SecretDisplayCard.js
@@ -1,43 +1,16 @@
+import { useTheme } from '@shopify/restyle';
 import { times } from 'lodash';
 import React, { useMemo } from 'react';
-import LinearGradient from 'react-native-linear-gradient';
 import styled from 'styled-components';
 import CopyTooltip from '../copy-tooltip';
 import { Centered, ColumnWithMargins, Row, RowWithMargins } from '../layout';
 import { Text } from '../text';
 import WalletTypes from '@rainbow-me/helpers/walletTypes';
-import { fonts, padding, position } from '@rainbow-me/styles';
-import ShadowStack from 'react-native-shadow-stack';
-
-const CardBorderRadius = 25;
-
-const BackgroundGradient = styled(LinearGradient).attrs(
-  ({ theme: { colors } }) => ({
-    colors: colors.gradients.offWhite,
-    end: { x: 0.5, y: 1 },
-    start: { x: 0.5, y: 0 },
-  })
-)`
-  ${position.cover};
-  border-radius: ${CardBorderRadius};
-`;
-
-const CardShadow = styled(ShadowStack).attrs(
-  ({ theme: { colors, isDarkMode } }) => ({
-    ...position.coverAsObject,
-    backgroundColor: isDarkMode ? colors.offWhite80 : colors.white,
-    borderRadius: CardBorderRadius,
-    shadows: [
-      [0, 10, 30, colors.shadow, 0.1],
-      [0, 5, 15, colors.shadow, 0.04],
-    ],
-  })
-)`
-  elevation: 15;
-`;
+import { fonts, padding } from '@rainbow-me/styles';
 
 const Content = styled(Centered)`
   ${padding(19, 30, 24)};
+  margin-bottom: 48px;
   border-radius: 25;
   overflow: hidden;
   z-index: 1;
@@ -64,17 +37,17 @@ function SeedWordGrid({ seed }) {
   const { colors } = useTheme();
 
   return (
-    <RowWithMargins margin={24}>
+    <RowWithMargins margin={64}>
       {columns.map((wordColumn, colIndex) => (
-        <RowWithMargins key={wordColumn.join('')} margin={6}>
-          <ColumnWithMargins margin={9}>
+        <RowWithMargins key={wordColumn.join('')} margin={12}>
+          <ColumnWithMargins margin={16}>
             {times(wordColumn.length, index => {
               const number = Number(index + 1 + colIndex * wordColumn.length);
               return (
                 <GridItem justify="end" key={`grid_number_${number}`}>
                   <GridText
                     align="right"
-                    color={colors.alpha(colors.appleBlue, 0.6)}
+                    color={colors.buttonPrimaryBackground}
                   >
                     {number}
                   </GridText>
@@ -82,7 +55,7 @@ function SeedWordGrid({ seed }) {
               );
             })}
           </ColumnWithMargins>
-          <ColumnWithMargins margin={9}>
+          <ColumnWithMargins margin={16}>
             {wordColumn.map((word, index) => (
               <GridItem key={`${word}${index}`}>
                 <GridText weight="bold">{word}</GridText>
@@ -98,12 +71,6 @@ function SeedWordGrid({ seed }) {
 export default function SecretDisplayCard({ seed, type }) {
   return (
     <Centered>
-      {ios && (
-        <>
-          <CardShadow />
-          <BackgroundGradient />
-        </>
-      )}
       <Content>
         <CopyTooltip textToCopy={seed} tooltipText="Copy to clipboard">
           {seed && type === WalletTypes.mnemonic && (

--- a/src/components/secret-display/SecretDisplaySection.js
+++ b/src/components/secret-display/SecretDisplaySection.js
@@ -30,7 +30,7 @@ const AuthenticationText = styled(Text).attrs({
 `;
 
 const CopyButtonIcon = styled(Icon).attrs(({ theme: { colors } }) => ({
-  color: colors.appleBlue,
+  color: colors.settingsGray,
   name: 'copy',
 }))`
   ${position.size(16)};
@@ -42,16 +42,19 @@ const CopyButtonRow = styled(RowWithMargins).attrs({
   justify: 'start',
   margin: 6,
 })`
+  width: 100%;
+  border-radius: 32px;
+  border: 1px solid lightgray;
   background-color: ${({ theme: { colors } }) => colors.transparent};
-  height: 34;
+  padding: 12px 32px;
 `;
 
 const CopyButtonText = styled(Text).attrs(({ theme: { colors } }) => ({
-  color: colors.appleBlue,
+  color: colors.settingsGray,
   letterSpacing: 'roundedMedium',
   lineHeight: 19,
   size: 'large',
-  weight: 'bold',
+  weight: 'medium',
 }))``;
 
 const ToggleSecretButton = styled(Button)`
@@ -118,13 +121,13 @@ export default function SecretDisplaySection({
         <Fragment>
           {seed ? (
             <Fragment>
+              <SecretDisplayCard seed={seed} type={type} />
               <CopyFloatingEmojis textToCopy={seed}>
                 <CopyButtonRow>
                   <CopyButtonIcon />
                   <CopyButtonText>Copy to clipboard</CopyButtonText>
                 </CopyButtonRow>
               </CopyFloatingEmojis>
-              <SecretDisplayCard seed={seed} type={type} />
             </Fragment>
           ) : (
             <LoadingSpinner color={colors.blueGreyDark50} />

--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -66,6 +66,7 @@ const getColorsByTheme = darkMode => {
     mediumGrey: '#A1A5B3', // '161, 165, 179'
     mintDark: '#00E0A9', // '0, 224, 169'
     neonSkyblue: '#34FFFF', // '52, 255, 255'
+    cardstackBlue: '#00EBE5',
     offWhite: '#F8F9FA', // '248, 249, 250'
     orange: '#FF9900', // '255, 153, 0'
     orangeLight: '#FEBE44', // '254, 190, 68'


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Restyles the recovery phrase and private key UI to the Cardstack theme

- [ ] Completes #(CS-926)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

![Simulator Screen Shot - iPhone 11 - 2021-06-04 at 12 13 07](https://user-images.githubusercontent.com/7504299/120851938-634b9f80-c52e-11eb-937e-b202cdf49a86.png)
