### PR TITLE
[CS-1526] Bring Merchant top over prepaid cards

### DIFF
--- a/src/hooks/useAssetListData.tsx
+++ b/src/hooks/useAssetListData.tsx
@@ -155,9 +155,11 @@ export const useAssetListData = () => {
   const isLoadingAssets = useRainbowSelector(
     state => state.data.isLoadingAssets
   );
+
+  // order of sections in asset list
   const orderedSections = [
-    prepaidCardSection,
     merchantSafesSection,
+    prepaidCardSection,
     depotSection,
     balancesSection,
     collectiblesSection,


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### AC

If I have an active EOA with a merchant account it should come before prepaid cards section. If I do not have a merchant account I should not see any reference to a merchant section. 

- [x] Completes #1526

### Screenshots

<!-- Screenshots or animated GIFs included here -->
<img width="454" alt="Screen Shot 2021-08-18 at 11 07 14 PM" src="https://user-images.githubusercontent.com/16714648/129924118-27e18835-7649-4640-a666-e338c2c95698.png">
<img width="448" alt="Screen Shot 2021-08-18 at 11 13 13 PM" src="https://user-images.githubusercontent.com/16714648/129924131-7946e565-ce86-4f64-a8c0-a0d48b3df663.png">
