### PR TITLE
[CS-1095] Network settings fix

### DIFF
--- a/cardstack/src/components/Checkbox/Checkbox.tsx
+++ b/cardstack/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { Touchable, Container, Text, Icon } from '../.';
 import { IconProps } from '../Icon';
 
@@ -26,6 +26,10 @@ export const Checkbox = ({
       onPress();
     }
   }, [onPress, selected]);
+
+  useEffect(() => {
+    setSelected(isSelected);
+  }, [isSelected]);
 
   return (
     <Container flexDirection="row">

--- a/cardstack/src/components/RadioList/RadioList.tsx
+++ b/cardstack/src/components/RadioList/RadioList.tsx
@@ -4,7 +4,7 @@ import { IconProps, Text, Container } from '../.';
 import { RadioListItem } from './RadioListItem';
 
 export const RadioList = ({ items: sections, onChange }: RadioListProps) => {
-  const selectedItem = useCallback(() => {
+  const setSelectedItem = useCallback(() => {
     const findItemByType = (arr: Array<RadioItemProps>, type: string) => {
       return arr
         .map((section: RadioItemProps) => {
@@ -17,17 +17,15 @@ export const RadioList = ({ items: sections, onChange }: RadioListProps) => {
         .reduce((acc, val) => acc.concat(val), []);
     };
 
-    const selectedItems = findItemByType(sections, 'selected')[0];
-
-    const defaultItem = findItemByType(sections, 'default')[0];
+    const selectedItem = findItemByType(sections, 'selected')[0];
 
     return {
-      index: selectedItems?.key || defaultItem?.key,
-      value: selectedItems?.value || defaultItem?.value,
+      index: selectedItem?.key,
+      value: selectedItem?.value,
     };
   }, [sections]);
 
-  const [selected, setSelected] = useState<number>(selectedItem()?.index);
+  const [selected, setSelected] = useState<number>(setSelectedItem()?.index);
 
   const handleChange = ({
     value,
@@ -46,7 +44,7 @@ export const RadioList = ({ items: sections, onChange }: RadioListProps) => {
   };
 
   useEffect(() => {
-    const { value, index } = selectedItem();
+    const { value, index } = setSelectedItem();
     handleChange({ value, index });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sections]);

--- a/src/components/settings-menu/NetworkSection.js
+++ b/src/components/settings-menu/NetworkSection.js
@@ -11,6 +11,7 @@ import {
   useResetAccountState,
 } from '../../hooks';
 import {
+  INITIAL_STATE,
   settingsUpdateNetwork,
   toggleShowTestnets,
 } from '../../redux/settings';
@@ -25,6 +26,8 @@ const NetworkSection = () => {
   const loadAccountData = useLoadAccountData();
   const initializeAccountData = useInitializeAccountData();
   const dispatch = useDispatch();
+  const networkSelected = networkInfo[network];
+  const defaultNetwork = INITIAL_STATE.network;
 
   //transform data for sectionList
   const DATA = networks
@@ -41,7 +44,7 @@ const NetworkSection = () => {
               label: curr.name,
               value: curr.value,
               selected: toLower(network) === toLower(curr.value),
-              default: curr.default,
+              default: curr.value === defaultNetwork,
             },
           ],
         } || {};
@@ -50,6 +53,13 @@ const NetworkSection = () => {
     }, [])
     .flat()
     .sort((a, b) => a.layer < b.layer);
+
+  useEffect(() => {
+    if (networkSelected.isTestnet !== showTestnets) {
+      dispatch(toggleShowTestnets(networkSelected.isTestnet));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onNetworkChange = useCallback(
     async network => {
@@ -73,7 +83,12 @@ const NetworkSection = () => {
         <Checkbox
           isSelected={showTestnets}
           label="Show testnets"
-          onPress={() => dispatch(toggleShowTestnets())}
+          onPress={() => {
+            if (networkSelected.isTestnet && showTestnets) {
+              onNetworkChange(defaultNetwork);
+            }
+            dispatch(toggleShowTestnets());
+          }}
         />
       </Container>
       <RadioList items={DATA} onChange={value => onNetworkChange(value)} />

--- a/src/helpers/networkInfo.ts
+++ b/src/helpers/networkInfo.ts
@@ -8,7 +8,6 @@ export const networkInfo = {
     name: 'xDai Chain',
     layer: 2,
     value: networkTypes.xdai,
-    default: true,
     isTestnet: false,
   },
   [networkTypes.sokol]: {
@@ -18,7 +17,6 @@ export const networkInfo = {
     name: 'Sokol',
     layer: 2,
     value: networkTypes.sokol,
-    default: false,
     isTestnet: true,
   },
   [`${networkTypes.mainnet}`]: {
@@ -28,7 +26,6 @@ export const networkInfo = {
     name: 'Ethereum Mainnet',
     layer: 1,
     value: networkTypes.mainnet,
-    default: false,
     isTestnet: false,
   },
   [`${networkTypes.kovan}`]: {
@@ -38,7 +35,6 @@ export const networkInfo = {
     name: 'Kovan',
     layer: 1,
     value: networkTypes.kovan,
-    default: false,
     isTestnet: true,
   },
 };


### PR DESCRIPTION
### Description

- Default network is now based on redux init state
- Updates network settings based on selected network redux state
- Toggles "Show testnets" open if redux selected state is testnets network
- If "Show testnets" checkbox is deselected, selection toggles to default network.

- [x] Completes #CS-1095

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

https://user-images.githubusercontent.com/19397130/124204538-1f4bac00-da94-11eb-86ca-76ef97d8dd3a.mp4

https://user-images.githubusercontent.com/19397130/124204547-24106000-da94-11eb-871e-1c0df707ee82.mp4
