### PR TITLE
[CS-1038] Share sheet firing twice

### DIFF
--- a/cardstack/src/components/Button/Button.tsx
+++ b/cardstack/src/components/Button/Button.tsx
@@ -55,6 +55,7 @@ export const Button = ({
   iconProps,
   iconPosition = 'left',
   loading,
+  onPress,
   ...props
 }: ButtonProps) => {
   const width = useVariantValue('buttonVariants', 'width', props.variant);
@@ -76,7 +77,12 @@ export const Button = ({
 
   return (
     <Container backgroundColor="transparent" {...props} flex={-1}>
-      <AnimatedButton alignItems="center" disabled={disabled} {...props}>
+      <AnimatedButton
+        {...props}
+        alignItems="center"
+        disabled={disabled}
+        onPress={onPress}
+      >
         {loading ? (
           <ActivityIndicator testID="button-loading" />
         ) : (


### PR DESCRIPTION
### Description

- Updates Button component, passing onPress event directly vs. spread of props `{...props}` to resolve binding issue. 

- [x] Completes #CS-1038

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots
### **Before** 

https://user-images.githubusercontent.com/19397130/121952763-86860400-cd11-11eb-9ed7-5c6e367bf3ce.mp4 

### **After**

 https://user-images.githubusercontent.com/19397130/121952625-59d1ec80-cd11-11eb-8ca6-901657549882.mp4

