### PR TITLE
Fix GoogleServices output path

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -145,7 +145,7 @@ lane :sync_google_service_info do
   cryptex(
       type: "export",
       key: 'google_service_info',
-      out: './Frameworks/GoogleService-Info.plist'
+      out: './ios/Frameworks/GoogleService-Info.plist'
     )
 end
 


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

<!-- Include a summary of the changes. -->

The build was falling because GoogleServices was being exported in the root instead of inside ios folder
