### PR TITLE
[CS-1572] - Temp disabling pagination to fix transactions loop

### DIFF
--- a/cardstack/src/graphql/apollo-client.ts
+++ b/cardstack/src/graphql/apollo-client.ts
@@ -4,24 +4,27 @@ import { networkTypes } from '@rainbow-me/networkTypes';
 
 let sokolClient: any;
 
+// Temporarily disabling pagination to fix transaction multiplier
+// const memoryPolicy = {
+//   typePolicies: {
+//     Account: {
+//       fields: {
+//         transactions: {
+//           keyArgs: false,
+//           merge(existing = [], incoming: any) {
+//             return [...existing, ...incoming];
+//           },
+//         },
+//       },
+//     },
+//   },
+// };
+
 export const initializeApolloClient = (network: string) => {
   const subgraphUrl = getConstantByNetwork('subgraphURL', network);
 
   sokolClient = new ApolloClient({
-    cache: new InMemoryCache({
-      typePolicies: {
-        Account: {
-          fields: {
-            transactions: {
-              keyArgs: false,
-              merge(existing = [], incoming) {
-                return [...existing, ...incoming];
-              },
-            },
-          },
-        },
-      },
-    }),
+    cache: new InMemoryCache(),
     link: new HttpLink({
       uri: subgraphUrl,
     }),


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
The merging of the cache was creating duplicated entries on transactions, since this is affecting the majority of users, we are disabling the pagination to have it work, because it defaults to 100 transactions anyways, so it shouldn't affect many users, an upcoming PR will have both things working, for now, we are prioritizing fixing repeated transaction
