### PR TITLE
[CS-1661] Order largest value first in merchant available balances an…

### DIFF
--- a/cardstack/src/screens/MerchantScreen.tsx
+++ b/cardstack/src/screens/MerchantScreen.tsx
@@ -19,6 +19,7 @@ import { MerchantSafeType, TokenType } from '@cardstack/types';
 import {
   convertSpendForBalanceDisplay,
   getAddressPreview,
+  sortedByTokenBalanceAmount,
 } from '@cardstack/utils';
 import { ChartPath } from '@rainbow-me/animated-charts';
 import { useNavigation } from '@rainbow-me/navigation';
@@ -252,7 +253,7 @@ const UnclaimedRevenueSection = () => {
       <SectionWrapper onPress={onPress}>
         <>
           {revenueBalances.length ? (
-            revenueBalances.map((token, index) => (
+            sortedByTokenBalanceAmount(revenueBalances).map((token, index) => (
               <TokenBalance
                 tokenSymbol={token.token.symbol}
                 tokenBalance={token.balance.display}
@@ -289,7 +290,7 @@ const AvailableBalancesSection = () => {
       <SectionWrapper onPress={onPress}>
         <>
           {tokens.length ? (
-            tokens.map((token, index) => (
+            sortedByTokenBalanceAmount(tokens).map((token, index) => (
               <TokenBalance
                 tokenSymbol={token.token.symbol}
                 tokenBalance={token.balance.display}

--- a/cardstack/src/utils/__tests__/sorting-utils.test.ts
+++ b/cardstack/src/utils/__tests__/sorting-utils.test.ts
@@ -1,0 +1,54 @@
+import { sortedByTokenBalanceAmount } from '../sorting-utils';
+
+describe('Sorting by token balance amount', () => {
+  it('should return the same when list has only one item or empty', () => {
+    const mockData = [
+      {
+        tokenAddress: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+        tokenSymbol: 'DAI',
+        token: { symbol: 'DAI' },
+        balance: { amount: '0.000173983', display: '0.000174 DAI' },
+        native: { balance: { amount: 0.00017433, display: '$0.000174 USD' } },
+      },
+    ];
+
+    expect(sortedByTokenBalanceAmount(mockData)).toStrictEqual(mockData);
+    expect(sortedByTokenBalanceAmount([])).toStrictEqual([]);
+  });
+
+  it('should return ordered list with the one with biggest amount on the top', () => {
+    const mockData = [
+      {
+        tokenAddress: '0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee',
+        token: {
+          name: 'CARD Token Kovan.CPXD',
+          symbol: 'CARD',
+          decimals: 18,
+          value: '100',
+        },
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        coingecko_id: 'cardstack',
+        balance: { amount: '100', display: '100.00 CARD' },
+        native: { balance: { amount: 0.733227, display: '$0.733 USD' } },
+      },
+      {
+        tokenAddress: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+        token: {
+          name: 'Dai Stablecoin.CPXD',
+          symbol: 'DAI',
+          decimals: 18,
+          value: '3.475236916195608782',
+        },
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        coingecko_id: 'dai',
+        balance: { amount: '3.475236916195608782', display: '3.475 DAI' },
+        native: { balance: { amount: 3.48218739, display: '$3.48 USD' } },
+      },
+    ];
+
+    expect(sortedByTokenBalanceAmount(mockData)[0]).toHaveProperty(
+      'tokenAddress',
+      '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1'
+    );
+  });
+});

--- a/cardstack/src/utils/sorting-utils.ts
+++ b/cardstack/src/utils/sorting-utils.ts
@@ -1,6 +1,13 @@
+import { TokenType } from '@cardstack/types';
+
 export const sortByTime = (a: any, b: any) => {
   const timeA = Number(a.timestamp || a.minedAt || a.createdAt);
   const timeB = Number(b.timestamp || b.minedAt || b.createdAt);
 
   return timeB - timeA;
 };
+
+export const sortedByTokenBalanceAmount = (tokenItems: any): TokenType[] =>
+  [...tokenItems].sort((a: any, b: any) => {
+    return b.native?.balance?.amount - a.native?.balance?.amount;
+  }) || [];


### PR DESCRIPTION
Order largest value first in merchant available balances and unclaimed revenue

<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

<!-- Include a summary of the changes. -->

- [X] Completes #1661

### Checklist

- [X] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

![Screen Shot 2021-08-18 at 20 30 09](https://user-images.githubusercontent.com/8547776/129985124-a5a6189f-32c7-411f-82f9-dcd407c5398e.png)
