### PR TITLE
[CS-911 ] add feature toggle to display review link

### DIFF
--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -87,7 +87,6 @@ export default function SettingsSection({
   onPressNetwork,
   onPressShowSecret,
 }) {
-  const isReviewAvailable = true; // useExperimentalFlag(REVIEW_ANDROID) || ios;
   const { wallets } = useWallets();
   const { /*language,*/ nativeCurrency, network } = useAccountSettings();
   const { isTinyPhone } = useDimensions();
@@ -95,6 +94,24 @@ export default function SettingsSection({
   const { colors } = useTheme();
 
   const onSendFeedback = useSendFeedback();
+
+  const [isReviewEnabled, setReviewEnabled] = useState(false);
+
+  const getReviewFeature = async () => {
+    try {
+      const response = await fetch(
+        'https://us-central1-card-pay-3e9be.cloudfunctions.net/review-feature'
+      );
+
+      return await response.json();
+    } catch (e) {
+      return false;
+    }
+  };
+
+  useEffect(() => {
+    setReviewFeature();
+  }, []);
 
   const onPressReview = useCallback(async () => {
     if (ios) {
@@ -128,6 +145,11 @@ export default function SettingsSection({
     () => checkAllWallets(wallets),
     [wallets]
   );
+
+  const setReviewFeature = async () => {
+    const { reviewActive } = await getReviewFeature();
+    return setReviewEnabled(reviewActive);
+  };
 
   return (
     <Container backgroundColor={colors.white} scrollEnabled={isTinyPhone}>
@@ -190,7 +212,7 @@ export default function SettingsSection({
           onPress={onSendFeedback}
           testID="feedback-section"
         />
-        {isReviewAvailable && (
+        {isReviewEnabled && (
           <ListItem
             icon={<Icon color="settingsGray" name="star" />}
             label="Review"


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
 - Fetches feature toggle to render Review Link in Settings (currently returns false)
 - Create cloud function to return feature toggle
https://console.cloud.google.com/functions/details/us-central1/review-feature?authuser=3&project=card-pay-3e9be

Note: But for sake of time and keeping with established pattern created new endpoint to single feature. When going greenfield it will be better to consolidate feature toggles under single source of truth (whether single api endpoint, or a service such as Launch Darkly). 

- [x] Completes #CS-911

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots
![Simulator Screen Shot - iPhone 11 - 2021-06-07 at 16 08 06](https://user-images.githubusercontent.com/19397130/121098371-91d5ae80-c7aa-11eb-9a3c-1d26d81221af.png)
