### PR TITLE
[CS-1628] Add merchant revenue transactions to EOA screen

### DIFF
--- a/cardstack/src/components/Transactions/MerchantEarnedSpendAndRevenueTransaction.tsx
+++ b/cardstack/src/components/Transactions/MerchantEarnedSpendAndRevenueTransaction.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { Icon } from '../Icon';
+import {
+  TransactionBase,
+  TransactionBaseCustomizationProps,
+} from './TransactionBase';
+import { MerchantEarnedSpendAndRevenueTransactionType } from '@cardstack/types';
+import { CoinIcon, Container, SafeHeader, Text } from '@cardstack/components';
+
+export interface MerchantEarnSpendAndRevenueTransactionProps
+  extends TransactionBaseCustomizationProps {
+  item: MerchantEarnedSpendAndRevenueTransactionType;
+}
+
+export const MerchantEarnedSpendAndRevenueTransaction = ({
+  item,
+  ...props
+}: MerchantEarnSpendAndRevenueTransactionProps) => {
+  return (
+    <TransactionBase
+      {...props}
+      CoinIcon={<Icon name="spend" />}
+      Header={
+        <SafeHeader address={item.address} rightText="MERCHANT NAME" small />
+      }
+      Footer={
+        <Container
+          paddingHorizontal={5}
+          flexDirection="row"
+          justifyContent="space-between"
+        >
+          <Container maxWidth={100}>
+            <Text variant="subText" marginBottom={1}>
+              Added to revenue pool
+            </Text>
+          </Container>
+          <Container flexDirection="row" alignItems="center">
+            <Text size="xs" weight="extraBold" marginRight={2}>
+              {`- ${item.balance.display}`}
+            </Text>
+            <CoinIcon
+              address={item.token.address}
+              symbol={item.token.symbol}
+              size={20}
+            />
+          </Container>
+        </Container>
+      }
+      primaryText={`+ ${item.spendBalanceDisplay}`}
+      statusIconName="arrow-down"
+      statusText="Earned"
+      subText={item.nativeBalanceDisplay}
+      transactionHash={item.transactionHash}
+    />
+  );
+};

--- a/cardstack/src/components/Transactions/TransactionItem.tsx
+++ b/cardstack/src/components/Transactions/TransactionItem.tsx
@@ -12,6 +12,7 @@ import { PrepaidCardSplitTransaction } from './PrepaidCardSplitTransaction';
 import { PrepaidCardTransferTransaction } from './PrepaidCardTransferTransaction';
 import { TransactionBaseCustomizationProps } from './TransactionBase';
 import { MerchantEarnedSpendTransaction } from './MerchantEarnedSpendTransaction';
