### PR TITLE
Fix transaction caching issues

### DIFF
--- a/cardstack/src/services/gnosis-service.ts
+++ b/cardstack/src/services/gnosis-service.ts
@@ -14,6 +14,7 @@ import {
 } from '@rainbow-me/handlers/localstorage/accountLocal';
 import { web3ProviderSdk } from '@rainbow-me/handlers/web3';
 import { CurrencyConversionRates } from '@cardstack/types';
+import logger from 'logger';
 
 export const fetchGnosisSafes = async (address: string) => {
   try {
@@ -70,7 +71,7 @@ export const fetchGnosisSafes = async (address: string) => {
       prepaidCards,
     };
   } catch (error) {
-    console.log({ error });
+    logger.error(error);
   }
 };
 

--- a/cardstack/src/services/transaction-service.ts
+++ b/cardstack/src/services/transaction-service.ts
@@ -105,6 +105,8 @@ const useSokolTransactions = () => {
         }
 
         setLoading(false);
+      } else if (data?.account === null) {
+        setSections([]);
       }
     };
 
@@ -122,7 +124,7 @@ const useSokolTransactions = () => {
 export const useTransactions = () => {
   const network = useRainbowSelector(state => state.settings.network);
   const layer1Data = useAccountTransactions();
-  const sokolData = useSokolTransactions();
+  const layer2Data = useSokolTransactions();
 
   if (isLayer1(network)) {
     return {
@@ -131,7 +133,7 @@ export const useTransactions = () => {
       refetchLoading: false,
     };
   } else if (network === networkTypes.sokol) {
-    return sokolData;
+    return layer2Data;
   }
 
   return {

--- a/cardstack/src/services/transaction-service.ts
+++ b/cardstack/src/services/transaction-service.ts
@@ -122,7 +122,7 @@ const useSokolTransactions = () => {
 export const useTransactions = () => {
   const network = useRainbowSelector(state => state.settings.network);
   const layer1Data = useAccountTransactions();
-  const layer2Data = useSokolTransactions();
+  const sokolData = useSokolTransactions();
 
   if (isLayer1(network)) {
     return {
@@ -130,7 +130,14 @@ export const useTransactions = () => {
       refetch: () => ({}),
       refetchLoading: false,
     };
+  } else if (network === networkTypes.sokol) {
+    return sokolData;
   }
 
-  return layer2Data;
+  return {
+    isLoadingTransactions: false,
+    sections: [],
+    refetch: () => ({}),
+    refetchLoading: false,
+  };
 };

--- a/src/redux/settings.js
+++ b/src/redux/settings.js
@@ -53,7 +53,7 @@ export const settingsLoadNetwork = () => async dispatch => {
       type: SETTINGS_UPDATE_NETWORK_SUCCESS,
     });
   } catch (error) {
-    logger.log('Error loading network settings', error);
+    logger.error('Error loading network settings', error);
   }
 };
 


### PR DESCRIPTION
* We were returning sokol data on xdai rather than empty data (there is no deployed subgraph for xdai)
* We were not resetting sections data for transactions if account was null