### PR TITLE
[CS-1406] Fix sending of assets in Layer 2

### DIFF
--- a/src/parsers/gas.js
+++ b/src/parsers/gas.js
@@ -67,13 +67,13 @@ export const parseGasPrices = (data, source = 'etherscan') =>
 
 export const parseLayer2GasPrices = data => ({
   [CUSTOM]: null,
-  [FAST]: defaultGasPriceFormat(FAST, null, data.fast ? data.fast / 10 : 0),
+  [FAST]: defaultGasPriceFormat(FAST, null, data.fast ? data.fast : 1),
   [NORMAL]: defaultGasPriceFormat(
     NORMAL,
     null,
-    data.average ? data.average / 10 : 0
+    data.average ? data.average : 1
   ),
-  [SLOW]: defaultGasPriceFormat(SLOW, null, data.slow ? data.slow / 10 : 0),
+  [SLOW]: defaultGasPriceFormat(SLOW, null, data.slow ? data.slow : 1),
 });
 
 export const defaultGasPriceFormat = (option, timeWait, value) => {


### PR DESCRIPTION
We were previously dividing by 10 based off what Rainbow does, but we don't want to do that because it was miscalculating and giving less than 1 gwei as our gas price. Also updated the fallback so we should always have a gas price of at least 1


https://user-images.githubusercontent.com/17347720/128089338-f68eca99-ccf0-483d-b08f-4c80a0b958a2.mp4

<img width="438" alt="Screen Shot 2021-08-03 at 14 32 38" src="https://user-images.githubusercontent.com/17347720/128089363-1cf2fe0e-64eb-4b68-98ae-43877860ebee.png">
