### PR TITLE
[CS-1612] - Fix crash on Mainnet

### DIFF
--- a/src/redux/fallbackExplorer.js
+++ b/src/redux/fallbackExplorer.js
@@ -596,7 +596,7 @@ export const fetchAssetsBalancesAndPrices = async () => {
   let fallbackExplorerAssetsHandle = null;
   if (isMainnet(network)) {
     fallbackExplorerAssetsHandle = setTimeout(
-      () => store.AssetTypes.dispatch(findNewAssetsToWatch(accountAddress)),
+      () => store.dispatch(findNewAssetsToWatch(accountAddress)),
       DISCOVER_NEW_ASSETS_FREQUENCY
     );
   }


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

AssetTypes is not a method from store, so the app was crashing.

PS: I am missing Typescript so much 😫 

- [x] Completes #(CS-1612)
