### PR TITLE
[CS-1098, CS-1102] Fix autolock and twitter crash

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -144,23 +144,23 @@ class App extends Component {
       }
     );
 
-    this.branchListener = branch.subscribe(({ error, params, uri }) => {
-      if (error) {
-        logger.error('Error from Branch: ' + error);
-      }
+    // this.branchListener = branch.subscribe(({ error, params, uri }) => {
+    //   if (error) {
+    //     logger.error('Error from Branch: ' + error);
+    //   }
 
-      if (params['+non_branch_link']) {
-        const nonBranchUrl = params['+non_branch_link'];
-        handleDeepLink(nonBranchUrl);
-        return;
-      } else if (!params['+clicked_branch_link']) {
-        // Indicates initialization success and some other conditions.
-        // No link was opened.
-        return;
-      } else if (uri) {
-        handleDeepLink(uri);
-      }
-    });
+    //   if (params['+non_branch_link']) {
+    //     const nonBranchUrl = params['+non_branch_link'];
+    //     handleDeepLink(nonBranchUrl);
+    //     return;
+    //   } else if (!params['+clicked_branch_link']) {
+    //     // Indicates initialization success and some other conditions.
+    //     // No link was opened.
+    //     return;
+    //   } else if (uri) {
+    //     handleDeepLink(uri);
+    //   }
+    // });
 
     // Walletconnect uses direct deeplinks
     if (android) {

--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -6,7 +6,6 @@ import {
   getConstantByNetwork,
   greaterThan,
   handleSignificantDecimals,
-  HttpProvider,
   multiply,
 } from '@cardstack/cardpay-sdk';
 import { getAddress } from '@ethersproject/address';
@@ -17,6 +16,7 @@ import { JsonRpcProvider, Web3Provider } from '@ethersproject/providers';
 import { parseEther } from '@ethersproject/units';
 import UnstoppableResolution from '@unstoppabledomains/resolution';
 import { get, startsWith } from 'lodash';
+import Web3 from 'web3';
 
 import AssetTypes from '../helpers/assetTypes';
 import NetworkTypes, { networkTypes } from '../helpers/networkTypes';
@@ -37,8 +37,8 @@ export let web3Provider = new JsonRpcProvider(
 /**
  * @desc web3 http instance - to be used with web3 contracts
  */
-export let web3ProviderSdk = new HttpProvider(
-  getConstantByNetwork('rpcNode', networkTypes.mainnet)
+export let web3ProviderSdk = new Web3.providers.WebsocketProvider(
+  getConstantByNetwork('rpcWssNode', networkTypes.mainnet)
 );
 
 /**
@@ -49,13 +49,16 @@ export const web3SetHttpProvider = async network => {
   if (network.startsWith('http://')) {
     web3Provider = new JsonRpcProvider(network, NetworkTypes.mainnet);
   } else {
-    const networkUrl = getConstantByNetwork('rpcNode', network);
-
     if (isLayer1(network)) {
-      web3Provider = new JsonRpcProvider(networkUrl, network);
+      web3Provider = new JsonRpcProvider(
+        getConstantByNetwork('rpcNode', network),
+        network
+      );
     } else {
       try {
-        web3ProviderSdk = new HttpProvider(networkUrl);
+        web3ProviderSdk = new Web3.providers.WebsocketProvider(
+          getConstantByNetwork('rpcWssNode', networkTypes.mainnet)
+        );
 
         web3Provider = new Web3Provider(web3ProviderSdk);
       } catch (error) {


### PR DESCRIPTION
After running it on device with debug, I was seeing two errors, one being the `PollingBlockTracker` error and the other being an error having to do with the branch subscription. I don't think we need the branch subscription so I removed that. I also found [this issue](https://github.com/trufflesuite/truffle/issues/3357) related to the polling block tracker error which recommended using a websocket provider instead. Since switching it over, I haven't been able to reproduce any of the red screens I was seeing prior to making these changes. We'll obviously still want to test on device with a new build but hopefully these intermittent crashes will be resolved 🤞 