### PR TITLE
[CS-929] Prepaid cards notification

### DIFF
--- a/cardstack/src/components/SystemNotification/SystemNotification.tsx
+++ b/cardstack/src/components/SystemNotification/SystemNotification.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import { Animated, TouchableOpacity } from 'react-native';
 
+import AsyncStorage from '@react-native-community/async-storage';
 import downIcon from '../../assets/chevron-down.png';
 import { AnimatedContainer, AnimatedText } from '../Animated';
 import { Container, Icon, Text, IconName } from '@cardstack/components';
+import { NOTIFICATION_KEY } from '@cardstack/utils';
 
 const ANIMATION_DURATION = 150;
 const CLOSED_HEIGHT = 40;
@@ -86,13 +88,18 @@ export const SystemNotification = ({
   };
 
   const hideNotification = () => {
-    Animated.parallel([
-      Animated.timing(containerOpacity, {
-        duration: ANIMATION_DURATION,
-        toValue: HIDDEN_OPACITY,
-        useNativeDriver: true,
-      }),
-    ]).start(() => setIsVisible(false));
+    try {
+      AsyncStorage.setItem(NOTIFICATION_KEY, 'false');
+      Animated.parallel([
+        Animated.timing(containerOpacity, {
+          duration: ANIMATION_DURATION,
+          toValue: HIDDEN_OPACITY,
+          useNativeDriver: true,
+        }),
+      ]).start(() => setIsVisible(false));
+    } catch (error) {
+      console.log('error', error);
+    }
   };
 
   const toggle = isOpen ? closeNotification : openNotification;

--- a/cardstack/src/utils/async-utils.ts
+++ b/cardstack/src/utils/async-utils.ts
@@ -1,0 +1,1 @@
+export const NOTIFICATION_KEY = 'notificationKey';

--- a/cardstack/src/utils/index.ts
+++ b/cardstack/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './formatting-utils';
 export * from './currency-utils';
 export * from './ganache-utils';
 export * from './cardpay-utils';
+export * from './async-utils';


### PR DESCRIPTION
### Description

- Hardcoded notification for prepaid cards. 
- Displays only on layer 2 and when there are wallet items (to account for empty states). 
- Dismiss removes notification until ~~next app session~~ async storage is cleared or app is reinstalled. 

- [x] Completes #CS-929

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

**Dismiss notification permanently:**

https://user-images.githubusercontent.com/19397130/121578704-ced6b680-c9df-11eb-9630-8ed29ead6e40.mp4

**Hides on layer 1**

https://user-images.githubusercontent.com/19397130/121257187-42eb5000-c862-11eb-9b89-147a2f7bcd01.mp4

**When list is empty**

https://user-images.githubusercontent.com/19397130/121257926-1f74d500-c863-11eb-8cc9-ad751496d669.mp4