+import { MerchantEarnedSpendAndRevenueTransaction } from './MerchantEarnedSpendAndRevenueTransaction';
 import { TransactionType, TransactionTypes } from '@cardstack/types';
 
 interface TransactionItemProps extends TransactionBaseCustomizationProps {
@@ -47,6 +48,10 @@ export const TransactionItem = (props: TransactionItemProps) => {
       return <MerchantEarnedRevenueTransaction {...props} item={item} />;
     case TransactionTypes.MERCHANT_EARNED_SPEND:
       return <MerchantEarnedSpendTransaction {...props} item={item} />;
+    case TransactionTypes.MERCHANT_EARNED_SPEND_AND_REVENUE:
+      return (
+        <MerchantEarnedSpendAndRevenueTransaction {...props} item={item} />
+      );
     case TransactionTypes.ERC_20:
       return <ERC20Transaction {...props} item={item} />;
     default:

--- a/cardstack/src/hooks/transactions/use-transaction-sections.tsx
+++ b/cardstack/src/hooks/transactions/use-transaction-sections.tsx
@@ -106,6 +106,7 @@ export const useTransactionSections = ({
     isEmpty,
     merchantSafeAddress,
     transactionStrategies,
+    merchantSafeAddresses,
   ]);
 
   const isLoading = networkStatus === NetworkStatus.loading || loading;

--- a/cardstack/src/hooks/transactions/use-transaction-sections.tsx
+++ b/cardstack/src/hooks/transactions/use-transaction-sections.tsx
@@ -37,6 +37,8 @@ export const useTransactionSections = ({
 }: UseTransactionSectionsProps) => {
   const [sections, setSections] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
+  const merchantSafes = useRainbowSelector(state => state.data.merchantSafes);
+  const merchantSafeAddresses = merchantSafes?.map(safe => safe.address) || [];
 
   const [
     nativeCurrency,
@@ -52,8 +54,6 @@ export const useTransactionSections = ({
       if (transactions) {
         setLoading(true);
 
-        console.log('merchantSafeAddress', merchantSafeAddress);
-
         try {
           const transactionMappingContext = new TransactionMappingContext({
             transactions: merchantSafeAddress
@@ -63,6 +63,7 @@ export const useTransactionSections = ({
             nativeCurrency,
             currencyConversionRates,
             transactionStrategies,
+            merchantSafeAddresses,
             merchantSafeAddress,
           });
 

--- a/cardstack/src/hooks/transactions/use-transaction-sections.tsx
+++ b/cardstack/src/hooks/transactions/use-transaction-sections.tsx
@@ -37,8 +37,11 @@ export const useTransactionSections = ({
 }: UseTransactionSectionsProps) => {
   const [sections, setSections] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
-  const merchantSafes = useRainbowSelector(state => state.data.merchantSafes);
-  const merchantSafeAddresses = merchantSafes?.map(safe => safe.address) || [];
+
+  const [merchantSafes, prepaidCards] = useRainbowSelector(state => [
+    state.data.merchantSafes,
+    state.data.prepaidCards,
+  ]);
 
   const [
     nativeCurrency,
@@ -55,6 +58,9 @@ export const useTransactionSections = ({
         setLoading(true);
 
         try {
+          const merchantSafeAddresses = merchantSafes.map(safe => safe.address);
+          const prepaidCardAddresses = prepaidCards.map(safe => safe.address);
+
           const transactionMappingContext = new TransactionMappingContext({
             transactions: merchantSafeAddress
               ? merchantRevenueEventsToTransactions(transactions as any[])
@@ -64,6 +70,7 @@ export const useTransactionSections = ({
             currencyConversionRates,
             transactionStrategies,
             merchantSafeAddresses,
+            prepaidCardAddresses,
             merchantSafeAddress,
           });
 
@@ -106,7 +113,8 @@ export const useTransactionSections = ({
     isEmpty,
     merchantSafeAddress,
     transactionStrategies,
-    merchantSafeAddresses,
+    merchantSafes,
+    prepaidCards,
   ]);
 
   const isLoading = networkStatus === NetworkStatus.loading || loading;

--- a/cardstack/src/transaction-mapping-strategies/base-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/base-strategy.ts
@@ -6,6 +6,7 @@ interface BaseStrategyParams {
   accountAddress: string;
   nativeCurrency: string;
   currencyConversionRates: CurrencyConversionRates;
+  merchantSafeAddresses: string[];
   merchantSafeAddress?: string;
 }
 
@@ -19,6 +20,7 @@ export abstract class BaseStrategy {
   accountAddress: string;
   nativeCurrency: string;
   currencyConversionRates: CurrencyConversionRates;
+  merchantSafeAddresses: string[];
   merchantSafeAddress?: string;
 
   constructor({
@@ -26,12 +28,14 @@ export abstract class BaseStrategy {
     accountAddress,
     nativeCurrency,
     currencyConversionRates,
+    merchantSafeAddresses,
     merchantSafeAddress,
   }: BaseStrategyParams) {
     this.transaction = transaction;
     this.accountAddress = accountAddress;
     this.nativeCurrency = nativeCurrency;
     this.currencyConversionRates = currencyConversionRates;
+    this.merchantSafeAddresses = merchantSafeAddresses;
     this.merchantSafeAddress = merchantSafeAddress;
   }
 }

--- a/cardstack/src/transaction-mapping-strategies/base-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/base-strategy.ts
@@ -7,6 +7,7 @@ interface BaseStrategyParams {
   nativeCurrency: string;
   currencyConversionRates: CurrencyConversionRates;
   merchantSafeAddresses: string[];
+  prepaidCardAddresses: string[];
   merchantSafeAddress?: string;
 }
 
@@ -21,6 +22,7 @@ export abstract class BaseStrategy {
   nativeCurrency: string;
   currencyConversionRates: CurrencyConversionRates;
   merchantSafeAddresses: string[];
+  prepaidCardAddresses: string[];
   merchantSafeAddress?: string;
 
   constructor({
@@ -29,6 +31,7 @@ export abstract class BaseStrategy {
     nativeCurrency,
     currencyConversionRates,
     merchantSafeAddresses,
+    prepaidCardAddresses,
     merchantSafeAddress,
   }: BaseStrategyParams) {
     this.transaction = transaction;
@@ -36,6 +39,7 @@ export abstract class BaseStrategy {
     this.nativeCurrency = nativeCurrency;
     this.currencyConversionRates = currencyConversionRates;
     this.merchantSafeAddresses = merchantSafeAddresses;
+    this.prepaidCardAddresses = prepaidCardAddresses;
     this.merchantSafeAddress = merchantSafeAddress;
   }
 }

--- a/cardstack/src/transaction-mapping-strategies/context.ts
+++ b/cardstack/src/transaction-mapping-strategies/context.ts
@@ -1,23 +1,21 @@
 import { flatten } from 'lodash';
-import { MerchantEarnedSpendAndRevenueStrategy } from './transaction-mapping-strategy-types/merchant-earned-spend-and-revenue-strategy';
-import {
-  MerchantEarnedSpendAndRevenueTransactionType,
-  TransactionTypes,
-} from './../types/transaction-types';
-import { PrepaidCardSplitStrategy } from './transaction-mapping-strategy-types/prepaid-card-split-strategy';
-import { MerchantClaimStrategy } from './transaction-mapping-strategy-types/merchant-claim-strategy';
-import { PrepaidCardCreationStrategy } from './transaction-mapping-strategy-types/prepaid-card-creation-strategy';
-import { PrepaidCardTransferStrategy } from './transaction-mapping-strategy-types/prepaid-card-transfer-strategy';
+
+import { TransactionTypes } from '../types/transaction-types';
 import { BridgeToLayer1EventStrategy } from './transaction-mapping-strategy-types/bridge-to-layer1-strategy';
 import { BridgeToLayer2EventStrategy } from './transaction-mapping-strategy-types/bridge-to-layer2-strategy';
-import { MerchantCreationStrategy } from './transaction-mapping-strategy-types/merchant-creation-strategy';
 import { ERC20TokenStrategy } from './transaction-mapping-strategy-types/erc20-token-strategy';
-import { PrepaidCardPaymentStrategy } from './transaction-mapping-strategy-types/prepaid-card-payment-strategy';
+import { MerchantClaimStrategy } from './transaction-mapping-strategy-types/merchant-claim-strategy';
+import { MerchantCreationStrategy } from './transaction-mapping-strategy-types/merchant-creation-strategy';
 import { MerchantEarnedRevenueStrategy } from './transaction-mapping-strategy-types/merchant-earned-revenue-strategy';
+import { MerchantEarnedSpendAndRevenueStrategy } from './transaction-mapping-strategy-types/merchant-earned-spend-and-revenue-strategy';
 import { MerchantEarnedSpendStrategy } from './transaction-mapping-strategy-types/merchant-earned-spend-strategy';
+import { PrepaidCardCreationStrategy } from './transaction-mapping-strategy-types/prepaid-card-creation-strategy';
+import { PrepaidCardPaymentStrategy } from './transaction-mapping-strategy-types/prepaid-card-payment-strategy';
+import { PrepaidCardSplitStrategy } from './transaction-mapping-strategy-types/prepaid-card-split-strategy';
+import { PrepaidCardTransferStrategy } from './transaction-mapping-strategy-types/prepaid-card-transfer-strategy';
 import logger from 'logger';
-import { TransactionFragment } from '@cardstack/graphql';
 import { CurrencyConversionRates, TransactionType } from '@cardstack/types';
+import { TransactionFragment } from '@cardstack/graphql';
 
 export type TransactionMappingStrategy =
   | typeof PrepaidCardSplitStrategy

--- a/cardstack/src/transaction-mapping-strategies/context.ts
+++ b/cardstack/src/transaction-mapping-strategies/context.ts
@@ -37,6 +37,7 @@ interface TransactionData {
   currencyConversionRates: CurrencyConversionRates;
   transactionStrategies?: TransactionMappingStrategy[];
   merchantSafeAddresses: string[];
+  prepaidCardAddresses: string[];
   merchantSafeAddress?: string;
 }
 
@@ -85,6 +86,7 @@ export class TransactionMappingContext {
             currencyConversionRates: this.transactionData
               .currencyConversionRates,
             merchantSafeAddresses: this.transactionData.merchantSafeAddresses,
+            prepaidCardAddresses: this.transactionData.prepaidCardAddresses,
             merchantSafeAddress: this.transactionData.merchantSafeAddress,
           };
 
@@ -133,6 +135,7 @@ export class TransactionMappingContext {
             accountAddress: this.transactionData.accountAddress,
             nativeCurrency: this.transactionData.nativeCurrency,
             merchantSafeAddresses: this.transactionData.merchantSafeAddresses,
+            prepaidCardAddresses: this.transactionData.prepaidCardAddresses,
             currencyConversionRates: this.transactionData
               .currencyConversionRates,
           });

--- a/cardstack/src/transaction-mapping-strategies/context.ts
+++ b/cardstack/src/transaction-mapping-strategies/context.ts
@@ -1,3 +1,9 @@
+import { flatten } from 'lodash';
+import { MerchantEarnedSpendAndRevenueStrategy } from './transaction-mapping-strategy-types/merchant-earned-spend-and-revenue-strategy';
+import {
+  MerchantEarnedSpendAndRevenueTransactionType,
+  TransactionTypes,
+} from './../types/transaction-types';
 import { PrepaidCardSplitStrategy } from './transaction-mapping-strategy-types/prepaid-card-split-strategy';
 import { MerchantClaimStrategy } from './transaction-mapping-strategy-types/merchant-claim-strategy';
 import { PrepaidCardCreationStrategy } from './transaction-mapping-strategy-types/prepaid-card-creation-strategy';
@@ -22,6 +28,7 @@ export type TransactionMappingStrategy =
   | typeof BridgeToLayer1EventStrategy
   | typeof BridgeToLayer2EventStrategy
   | typeof MerchantCreationStrategy
+  | typeof MerchantEarnedSpendAndRevenueStrategy
   | typeof MerchantEarnedSpendStrategy
   | typeof MerchantEarnedRevenueStrategy;
 
@@ -31,6 +38,7 @@ interface TransactionData {
   nativeCurrency: string;
   currencyConversionRates: CurrencyConversionRates;
   transactionStrategies?: TransactionMappingStrategy[];
+  merchantSafeAddresses: string[];
   merchantSafeAddress?: string;
 }
 
@@ -44,7 +52,15 @@ const defaultTransactionStrategies = [
   BridgeToLayer1EventStrategy,
   BridgeToLayer2EventStrategy,
   MerchantCreationStrategy,
+  MerchantEarnedSpendAndRevenueStrategy,
 ];
+
+// specify transaction types that have additional potential handlers
+const mapTransactionTypeToAdditionalHandlers = {
+  [TransactionTypes.PREPAID_CARD_PAYMENT]: [
+    MerchantEarnedSpendAndRevenueStrategy,
+  ],
+};
 
 // Map graphql transactions list response into readable values in UI
 export class TransactionMappingContext {
@@ -56,55 +72,90 @@ export class TransactionMappingContext {
       defaultTransactionStrategies;
 
     const mappedTransactions = await Promise.all(
-      this.transactionData.transactions.map<Promise<TransactionType | null>>(
-        async (transaction: TransactionFragment | undefined) => {
-          try {
-            if (!transaction) {
-              return null;
-            }
-
-            for (let i = 0; i < transactionStrategies.length; i++) {
-              const strategy = new transactionStrategies[i]({
-                transaction,
-                accountAddress: this.transactionData.accountAddress,
-                nativeCurrency: this.transactionData.nativeCurrency,
-                currencyConversionRates: this.transactionData
-                  .currencyConversionRates,
-                merchantSafeAddress: this.transactionData.merchantSafeAddress,
-              });
-
-              if (strategy.handlesTransaction()) {
-                const mappedTransaction = await strategy.mapTransaction();
-
-                return mappedTransaction;
-              }
-            }
-
-            // Check if it's tokenTransfer transaction at the end of mapping as other transaction types can have tokenTransfers
-            const tokenTransferStrategy = new ERC20TokenStrategy({
-              transaction,
-              accountAddress: this.transactionData.accountAddress,
-              nativeCurrency: this.transactionData.nativeCurrency,
-              currencyConversionRates: this.transactionData
-                .currencyConversionRates,
-            });
-
-            if (tokenTransferStrategy.handlesTransaction()) {
-              const mappedTransaction = await tokenTransferStrategy.mapTransaction();
-              return mappedTransaction;
-            }
-
-            logger.sentry('Unable to map transaction:', transaction);
-          } catch (error) {
-            logger.sentry('Error mapping transaction:', transaction);
+      this.transactionData.transactions.map<
+        Promise<TransactionType | null | (TransactionType | null)[]>
+      >(async (transaction: TransactionFragment | undefined) => {
+        try {
+          if (!transaction) {
+            return null;
           }
 
-          return null;
+          const strategyParam = {
+            transaction,
+            accountAddress: this.transactionData.accountAddress,
+            nativeCurrency: this.transactionData.nativeCurrency,
+            currencyConversionRates: this.transactionData
+              .currencyConversionRates,
+            merchantSafeAddresses: this.transactionData.merchantSafeAddresses,
+            merchantSafeAddress: this.transactionData.merchantSafeAddress,
+          };
+
+          for (let i = 0; i < transactionStrategies.length; i++) {
+            const strategy = new transactionStrategies[i](strategyParam);
+
+            if (strategy.handlesTransaction()) {
+              const mappedTransaction = await strategy.mapTransaction();
+
+              const additionalHandlers =
+                // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+                // @ts-ignore some types won't have a key on the map but that will just return undefined
+                mapTransactionTypeToAdditionalHandlers[
+                  mappedTransaction?.type || ''
+                ];
+
+              // a single transaction may be handled by multiple strategies
+              if (additionalHandlers) {
+                let allMappedTransactions = [mappedTransaction];
+
+                for (let j = 0; j < additionalHandlers.length; j++) {
+                  const additionalStrategy = new additionalHandlers[j](
+                    strategyParam
+                  );
+
+                  if (additionalStrategy.handlesTransaction()) {
+                    const additionalMappedTransaction = await additionalStrategy.mapTransaction();
+
+                    allMappedTransactions = [
+                      ...allMappedTransactions,
+                      additionalMappedTransaction,
+                    ];
+                  }
+                }
+
+                return allMappedTransactions;
+              }
+
+              return mappedTransaction;
+            }
+          }
+
+          // Check if it's tokenTransfer transaction at the end of mapping as other transaction types can have tokenTransfers
+          const tokenTransferStrategy = new ERC20TokenStrategy({
+            transaction,
+            accountAddress: this.transactionData.accountAddress,
+            nativeCurrency: this.transactionData.nativeCurrency,
+            merchantSafeAddresses: this.transactionData.merchantSafeAddresses,
+            currencyConversionRates: this.transactionData
+              .currencyConversionRates,
+          });
+
+          if (tokenTransferStrategy.handlesTransaction()) {
+            const mappedTransaction = await tokenTransferStrategy.mapTransaction();
+            return mappedTransaction;
+          }
+
+          logger.sentry('Unable to map transaction:', transaction);
+        } catch (error) {
+          logger.sentry('Error mapping transaction:', transaction);
         }
-      )
+
+        return null;
+      })
     );
 
+    const flattenedTransactions = flatten(mappedTransactions);
+
     // Remove null values from transactions list
-    return mappedTransactions.filter(t => t);
+    return flattenedTransactions.filter(t => t);
   }
 }

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-strategy.ts
@@ -32,7 +32,7 @@ export class MerchantEarnedSpendStrategy extends BaseStrategy {
     );
 
     return {
-      address: prepaidCardPaymentTransaction.prepaidCard.id,
+      address: prepaidCardPaymentTransaction.merchantSafe?.id || '',
       timestamp: prepaidCardPaymentTransaction.timestamp,
       type: TransactionTypes.MERCHANT_EARNED_SPEND,
       spendBalanceDisplay: spendDisplay.tokenBalanceDisplay,

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/prepaid-card-payment-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/prepaid-card-payment-strategy.ts
@@ -9,11 +9,12 @@ export class PrepaidCardPaymentStrategy extends BaseStrategy {
   handlesTransaction(): boolean {
     const { prepaidCardPayments } = this.transaction;
 
-    if (prepaidCardPayments?.[0]) {
-      return true;
-    }
-
-    return false;
+    return Boolean(
+      prepaidCardPayments?.[0] &&
+        this.prepaidCardAddresses.includes(
+          prepaidCardPayments[0].prepaidCard.id
+        )
+    );
   }
 
   async mapTransaction(): Promise<PrepaidCardPaymentTransactionType | null> {

--- a/cardstack/src/types/transaction-types.ts
+++ b/cardstack/src/types/transaction-types.ts
@@ -9,6 +9,7 @@ export enum TransactionTypes {
   MERCHANT_CLAIM = 'merchantClaim',
   MERCHANT_CREATION = 'merchantCreation',
   MERCHANT_REVENUE_EVENT = 'merchantRevenueEvent',
+  MERCHANT_EARNED_SPEND_AND_REVENUE = 'merchantEarnedSpendAndRevenue',
   MERCHANT_EARNED_REVENUE = 'merchantEarnedRevenue',
   MERCHANT_EARNED_SPEND = 'merchantEarnedSpend',
   ERC_20 = 'erc20',
@@ -137,6 +138,22 @@ export interface MerchantEarnedSpendTransactionType {
   transactionHash: string;
 }
 
+export interface MerchantEarnedSpendAndRevenueTransactionType {
+  address: string;
+  balance: BalanceType;
+  native: BalanceType;
+  token: {
+    address: string;
+    name?: string | null;
+    symbol?: string | null;
+  };
+  spendBalanceDisplay: string;
+  nativeBalanceDisplay: string;
+  timestamp: number;
+  type: TransactionTypes.MERCHANT_EARNED_SPEND_AND_REVENUE;
+  transactionHash: string;
+}
+
 export interface PrepaidCardSplitTransactionType {
   address: string;
   timestamp: number;
@@ -206,5 +223,6 @@ export type TransactionType =
   | PrepaidCardSplitTransactionType
   | MerchantRevenueEventType
   | MerchantClaimType
+  | MerchantEarnedSpendAndRevenueTransactionType
   | MerchantEarnedRevenueTransactionType
   | MerchantEarnedSpendTransactionType;


### PR DESCRIPTION
Handling merchant revenue transactions on EOA screen. A little bit tricky because a single transaction could be both a prepaid card payment and a merchant revenue transaction, if the EOA owns both the prepaid card and the merchant safe. Added a map for transaction types that may have additional handlers so that we can break out a single transaction type into multiple in the UI. If anyone has suggestions for a better way to handle this I am open to hearing them. Also, looking at the description of PR #316 for more information on how we are handle merchant revenue transactions differently based on location

![Screen Shot 2021-08-18 at 09 45 54](https://user-images.githubusercontent.com/17347720/129939530-49104cf6-4628-4d2c-9bb1-e79b3200e90e.png)

Also validated that it properly handles earning revenue from a prepaid card the EOA does not own and sending a prepaid card payment to a merchant safe we don't own. This entailed updating the prepaid card payment strategy to check that the prepaid card payment is from a prepaid card we own, otherwise previously it wouldn't have shown every merchant payment as a prepaid card payment transaction as well

![Screen Shot 2021-08-18 at 11 49 29](https://user-images.githubusercontent.com/17347720/129955158-b26800c4-7aa6-416c-989e-fb218a6f0f64.png)
