### PR TITLE
Handle ellipses on issuer names if too long on prepaid card

### DIFF
--- a/cardstack/src/components/PrepaidCard/PrepaidCard.tsx
+++ b/cardstack/src/components/PrepaidCard/PrepaidCard.tsx
@@ -369,14 +369,17 @@ const Top = ({ address, networkName, cardCustomization }: PrepaidCardProps) => {
         justifyContent="space-between"
         alignItems="flex-start"
       >
-        <TextOverGrad
-          size="xs"
-          weight="extraBold"
-          color={cardCustomization?.textColor as ColorTypes}
-          shadowColor={cardCustomization?.patternColor}
-        >
-          {cardCustomization?.issuerName || 'Unknown'}
-        </TextOverGrad>
+        <Container maxWidth={175}>
+          <TextOverGrad
+            size="xs"
+            weight="extraBold"
+            color={cardCustomization?.textColor as ColorTypes}
+            shadowColor={cardCustomization?.patternColor}
+            numberOfLines={1}
+          >
+            {cardCustomization?.issuerName || 'Unknown'}
+          </TextOverGrad>
+        </Container>
         <Container flexDirection="column" paddingTop={3}>
           <TextOverGrad
             variant="shadowRoboto"


### PR DESCRIPTION
<img width="396" alt="Screen Shot 2021-08-04 at 15 10 48" src="https://user-images.githubusercontent.com/17347720/128272237-dce744b1-a938-4a25-bf48-d4da01ea73d0.png">
