### PR TITLE
Temporarily rename Merchant Name into Mandello

### DIFF
--- a/cardstack/src/components/MerchantSafe/MerchantSafe.tsx
+++ b/cardstack/src/components/MerchantSafe/MerchantSafe.tsx
@@ -59,7 +59,7 @@ const MerchantInfo = () => (
     >
       <Icon name="user" />
       <Container flexDirection="column" marginLeft={4} justifyContent="center">
-        <Text weight="bold">Merchant Name</Text>
+        <Text weight="bold">Mandello</Text>
         <Text variant="subText">Merchant Account</Text>
       </Container>
     </Container>

--- a/cardstack/src/components/TransactionConfirmationSheet/ClaimRevenueDisplay.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/ClaimRevenueDisplay.tsx
@@ -98,7 +98,7 @@ const ToSection = ({ merchantSafe }: { merchantSafe: string }) => {
         <Container flexDirection="row" alignItems="center">
           <Icon name="user" />
           <Text size="small" weight="extraBold" style={{ marginLeft: 6 }}>
-           Mandello 
+            Mandello
           </Text>
         </Container>
         <Container maxWidth={180} marginLeft={9}>

--- a/cardstack/src/components/TransactionConfirmationSheet/ClaimRevenueDisplay.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/ClaimRevenueDisplay.tsx
@@ -98,7 +98,7 @@ const ToSection = ({ merchantSafe }: { merchantSafe: string }) => {
         <Container flexDirection="row" alignItems="center">
           <Icon name="user" />
           <Text size="small" weight="extraBold" style={{ marginLeft: 6 }}>
-            Merchant Name
+           Mandello 
           </Text>
         </Container>
         <Container maxWidth={180} marginLeft={9}>

--- a/cardstack/src/components/TransactionConfirmationSheet/PayMerchantDisplay.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/PayMerchantDisplay.tsx
@@ -41,7 +41,7 @@ const ToSection = ({ data }: PayMerchantDisplayProps) => {
         <Container flexDirection="row" alignItems="center">
           <Icon name="user" />
           <Text size="small" weight="extraBold" style={{ marginLeft: 6 }}>
-            Merchant Name
+           Mandello 
           </Text>
         </Container>
         <Container maxWidth={180} marginLeft={9}>

--- a/cardstack/src/components/TransactionConfirmationSheet/PayMerchantDisplay.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/PayMerchantDisplay.tsx
@@ -41,7 +41,7 @@ const ToSection = ({ data }: PayMerchantDisplayProps) => {
         <Container flexDirection="row" alignItems="center">
           <Icon name="user" />
           <Text size="small" weight="extraBold" style={{ marginLeft: 6 }}>
-           Mandello 
+            Mandello
           </Text>
         </Container>
         <Container maxWidth={180} marginLeft={9}>

--- a/cardstack/src/components/TransactionConfirmationSheet/RegisterMerchantDisplay.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/RegisterMerchantDisplay.tsx
@@ -42,7 +42,7 @@ const ToSection = () => {
         <Container flexDirection="row">
           <Icon name="user" />
           <Container marginLeft={4}>
-            <Text weight="extraBold">Merchant Name</Text>
+            <Text weight="extraBold">Mandello</Text>
             <Text variant="subAddress" marginTop={1}>
               {getAddressPreview('0xXXXXXXXXXXXX')}*
             </Text>

--- a/cardstack/src/components/Transactions/MerchantCreationTransaction.tsx
+++ b/cardstack/src/components/Transactions/MerchantCreationTransaction.tsx
@@ -16,7 +16,7 @@ export const MerchantCreationTransaction = ({
       }
       statusIconName="plus"
       statusText="Created"
-      primaryText="Merchant Name"
+      primaryText="Mandello"
       subText="Merchant Account"
       transactionHash={item.transactionHash}
     />

--- a/cardstack/src/screens/MerchantScreen.tsx
+++ b/cardstack/src/screens/MerchantScreen.tsx
@@ -90,7 +90,7 @@ const Header = () => {
           </Touchable>
           <Container alignItems="center">
             <Text color="white" weight="bold">
-              Merchant Name
+              Mandello
             </Text>
             <Container flexDirection="row" alignItems="center">
               <NetworkBadge marginRight={2} />
@@ -135,7 +135,7 @@ const MerchantInfo = () => (
   >
     <Icon name="user" size={80} />
     <Text weight="extraBold" size="medium">
-      Merchant Name
+      Mandello
     </Text>
     <Container flexDirection="row" marginTop={2}>
       <Text weight="extraBold" size="xs">


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Rename hardcoded "Merchant Name" into "Mandello". Mandello represents a merchant store name. As part of the beta program, we want to show a watch address so that users can view account history from the perspective of a merchant. This is a temporary fix and is intended to be reverted post beta. 


### Checklist

- [ ] All UI changes have been tested on a small device

### Screenshots

![IMG_4286](https://user-images.githubusercontent.com/8165111/126646637-3bdd2aed-0cba-4821-9d2c-112957789c52.jpg)
![IMG_4285](https://user-images.githubusercontent.com/8165111/126646656-475ed883-9d41-4f8b-bf0a-ee4fe65846d7.jpg)
