### PR TITLE
[CS-1479] Merchant transactions updates

### DIFF
--- a/cardstack/src/components/Transactions/MerchantEarnedRevenueTransaction.tsx
+++ b/cardstack/src/components/Transactions/MerchantEarnedRevenueTransaction.tsx
@@ -1,22 +1,21 @@
 import React from 'react';
 
-import { SafeHeader } from '../SafeHeader';
 import {
   TransactionBase,
   TransactionBaseCustomizationProps,
 } from './TransactionBase';
-import { MerchantClaimType } from '@cardstack/types';
-import { CoinIcon } from '@cardstack/components';
+import { CoinIcon, SafeHeader } from '@cardstack/components';
+import { MerchantEarnedRevenueTransactionType } from '@cardstack/types';
 
-export interface MerchantClaimTransactionProps
+export interface MerchantEarnRevenueTransactionProps
   extends TransactionBaseCustomizationProps {
-  item: MerchantClaimType;
+  item: MerchantEarnedRevenueTransactionType;
 }
 
-export const MerchantClaimTransaction = ({
+export const MerchantEarnedRevenueTransaction = ({
   item,
   ...props
-}: MerchantClaimTransactionProps) => {
+}: MerchantEarnRevenueTransactionProps) => {
   return (
     <TransactionBase
       {...props}
@@ -26,9 +25,9 @@ export const MerchantClaimTransaction = ({
       Header={
         <SafeHeader address={item.address} rightText="MERCHANT NAME" small />
       }
-      primaryText={`- ${item.balance.display}`}
+      primaryText={`+ ${item.balance.display}`}
       statusIconName="arrow-down"
-      statusText="Claimed"
+      statusText="Earned"
       subText={item.native.display}
       transactionHash={item.transactionHash}
     />

--- a/cardstack/src/components/Transactions/MerchantEarnedSpendTransaction.tsx
+++ b/cardstack/src/components/Transactions/MerchantEarnedSpendTransaction.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { Icon } from '../Icon';
+import {
+  TransactionBase,
+  TransactionBaseCustomizationProps,
+} from './TransactionBase';
+import { MerchantEarnedSpendTransactionType } from '@cardstack/types';
+import { SafeHeader } from '@cardstack/components';
+
+export interface MerchantEarnSpendTransactionProps
+  extends TransactionBaseCustomizationProps {
+  item: MerchantEarnedSpendTransactionType;
+}
+
+export const MerchantEarnedSpendTransaction = ({
+  item,
+  ...props
+}: MerchantEarnSpendTransactionProps) => {
+  return (
+    <TransactionBase
+      {...props}
+      CoinIcon={<Icon name="spend" />}
+      Header={
+        <SafeHeader address={item.address} rightText="MERCHANT NAME" small />
+      }
+      primaryText={`+ ${item.spendBalanceDisplay}`}
+      statusIconName="arrow-down"
+      statusText="Earned"
+      subText={item.nativeBalanceDisplay}
+      transactionHash={item.transactionHash}
+    />
+  );
+};

--- a/cardstack/src/components/Transactions/TransactionItem.tsx
+++ b/cardstack/src/components/Transactions/TransactionItem.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
-import { ERC20Transaction } from './ERC20Transaction';
+
+import { DepotBridgedLayer1Transaction } from './DepotBridgedLayer1Transaction';
 import { DepotBridgedLayer2Transaction } from './DepotBridgedLayer2Transaction';
-import { MerchantCreationTransaction } from './MerchantCreationTransaction';
+import { ERC20Transaction } from './ERC20Transaction';
 import { MerchantClaimTransaction } from './MerchantClaimTransaction';
+import { MerchantCreationTransaction } from './MerchantCreationTransaction';
+import { MerchantEarnedRevenueTransaction } from './MerchantEarnedRevenueTransaction';
 import { PrepaidCardCreatedTransaction } from './PrepaidCardCreatedTransaction';
 import { PrepaidCardPaymentTransaction } from './PrepaidCardPaymentTransaction';
 import { PrepaidCardSplitTransaction } from './PrepaidCardSplitTransaction';
 import { PrepaidCardTransferTransaction } from './PrepaidCardTransferTransaction';
-import { DepotBridgedLayer1Transaction } from './DepotBridgedLayer1Transaction';
 import { TransactionBaseCustomizationProps } from './TransactionBase';
 import { TransactionType, TransactionTypes } from '@cardstack/types';
+
 interface TransactionItemProps extends TransactionBaseCustomizationProps {
   item: TransactionType;
   isFullWidth?: boolean;
@@ -38,6 +41,8 @@ export const TransactionItem = (props: TransactionItemProps) => {
     return <MerchantCreationTransaction {...props} item={item} />;
   } else if (item.type === TransactionTypes.MERCHANT_CLAIM) {
     return <MerchantClaimTransaction {...props} item={item} />;
+  } else if (item.type === TransactionTypes.MERCHANT_EARNED_REVENUE) {
+    return <MerchantEarnedRevenueTransaction {...props} item={item} />;
   } else if (item.type === TransactionTypes.ERC_20) {
     return <ERC20Transaction {...props} item={item} />;
   }

--- a/cardstack/src/components/Transactions/TransactionItem.tsx
+++ b/cardstack/src/components/Transactions/TransactionItem.tsx
@@ -26,29 +26,30 @@ export const TransactionItem = (props: TransactionItemProps) => {
     return null;
   }
 
-  if (item.type === TransactionTypes.DEPOT_BRIDGED_LAYER_1) {
-    return <DepotBridgedLayer1Transaction {...props} item={item} />;
-  } else if (item.type === TransactionTypes.DEPOT_BRIDGED_LAYER_2) {
-    return <DepotBridgedLayer2Transaction {...props} item={item} />;
-  } else if (item.type === TransactionTypes.PREPAID_CARD_CREATED) {
-    return <PrepaidCardCreatedTransaction {...props} item={item} />;
-  } else if (item.type === TransactionTypes.PREPAID_CARD_PAYMENT) {
-    return <PrepaidCardPaymentTransaction {...props} item={item} />;
-  } else if (item.type === TransactionTypes.PREPAID_CARD_SPLIT) {
-    return <PrepaidCardSplitTransaction {...props} item={item} />;
-  } else if (item.type === TransactionTypes.PREPAID_CARD_TRANSFER) {
-    return <PrepaidCardTransferTransaction {...props} item={item} />;
-  } else if (item.type === TransactionTypes.MERCHANT_CREATION) {
-    return <MerchantCreationTransaction {...props} item={item} />;
-  } else if (item.type === TransactionTypes.MERCHANT_CLAIM) {
-    return <MerchantClaimTransaction {...props} item={item} />;
-  } else if (item.type === TransactionTypes.MERCHANT_EARNED_REVENUE) {
-    return <MerchantEarnedRevenueTransaction {...props} item={item} />;
-  } else if (item.type === TransactionTypes.MERCHANT_EARNED_SPEND) {
-    return <MerchantEarnedSpendTransaction {...props} item={item} />;
-  } else if (item.type === TransactionTypes.ERC_20) {
-    return <ERC20Transaction {...props} item={item} />;
+  switch (item.type) {
+    case TransactionTypes.DEPOT_BRIDGED_LAYER_1:
+      return <DepotBridgedLayer1Transaction {...props} item={item} />;
+    case TransactionTypes.DEPOT_BRIDGED_LAYER_2:
+      return <DepotBridgedLayer2Transaction {...props} item={item} />;
+    case TransactionTypes.PREPAID_CARD_CREATED:
+      return <PrepaidCardCreatedTransaction {...props} item={item} />;
+    case TransactionTypes.PREPAID_CARD_PAYMENT:
+      return <PrepaidCardPaymentTransaction {...props} item={item} />;
+    case TransactionTypes.PREPAID_CARD_SPLIT:
+      return <PrepaidCardSplitTransaction {...props} item={item} />;
+    case TransactionTypes.PREPAID_CARD_TRANSFER:
+      return <PrepaidCardTransferTransaction {...props} item={item} />;
+    case TransactionTypes.MERCHANT_CREATION:
+      return <MerchantCreationTransaction {...props} item={item} />;
+    case TransactionTypes.MERCHANT_CLAIM:
+      return <MerchantClaimTransaction {...props} item={item} />;
+    case TransactionTypes.MERCHANT_EARNED_REVENUE:
+      return <MerchantEarnedRevenueTransaction {...props} item={item} />;
+    case TransactionTypes.MERCHANT_EARNED_SPEND:
+      return <MerchantEarnedSpendTransaction {...props} item={item} />;
+    case TransactionTypes.ERC_20:
+      return <ERC20Transaction {...props} item={item} />;
+    default:
+      return null;
   }
-
-  return null;
 };

--- a/cardstack/src/components/Transactions/TransactionItem.tsx
+++ b/cardstack/src/components/Transactions/TransactionItem.tsx
@@ -11,6 +11,7 @@ import { PrepaidCardPaymentTransaction } from './PrepaidCardPaymentTransaction';
 import { PrepaidCardSplitTransaction } from './PrepaidCardSplitTransaction';
 import { PrepaidCardTransferTransaction } from './PrepaidCardTransferTransaction';
 import { TransactionBaseCustomizationProps } from './TransactionBase';
+import { MerchantEarnedSpendTransaction } from './MerchantEarnedSpendTransaction';
 import { TransactionType, TransactionTypes } from '@cardstack/types';
 
 interface TransactionItemProps extends TransactionBaseCustomizationProps {
@@ -43,6 +44,8 @@ export const TransactionItem = (props: TransactionItemProps) => {
     return <MerchantClaimTransaction {...props} item={item} />;
   } else if (item.type === TransactionTypes.MERCHANT_EARNED_REVENUE) {
     return <MerchantEarnedRevenueTransaction {...props} item={item} />;
+  } else if (item.type === TransactionTypes.MERCHANT_EARNED_SPEND) {
+    return <MerchantEarnedSpendTransaction {...props} item={item} />;
   } else if (item.type === TransactionTypes.ERC_20) {
     return <ERC20Transaction {...props} item={item} />;
   }

--- a/cardstack/src/graphql/fragments.graphql
+++ b/cardstack/src/graphql/fragments.graphql
@@ -30,6 +30,9 @@ fragment PrepaidCardPayment on PrepaidCardPayment {
   prepaidCard {
     id
   }
+  merchantSafe {
+    id
+  }
 }
 
 fragment BridgeToLayer1Event on BridgeToLayer1Event {

--- a/cardstack/src/graphql/graphql-codegen.ts
+++ b/cardstack/src/graphql/graphql-codegen.ts
@@ -4392,7 +4392,10 @@ export type PrepaidCardPaymentFragment = (
   ), prepaidCard: (
     { __typename?: 'PrepaidCard' }
     & Pick<PrepaidCard, 'id'>
-  ) }
+  ), merchantSafe?: Maybe<(
+    { __typename?: 'MerchantSafe' }
+    & Pick<MerchantSafe, 'id'>
+  )> }
 );
 
 export type BridgeToLayer1EventFragment = (
@@ -4689,6 +4692,9 @@ export const PrepaidCardPaymentFragmentDoc = gql`
     name
   }
   prepaidCard {
+    id
+  }
+  merchantSafe {
     id
   }
 }

--- a/cardstack/src/hooks/transactions/use-merchant-transactions.tsx
+++ b/cardstack/src/hooks/transactions/use-merchant-transactions.tsx
@@ -6,6 +6,8 @@ import { getApolloClient } from '../../graphql/apollo-client';
 import { useTransactionSections } from './use-transaction-sections';
 import logger from 'logger';
 import { useGetMerchantTransactionHistoryDataQuery } from '@cardstack/graphql';
+import { MerchantClaimStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-claim-strategy';
+import { MerchantEarnedRevenueStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-revenue-strategy';
 
 export const useMerchantTransactions = (safeAddress: string) => {
   const [network] = useRainbowSelector(state => [state.settings.network]);
@@ -44,7 +46,11 @@ export const useMerchantTransactions = (safeAddress: string) => {
     transactionsCount: revenueEvents?.length || 0,
     networkStatus,
     fetchMore,
-    isMerchantTransactions: true,
+    merchantSafeAddress: safeAddress,
+    transactionStrategies: [
+      MerchantClaimStrategy,
+      MerchantEarnedRevenueStrategy,
+    ],
   });
 
   return {

--- a/cardstack/src/hooks/transactions/use-merchant-transactions.tsx
+++ b/cardstack/src/hooks/transactions/use-merchant-transactions.tsx
@@ -5,11 +5,13 @@ import { TRANSACTION_PAGE_SIZE } from '../../constants';
 import { getApolloClient } from '../../graphql/apollo-client';
 import { useTransactionSections } from './use-transaction-sections';
 import logger from 'logger';
+import { TransactionMappingStrategy } from '@cardstack/transaction-mapping-strategies/context';
 import { useGetMerchantTransactionHistoryDataQuery } from '@cardstack/graphql';
-import { MerchantClaimStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-claim-strategy';
-import { MerchantEarnedRevenueStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-revenue-strategy';
 
-export const useMerchantTransactions = (safeAddress: string) => {
+export const useMerchantTransactions = (
+  safeAddress: string,
+  transactionStrategies?: TransactionMappingStrategy[]
+) => {
   const [network] = useRainbowSelector(state => [state.settings.network]);
 
   const client = getApolloClient(network);
@@ -47,10 +49,7 @@ export const useMerchantTransactions = (safeAddress: string) => {
     networkStatus,
     fetchMore,
     merchantSafeAddress: safeAddress,
-    transactionStrategies: [
-      MerchantClaimStrategy,
-      MerchantEarnedRevenueStrategy,
-    ],
+    transactionStrategies,
   });
 
   return {

--- a/cardstack/src/hooks/transactions/use-transaction-sections.tsx
+++ b/cardstack/src/hooks/transactions/use-transaction-sections.tsx
@@ -52,6 +52,8 @@ export const useTransactionSections = ({
       if (transactions) {
         setLoading(true);
 
+        console.log('merchantSafeAddress', merchantSafeAddress);
+
         try {
           const transactionMappingContext = new TransactionMappingContext({
             transactions: merchantSafeAddress

--- a/cardstack/src/hooks/transactions/use-transaction-sections.tsx
+++ b/cardstack/src/hooks/transactions/use-transaction-sections.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { groupBy } from 'lodash';
 import { NetworkStatus } from '@apollo/client';
-import { TransactionMappingContext } from '@cardstack/transaction-mapping-strategies/context';
+import {
+  TransactionMappingContext,
+  TransactionMappingStrategy,
+} from '@cardstack/transaction-mapping-strategies/context';
 import {
   useNativeCurrencyAndConversionRates,
   useRainbowSelector,
@@ -19,7 +22,8 @@ interface UseTransactionSectionsProps {
   transactionsCount: number;
   networkStatus: NetworkStatus;
   fetchMore?: (props: any) => void;
-  isMerchantTransactions?: boolean;
+  merchantSafeAddress?: string;
+  transactionStrategies?: TransactionMappingStrategy[];
 }
 
 export const useTransactionSections = ({
@@ -28,7 +32,8 @@ export const useTransactionSections = ({
   transactionsCount,
   networkStatus,
   fetchMore,
-  isMerchantTransactions,
+  merchantSafeAddress,
+  transactionStrategies,
 }: UseTransactionSectionsProps) => {
   const [sections, setSections] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
@@ -49,12 +54,14 @@ export const useTransactionSections = ({
 
         try {
           const transactionMappingContext = new TransactionMappingContext({
-            transactions: isMerchantTransactions
+            transactions: merchantSafeAddress
               ? merchantRevenueEventsToTransactions(transactions as any[])
               : transactions.map((t: any) => t?.transaction),
             accountAddress,
             nativeCurrency,
             currencyConversionRates,
+            transactionStrategies,
+            merchantSafeAddress,
           });
 
           const mappedTransactions = await transactionMappingContext.mapTransactions();
@@ -94,7 +101,8 @@ export const useTransactionSections = ({
     accountAddress,
     transactions,
     isEmpty,
-    isMerchantTransactions,
+    merchantSafeAddress,
+    transactionStrategies,
   ]);
 
   const isLoading = networkStatus === NetworkStatus.loading || loading;

--- a/cardstack/src/transaction-mapping-strategies/base-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/base-strategy.ts
@@ -6,6 +6,7 @@ interface BaseStrategyParams {
   accountAddress: string;
   nativeCurrency: string;
   currencyConversionRates: CurrencyConversionRates;
+  merchantSafeAddress?: string;
 }
 
 export abstract class BaseStrategy {
@@ -18,16 +19,19 @@ export abstract class BaseStrategy {
   accountAddress: string;
   nativeCurrency: string;
   currencyConversionRates: CurrencyConversionRates;
+  merchantSafeAddress?: string;
 
   constructor({
     transaction,
     accountAddress,
     nativeCurrency,
     currencyConversionRates,
+    merchantSafeAddress,
   }: BaseStrategyParams) {
     this.transaction = transaction;
     this.accountAddress = accountAddress;
     this.nativeCurrency = nativeCurrency;
     this.currencyConversionRates = currencyConversionRates;
+    this.merchantSafeAddress = merchantSafeAddress;
   }
 }

--- a/cardstack/src/transaction-mapping-strategies/context.ts
+++ b/cardstack/src/transaction-mapping-strategies/context.ts
@@ -8,6 +8,7 @@ import { MerchantCreationStrategy } from './transaction-mapping-strategy-types/m
 import { ERC20TokenStrategy } from './transaction-mapping-strategy-types/erc20-token-strategy';
 import { PrepaidCardPaymentStrategy } from './transaction-mapping-strategy-types/prepaid-card-payment-strategy';
 import { MerchantEarnedRevenueStrategy } from './transaction-mapping-strategy-types/merchant-earned-revenue-strategy';
+import { MerchantEarnedSpendStrategy } from './transaction-mapping-strategy-types/merchant-earned-spend-strategy';
 import logger from 'logger';
 import { TransactionFragment } from '@cardstack/graphql';
 import { CurrencyConversionRates, TransactionType } from '@cardstack/types';
@@ -21,6 +22,7 @@ export type TransactionMappingStrategy =
   | typeof BridgeToLayer1EventStrategy
   | typeof BridgeToLayer2EventStrategy
   | typeof MerchantCreationStrategy
+  | typeof MerchantEarnedSpendStrategy
   | typeof MerchantEarnedRevenueStrategy;
 
 interface TransactionData {

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-revenue-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-revenue-strategy.ts
@@ -1,0 +1,68 @@
+import {
+  convertAmountToNativeDisplay,
+  convertRawAmountToBalance,
+} from '@cardstack/cardpay-sdk';
+import { BaseStrategy } from '../base-strategy';
+import {
+  MerchantEarnedRevenueTransactionType,
+  TransactionTypes,
+} from '@cardstack/types';
+import { getNativeBalance } from '@cardstack/services';
+
+export class MerchantEarnedRevenueStrategy extends BaseStrategy {
+  handlesTransaction(): boolean {
+    const { prepaidCardPayments } = this.transaction;
+
+    if (
+      prepaidCardPayments?.[0] &&
+      this.merchantSafeAddress &&
+      prepaidCardPayments[0].merchantSafe?.id === this.merchantSafeAddress
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  async mapTransaction(): Promise<MerchantEarnedRevenueTransactionType> | null {
+    const prepaidCardPaymentTransaction = this.transaction
+      .prepaidCardPayments?.[0];
+
+    if (!prepaidCardPaymentTransaction) {
+      return null;
+    }
+
+    const symbol = prepaidCardPaymentTransaction.issuingToken.symbol || '';
+    const amount = prepaidCardPaymentTransaction.issuingTokenAmount;
+
+    const nativeBalance = await getNativeBalance({
+      symbol,
+      balance: amount,
+      nativeCurrency: this.nativeCurrency,
+      currencyConversionRates: this.currencyConversionRates,
+    });
+
+    return {
+      balance: convertRawAmountToBalance(amount, {
+        decimals: 18,
+        symbol,
+      }),
+      native: {
+        amount: nativeBalance.toString(),
+        display: convertAmountToNativeDisplay(
+          nativeBalance,
+          this.nativeCurrency
+        ),
+      },
+      address: prepaidCardPaymentTransaction.prepaidCard.id,
+      token: {
+        address: prepaidCardPaymentTransaction.issuingToken.id,
+        symbol: prepaidCardPaymentTransaction.issuingToken.symbol,
+        name: prepaidCardPaymentTransaction.issuingToken.name,
+      },
+      timestamp: prepaidCardPaymentTransaction.timestamp,
+      type: TransactionTypes.MERCHANT_EARNED_REVENUE,
+      transactionHash: this.transaction.id,
+    };
+  }
+}

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-revenue-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-revenue-strategy.ts
@@ -13,15 +13,11 @@ export class MerchantEarnedRevenueStrategy extends BaseStrategy {
   handlesTransaction(): boolean {
     const { prepaidCardPayments } = this.transaction;
 
-    if (
+    return Boolean(
       prepaidCardPayments?.[0] &&
-      this.merchantSafeAddress &&
-      prepaidCardPayments[0].merchantSafe?.id === this.merchantSafeAddress
-    ) {
-      return true;
-    }
-
-    return false;
+        this.merchantSafeAddress &&
+        prepaidCardPayments[0].merchantSafe?.id === this.merchantSafeAddress
+    );
   }
 
   async mapTransaction(): Promise<MerchantEarnedRevenueTransactionType | null> {

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-revenue-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-revenue-strategy.ts
@@ -24,7 +24,7 @@ export class MerchantEarnedRevenueStrategy extends BaseStrategy {
     return false;
   }
 
-  async mapTransaction(): Promise<MerchantEarnedRevenueTransactionType> | null {
+  async mapTransaction(): Promise<MerchantEarnedRevenueTransactionType | null> {
     const prepaidCardPaymentTransaction = this.transaction
       .prepaidCardPayments?.[0];
 

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-strategy.ts
@@ -9,15 +9,11 @@ export class MerchantEarnedSpendStrategy extends BaseStrategy {
   handlesTransaction(): boolean {
     const { prepaidCardPayments } = this.transaction;
 
-    if (
+    return Boolean(
       prepaidCardPayments?.[0] &&
-      this.merchantSafeAddress &&
-      prepaidCardPayments[0].merchantSafe?.id === this.merchantSafeAddress
-    ) {
-      return true;
-    }
-
-    return false;
+        this.merchantSafeAddress &&
+        prepaidCardPayments[0].merchantSafe?.id === this.merchantSafeAddress
+    );
   }
 
   async mapTransaction(): Promise<MerchantEarnedSpendTransactionType | null> {

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-strategy.ts
@@ -1,14 +1,8 @@
-import {
-  convertAmountToNativeDisplay,
-  convertRawAmountToBalance,
-} from '@cardstack/cardpay-sdk';
 import { BaseStrategy } from '../base-strategy';
 import {
-  MerchantEarnedRevenueTransactionType,
   MerchantEarnedSpendTransactionType,
   TransactionTypes,
 } from '@cardstack/types';
-import { getNativeBalance } from '@cardstack/services';
 import { convertSpendForBalanceDisplay } from '@cardstack/utils';
 
 export class MerchantEarnedSpendStrategy extends BaseStrategy {

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-strategy.ts
@@ -1,0 +1,53 @@
+import {
+  convertAmountToNativeDisplay,
+  convertRawAmountToBalance,
+} from '@cardstack/cardpay-sdk';
+import { BaseStrategy } from '../base-strategy';
+import {
+  MerchantEarnedRevenueTransactionType,
+  MerchantEarnedSpendTransactionType,
+  TransactionTypes,
+} from '@cardstack/types';
+import { getNativeBalance } from '@cardstack/services';
+import { convertSpendForBalanceDisplay } from '@cardstack/utils';
+
+export class MerchantEarnedSpendStrategy extends BaseStrategy {
+  handlesTransaction(): boolean {
+    const { prepaidCardPayments } = this.transaction;
+
+    if (
+      prepaidCardPayments?.[0] &&
+      this.merchantSafeAddress &&
+      prepaidCardPayments[0].merchantSafe?.id === this.merchantSafeAddress
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  async mapTransaction(): Promise<MerchantEarnedSpendTransactionType | null> {
+    const prepaidCardPaymentTransaction = this.transaction
+      .prepaidCardPayments?.[0];
+
+    if (!prepaidCardPaymentTransaction) {
+      return null;
+    }
+
+    const spendDisplay = convertSpendForBalanceDisplay(
+      prepaidCardPaymentTransaction.spendAmount,
+      this.nativeCurrency,
+      this.currencyConversionRates,
+      true
+    );
+
+    return {
+      address: prepaidCardPaymentTransaction.prepaidCard.id,
+      timestamp: prepaidCardPaymentTransaction.timestamp,
+      type: TransactionTypes.MERCHANT_EARNED_SPEND,
+      spendBalanceDisplay: spendDisplay.tokenBalanceDisplay,
+      nativeBalanceDisplay: spendDisplay.nativeBalanceDisplay,
+      transactionHash: this.transaction.id,
+    };
+  }
+}

--- a/cardstack/src/types/transaction-types.ts
+++ b/cardstack/src/types/transaction-types.ts
@@ -9,6 +9,7 @@ export enum TransactionTypes {
   MERCHANT_CREATION = 'merchantCreation',
   MERCHANT_REVENUE_EVENT = 'merchantRevenueEvent',
   MERCHANT_EARNED_REVENUE = 'merchantEarnedRevenue',
+  MERCHANT_EARNED_SPEND = 'merchantEarnedSpend',
   ERC_20 = 'erc20',
 }
 
@@ -150,6 +151,15 @@ export interface MerchantEarnedRevenueTransactionType {
   transactionHash: string;
 }
 
+export interface MerchantEarnedSpendTransactionType {
+  address: string;
+  spendBalanceDisplay: string;
+  nativeBalanceDisplay: string;
+  timestamp: number;
+  type: TransactionTypes.MERCHANT_EARNED_SPEND;
+  transactionHash: string;
+}
+
 export interface PrepaidCardSplitTransactionType {
   address: string;
   timestamp: number;
@@ -225,4 +235,5 @@ export type TransactionType =
   | PrepaidCardSplitTransactionType
   | MerchantRevenueEventType
   | MerchantClaimType
-  | MerchantEarnedRevenueTransactionType;
+  | MerchantEarnedRevenueTransactionType
+  | MerchantEarnedSpendTransactionType;

--- a/cardstack/src/types/transaction-types.ts
+++ b/cardstack/src/types/transaction-types.ts
@@ -8,6 +8,7 @@ export enum TransactionTypes {
   MERCHANT_CLAIM = 'merchantClaim',
   MERCHANT_CREATION = 'merchantCreation',
   MERCHANT_REVENUE_EVENT = 'merchantRevenueEvent',
+  MERCHANT_EARNED_REVENUE = 'merchantEarnedRevenue',
   ERC_20 = 'erc20',
 }
 
@@ -129,6 +130,26 @@ export interface PrepaidCardPaymentTransactionType {
   transactionHash: string;
 }
 
+export interface MerchantEarnedRevenueTransactionType {
+  address: string;
+  balance: {
+    amount: string;
+    display: string;
+  };
+  native: {
+    amount: string;
+    display: string;
+  };
+  token: {
+    address: string;
+    name?: string | null;
+    symbol?: string | null;
+  };
+  timestamp: number;
+  type: TransactionTypes.MERCHANT_EARNED_REVENUE;
+  transactionHash: string;
+}
+
 export interface PrepaidCardSplitTransactionType {
   address: string;
   timestamp: number;
@@ -203,4 +224,5 @@ export type TransactionType =
   | PrepaidCardTransferTransactionType
   | PrepaidCardSplitTransactionType
   | MerchantRevenueEventType
-  | MerchantClaimType;
+  | MerchantClaimType
+  | MerchantEarnedRevenueTransactionType;

--- a/cardstack/src/types/transaction-types.ts
+++ b/cardstack/src/types/transaction-types.ts
@@ -1,3 +1,4 @@
+import { BalanceType } from './AssetType';
 export enum TransactionTypes {
   DEPOT_BRIDGED_LAYER_1 = 'depotBridgedLayer1',
   DEPOT_BRIDGED_LAYER_2 = 'depotBridgedLayer2',
@@ -14,14 +15,8 @@ export enum TransactionTypes {
 }
 
 export interface DepotBridgedLayer2TransactionType {
-  balance: {
-    amount: string;
-    display: string;
-  };
-  native: {
-    amount: string;
-    display: string;
-  };
+  balance: BalanceType;
+  native: BalanceType;
   transactionHash: string;
   to: string;
   token: {
@@ -34,14 +29,8 @@ export interface DepotBridgedLayer2TransactionType {
 }
 
 export interface DepotBridgedLayer1TransactionType {
-  balance: {
-    amount: string;
-    display: string;
-  };
-  native: {
-    amount: string;
-    display: string;
-  };
+  balance: BalanceType;
+  native: BalanceType;
   transactionHash: string;
   to: string;
   token: {
@@ -105,14 +94,8 @@ export interface MerchantClaimType {
   address: string;
   createdAt: string;
   transactionHash: string;
-  balance: {
-    amount: string;
-    display: string;
-  };
-  native: {
-    amount: string;
-    display: string;
-  };
+  balance: BalanceType;
+  native: BalanceType;
   token: {
     address: string;
     name?: string | null;
@@ -133,14 +116,8 @@ export interface PrepaidCardPaymentTransactionType {
 
 export interface MerchantEarnedRevenueTransactionType {
   address: string;
-  balance: {
-    amount: string;
-    display: string;
-  };
-  native: {
-    amount: string;
-    display: string;
-  };
+  balance: BalanceType;
+  native: BalanceType;
   token: {
     address: string;
     name?: string | null;
@@ -207,16 +184,10 @@ export enum TransactionStatus {
 export interface ERC20TransactionType {
   from: string;
   to: string;
-  balance: {
-    amount: string;
-    display: string;
-  };
+  balance: BalanceType;
   hash: string;
   minedAt: number;
-  native: {
-    amount: string;
-    display: string;
-  };
+  native: BalanceType;
   status: TransactionStatus;
   title: string;
   symbol: string;

--- a/src/components/expanded-state/LifetimeEarningsExpandedState.tsx
+++ b/src/components/expanded-state/LifetimeEarningsExpandedState.tsx
@@ -17,7 +17,6 @@ import {
 } from '@cardstack/components';
 import { useMerchantTransactions } from '@cardstack/hooks';
 import { palette } from '@cardstack/theme';
-import { MerchantEarnedSpendStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-strategy';
 import { MerchantSafeType } from '@cardstack/types';
 import { convertSpendForBalanceDisplay } from '@cardstack/utils';
 import { ChartPath } from '@rainbow-me/animated-charts';
@@ -26,7 +25,7 @@ import { useNavigation } from '@rainbow-me/navigation';
 import { useRainbowSelector } from '@rainbow-me/redux/hooks';
 
 const CHART_HEIGHT = 200;
-const HEIGHT = CHART_HEIGHT + 310;
+const HEIGHT = CHART_HEIGHT + 400;
 
 const useMerchantSafe = (address: string) => {
   const merchantSafes = useRainbowSelector(state => state.data.merchantSafes);
@@ -52,7 +51,7 @@ export default function LifetimeEarningsExpandedState(props: {
 
   return (
     // @ts-ignore doesn't understand the JS props
-    <SlackSheet bottomInset={42} contentHeight={HEIGHT} scrollEnabled>
+    <SlackSheet bottomInset={42} height="100%" scrollEnabled>
       <ChartSection address={address} />
       <Container paddingHorizontal={5}>
         <HorizontalDivider />
@@ -146,42 +145,49 @@ const ActivitiesSection = ({ address }: { address: string }) => {
     refetchLoading,
     refetch,
     isLoadingTransactions,
-  } = useMerchantTransactions(address, [MerchantEarnedSpendStrategy]);
+  } = useMerchantTransactions(address, 'lifetimeEarnings');
 
   return (
-    <Container flexDirection="column" marginTop={7} width="100%">
-      {isLoadingTransactions ? (
-        <TransactionListLoading light />
-      ) : (
-        <SectionList
-          ListEmptyComponent={<ListEmptyComponent />}
-          ListFooterComponent={
-            isFetchingMore ? <ActivityIndicator color="white" /> : null
-          }
-          contentContainerStyle={{ paddingBottom: 40 }}
-          onEndReached={onEndReached}
-          onEndReachedThreshold={1}
-          refreshControl={
-            <RefreshControl
-              onRefresh={refetch}
-              refreshing={refetchLoading}
-              tintColor="white"
-            />
-          }
-          renderItem={props => (
-            <TransactionItem {...props} includeBorder isFullWidth />
-          )}
-          renderSectionHeader={({ section: { title } }) => (
-            <Container backgroundColor="white" paddingVertical={2} width="100%">
-              <Text color="blueText" size="medium">
-                {title}
-              </Text>
-            </Container>
-          )}
-          sections={sections}
-          style={{ width: '100%' }}
-        />
-      )}
+    <Container paddingHorizontal={5} paddingVertical={3}>
+      <Text size="medium">Activities</Text>
+      <Container flexDirection="column" marginTop={7} width="100%">
+        {isLoadingTransactions ? (
+          <TransactionListLoading light />
+        ) : (
+          <SectionList
+            ListEmptyComponent={<ListEmptyComponent />}
+            ListFooterComponent={
+              isFetchingMore ? <ActivityIndicator color="white" /> : null
+            }
+            contentContainerStyle={{ paddingBottom: 40 }}
+            onEndReached={onEndReached}
+            onEndReachedThreshold={1}
+            refreshControl={
+              <RefreshControl
+                onRefresh={refetch}
+                refreshing={refetchLoading}
+                tintColor="white"
+              />
+            }
+            renderItem={props => (
+              <TransactionItem {...props} includeBorder isFullWidth />
+            )}
+            renderSectionHeader={({ section: { title } }) => (
+              <Container
+                backgroundColor="white"
+                paddingVertical={2}
+                width="100%"
+              >
+                <Text color="blueText" size="medium">
+                  {title}
+                </Text>
+              </Container>
+            )}
+            sections={sections}
+            style={{ width: '100%' }}
+          />
+        )}
+      </Container>
     </Container>
   );
 };

--- a/src/components/expanded-state/LifetimeEarningsExpandedState.tsx
+++ b/src/components/expanded-state/LifetimeEarningsExpandedState.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, RefreshControl, SectionList } from 'react-native';
 import {
   ChartFilterOptions,
@@ -137,6 +137,18 @@ const ChartSection = ({ address }: { address: string }) => {
   );
 };
 
+const renderItem = (props: any) => (
+  <TransactionItem {...props} includeBorder isFullWidth />
+);
+
+const renderSectionHeader = ({ section: { title } }: any) => (
+  <Container backgroundColor="white" paddingVertical={2} width="100%">
+    <Text color="blueText" size="medium">
+      {title}
+    </Text>
+  </Container>
+);
+
 const ActivitiesSection = ({ address }: { address: string }) => {
   const {
     sections,
@@ -169,20 +181,8 @@ const ActivitiesSection = ({ address }: { address: string }) => {
                 tintColor="white"
               />
             }
-            renderItem={props => (
-              <TransactionItem {...props} includeBorder isFullWidth />
-            )}
-            renderSectionHeader={({ section: { title } }) => (
-              <Container
-                backgroundColor="white"
-                paddingVertical={2}
-                width="100%"
-              >
-                <Text color="blueText" size="medium">
-                  {title}
-                </Text>
-              </Container>
-            )}
+            renderItem={renderItem}
+            renderSectionHeader={renderSectionHeader}
             sections={sections}
             style={{ width: '100%' }}
           />

--- a/src/components/expanded-state/LifetimeEarningsExpandedState.tsx
+++ b/src/components/expanded-state/LifetimeEarningsExpandedState.tsx
@@ -1,6 +1,4 @@
-import { useRoute } from '@react-navigation/core';
 import React, { useEffect, useState } from 'react';
-import { Dimensions } from 'react-native';
 import {
   ChartFilterOptions,
   useLifetimeEarningsData,
@@ -13,7 +11,6 @@ import {
   Icon,
   Text,
 } from '@cardstack/components';
-import { useMerchantTransactions } from '@cardstack/hooks';
 import { palette } from '@cardstack/theme';
 import { MerchantSafeType } from '@cardstack/types';
 import { convertSpendForBalanceDisplay } from '@cardstack/utils';

--- a/src/components/expanded-state/UnclaimedRevenueExpandedState.tsx
+++ b/src/components/expanded-state/UnclaimedRevenueExpandedState.tsx
@@ -18,6 +18,8 @@ import {
   TransactionListLoading,
 } from '@cardstack/components';
 import { useMerchantTransactions } from '@cardstack/hooks';
+import { MerchantClaimStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-claim-strategy';
+import { MerchantEarnedRevenueStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-revenue-strategy';
 import { MerchantSafeType, TokenType } from '@cardstack/types';
 import { web3ProviderSdk } from '@rainbow-me/handlers/web3';
 import { useWallets } from '@rainbow-me/hooks';
@@ -132,7 +134,10 @@ const Activities = ({ address }: { address: string }) => {
     refetchLoading,
     refetch,
     isLoadingTransactions,
-  } = useMerchantTransactions(address);
+  } = useMerchantTransactions(address, [
+    MerchantClaimStrategy,
+    MerchantEarnedRevenueStrategy,
+  ]);
 
   return (
     <Container flexDirection="column" marginTop={7} width="100%">

--- a/src/components/expanded-state/UnclaimedRevenueExpandedState.tsx
+++ b/src/components/expanded-state/UnclaimedRevenueExpandedState.tsx
@@ -18,8 +18,6 @@ import {
   TransactionListLoading,
 } from '@cardstack/components';
 import { useMerchantTransactions } from '@cardstack/hooks';
-import { MerchantClaimStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-claim-strategy';
-import { MerchantEarnedRevenueStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-revenue-strategy';
 import { MerchantSafeType, TokenType } from '@cardstack/types';
 import { web3ProviderSdk } from '@rainbow-me/handlers/web3';
 import { useWallets } from '@rainbow-me/hooks';
@@ -134,10 +132,7 @@ const Activities = ({ address }: { address: string }) => {
     refetchLoading,
     refetch,
     isLoadingTransactions,
-  } = useMerchantTransactions(address, [
-    MerchantClaimStrategy,
-    MerchantEarnedRevenueStrategy,
-  ]);
+  } = useMerchantTransactions(address, 'unclaimedRevenue');
 
   return (
     <Container flexDirection="column" marginTop={7} width="100%">


### PR DESCRIPTION
- [x] Add transactions to life time earnings sheet
- [x] Update unclaimed revenue transactions to properly display claimed and earned transactions

This is a bit complicated because we are handling the same transaction (prepaid card payment) 3 different ways, soon to be 4.

If we are viewing from the lifetime earnings sheet, we want to show it as an earned spend transaction

![Screen Shot 2021-08-17 at 11 48 52](https://user-images.githubusercontent.com/17347720/129785139-c4a76f42-730a-4c7d-aeab-3a99936b5bfe.png)

If we are viewing it from the unclaimed revenue sheet, we want to show it as an earned tokens transaction

![Screen Shot 2021-08-17 at 11 49 11](https://user-images.githubusercontent.com/17347720/129785165-0727147d-60d0-47a3-90fd-983c58498eaa.png)

In a future ticket, we will have to handle showing it as both on an EOA screen, only if the prepaid card payment target is one of our merchant safes. 

![image](https://user-images.githubusercontent.com/17347720/129785224-389863b8-1989-426f-b4b0-c878928c7bbb.png)

We also still want to show valid prepaid card payments correctly on the EOA screen.

![image](https://user-images.githubusercontent.com/17347720/129785277-cb4b5abf-93c7-4b72-bf98-9fe810a1f421.png)

Open to suggestions on a better way to implement this, but for now I have split out the handling of an earned spend transaction and earned revenue transaction into separate strategies and I pass the strategies I want to use when pulling the transactions. This allows us to map the transaction correctly based on where we are using it and display correctly.