### PR TITLE
[CS-1098, CS-1102] Fix autolock and twitter crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@apollo/client": "^3.0.0-beta.34",
     "@babel/parser": "^7.13.11",
     "@bankify/react-native-animate-number": "^0.2.1",
-    "@cardstack/cardpay-sdk": "^0.19.32",
+    "@cardstack/cardpay-sdk": "0.19.33",
     "@ethersproject/abi": "^5.0.9",
     "@ethersproject/abstract-provider": "^5.0.7",
     "@ethersproject/abstract-signer": "^5.0.9",

--- a/src/App.js
+++ b/src/App.js
@@ -144,23 +144,25 @@ class App extends Component {
       }
     );
 
-    // this.branchListener = branch.subscribe(({ error, params, uri }) => {
-    //   if (error) {
-    //     logger.error('Error from Branch: ' + error);
-    //   }
+    /* cardstack isn't using this right now, leftover from Rainbow and causing bugs
+     this.branchListener = branch.subscribe(({ error, params, uri }) => {
+       if (error) {
+         logger.error('Error from Branch: ' + error);
+       }
 
-    //   if (params['+non_branch_link']) {
-    //     const nonBranchUrl = params['+non_branch_link'];
-    //     handleDeepLink(nonBranchUrl);
-    //     return;
-    //   } else if (!params['+clicked_branch_link']) {
-    //     // Indicates initialization success and some other conditions.
-    //     // No link was opened.
-    //     return;
-    //   } else if (uri) {
-    //     handleDeepLink(uri);
-    //   }
-    // });
+       if (params['+non_branch_link']) {
+         const nonBranchUrl = params['+non_branch_link'];
+         handleDeepLink(nonBranchUrl);
+         return;
+       } else if (!params['+clicked_branch_link']) {
+          Indicates initialization success and some other conditions.
+          No link was opened.
+         return;
+       } else if (uri) {
+         handleDeepLink(uri);
+       }
+     });
+    */
 
     // Walletconnect uses direct deeplinks
     if (android) {

--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -57,6 +57,8 @@ export const web3SetHttpProvider = async network => {
       );
     } else {
       try {
+        // use a websocket in layer 2 rather than http provider
+        // hopefully helps resolve the PollingBlockTracker error we were seeing
         web3ProviderSdk = new Web3.providers.WebsocketProvider(
           getConstantByNetwork('rpcWssNode', network)
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,10 +1255,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cardstack/cardpay-sdk@^0.19.32":
-  version "0.19.32"
-  resolved "https://registry.yarnpkg.com/@cardstack/cardpay-sdk/-/cardpay-sdk-0.19.32.tgz#619c8c467344ced7ba5b25f7ef93aa6515de7a7b"
-  integrity sha512-iUxzO3wv0XGsjsSxIOVZOfcZURxHqF8bKuBOjgLdcDPENsYtp1Qh1cu9/JbmAk6YQJlVTRwIm6HvJLWTbk88TA==
+"@cardstack/cardpay-sdk@0.19.33":
+  version "0.19.33"
+  resolved "https://registry.yarnpkg.com/@cardstack/cardpay-sdk/-/cardpay-sdk-0.19.33.tgz#ed907af770f12de79563e5cfb3a6c6b7ae4a1732"
+  integrity sha512-0DEQkvPtJo/Q4w3M6bJcJZrNb3c5CxCr/NVjnQdC0E0GWyEd4p/KNbvs/Ly/s2/qMkkGPcCCP3k6OMnCzdNCAQ==
   dependencies:
     "@truffle/hdwallet-provider" "^1.2.6"
     "@trufflesuite/web3-provider-engine" "^15.0.13-1"


### PR DESCRIPTION
After running it on device with debug, I was seeing two errors, one being the `PollingBlockTracker` error and the other being an error having to do with the branch subscription. I don't think we need the branch subscription so I removed that. I also found [this issue](https://github.com/trufflesuite/truffle/issues/3357) related to the polling block tracker error which recommended using a websocket provider instead. Since switching it over, I haven't been able to reproduce any of the red screens I was seeing prior to making these changes. We'll obviously still want to test on device with a new build but hopefully these intermittent crashes will be resolved 🤞 