### PR TITLE
[CS-1136] Import account modal doesn't dismiss from welcome screen

### DIFF
--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -71,12 +71,16 @@ export default function WalletProfileState({
   }, [actionType, goBack, navigate]);
 
   const handleSubmit = useCallback(async () => {
-    onCloseModal({
-      color,
-      name: nameEmoji ? `${nameEmoji} ${value}` : value,
-    });
+    setTimeout(() => {
+      onCloseModal({
+        color,
+        name: nameEmoji ? `${nameEmoji} ${value}` : value,
+      });
+    }, 500);
+
+    goBack();
+
     if (actionType === 'Create' && isNewProfile) {
-      goBack();
       navigate(Routes.CHANGE_WALLET_SHEET);
     }
   }, [


### PR DESCRIPTION
### Description

- Fixes bug when modal doesn't close when importing accounts from welcome screen.
- Reverts change to navigation, re-adding goBack method to imported accounts and sets delay to handle collision occurring with navigation actions and state updates. 

- [x] Completes #CS-1136

### Checklist

### Screenshots

https://user-images.githubusercontent.com/19397130/123681789-168e7800-d7ff-11eb-935d-7a857fbcc0ae.mp4

https://user-images.githubusercontent.com/19397130/123681812-1b532c00-d7ff-11eb-9027-cc74e50506d7.mp4
