### PR TITLE
Fix sending of tokens on Kovan

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@apollo/client": "^3.0.0-beta.34",
     "@babel/parser": "^7.13.11",
     "@bankify/react-native-animate-number": "^0.2.1",
-    "@cardstack/cardpay-sdk": "0.19.43",
+    "@cardstack/cardpay-sdk": "0.19.44",
     "@cardstack/did-resolver": "^0.19.37",
     "@ethersproject/abi": "^5.0.9",
     "@ethersproject/abstract-provider": "^5.0.7",

--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -6,7 +6,6 @@ import {
   getConstantByNetwork,
   greaterThan,
   handleSignificantDecimals,
-  HttpProvider,
   multiply,
 } from '@cardstack/cardpay-sdk';
 import { getAddress } from '@ethersproject/address';
@@ -21,7 +20,6 @@ import Web3 from 'web3';
 
 import AssetTypes from '../helpers/assetTypes';
 import NetworkTypes from '../helpers/networkTypes';
-
 import smartContractMethods from '../references/smartcontract-methods.json';
 import { ethereumUtils } from '../utils';
 import { isLayer1 } from '@cardstack/utils';
@@ -46,6 +44,10 @@ export const web3SetHttpProvider = async network => {
     web3Provider = new JsonRpcProvider(network, NetworkTypes.mainnet);
   } else {
     if (isLayer1(network)) {
+      web3ProviderSdk = new Web3.providers.HttpProvider(
+        getConstantByNetwork('rpcNode', network)
+      );
+
       web3Provider = new JsonRpcProvider(
         getConstantByNetwork('rpcNode', network),
         network

--- a/src/hooks/useUpdateAssetOnchainBalance.js
+++ b/src/hooks/useUpdateAssetOnchainBalance.js
@@ -18,7 +18,7 @@ export default function useUpdateAssetOnchainBalance() {
         accountAddress,
         network
       );
-      if (balance?.amount !== assetToUpdate?.balance?.amount) {
+      if (balance && balance?.amount !== assetToUpdate?.balance?.amount) {
         // Now we need to update the asset
         // First in the state
         successCallback({ ...assetToUpdate, balance });

--- a/src/references/testnet-assets.json
+++ b/src/references/testnet-assets.json
@@ -12,7 +12,7 @@
           "relative_change_24h": -4.586615622469276,
           "value": 259.2
         },
-        "symbol": "KETH"
+        "symbol": "ETH"
       },
       "quantity": 0
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,10 +1255,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cardstack/cardpay-sdk@0.19.43":
-  version "0.19.43"
-  resolved "https://registry.yarnpkg.com/@cardstack/cardpay-sdk/-/cardpay-sdk-0.19.43.tgz#c17aef108d6b5705afcb1b4b94ba9fbfb2fc8f9e"
-  integrity sha512-V4qwGnNOasXoKZNycIlqiqWvKvx7UU1PSLPd6Tzomxx++C1/+iv/mdR4ARjuXxD+mXYmYK3HMR7H2GD04GV1Aw==
+"@cardstack/cardpay-sdk@0.19.44":
+  version "0.19.44"
+  resolved "https://registry.yarnpkg.com/@cardstack/cardpay-sdk/-/cardpay-sdk-0.19.44.tgz#f38a7f08bc4e367e13236181adb3c23f0f9d8c9a"
+  integrity sha512-scArjfQzA9txYRuv5xiaJimotab4yb60RXVrYWokoEGee01CbtZ4mbLPRiwAn1xbIE23qYm8r7VcykjS4zGZbw==
   dependencies:
     "@truffle/hdwallet-provider" "^1.2.6"
     "@trufflesuite/web3-provider-engine" "^15.0.13-1"


### PR DESCRIPTION
We were previously not setting the `web3ProviderSdk` value on Layer1, which is necessary to be used to get assets through the SDK. Also updated the native token symbol to `ETH` rather than `KETH` for Kovan in the app and the SDK.

https://user-images.githubusercontent.com/17347720/128094187-849ea233-ab44-4121-b29b-dbe07347a267.mp4

