### PR TITLE
[CS-1684]: Fix crash on mainnet

### DIFF
--- a/cardstack/src/components/TransactionConfirmationSheet/IssuePrepaidCardDisplay.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/IssuePrepaidCardDisplay.tsx
@@ -47,7 +47,7 @@ const FromSection = ({ tokenAddress }: { tokenAddress: string }) => {
   const { accountColor, accountName, accountSymbol } = useAccountProfile();
 
   const depots = useRainbowSelector(state => state.data.depots);
-  const depot = depots[0];
+  const depot = depots?.[0];
 
   const token = getDepotTokenByAddress(depot, tokenAddress);
 

--- a/cardstack/src/components/TransactionConfirmationSheet/TransferPrepaidCardDisplay.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/TransferPrepaidCardDisplay.tsx
@@ -49,7 +49,7 @@ const FromSection = () => {
   const { accountColor, accountName, accountSymbol } = useAccountProfile();
 
   const depots = useRainbowSelector(state => state.data.depots);
-  const depot = depots[0];
+  const depot = depots?.[0];
 
   return (
     <Container marginTop={8} width="100%">

--- a/cardstack/src/hooks/transactions/use-transaction-sections.tsx
+++ b/cardstack/src/hooks/transactions/use-transaction-sections.tsx
@@ -44,7 +44,7 @@ export const useTransactionSections = ({
     state.data.depots,
   ]);
 
-  const depot = depots[0];
+  const depot = depots?.[0];
 
   const [
     nativeCurrency,

--- a/src/hooks/useInitializeAccountData.js
+++ b/src/hooks/useInitializeAccountData.js
@@ -5,7 +5,10 @@ import { useDispatch } from 'react-redux';
 import { uniqueTokensRefreshState } from '../redux/uniqueTokens';
 import { uniswapGetAllExchanges, uniswapPairsInit } from '../redux/uniswap';
 import { explorerInit } from '@rainbow-me/redux/explorer';
-import { fallbackExplorerInit } from '@rainbow-me/redux/fallbackExplorer';
+import {
+  fallbackExplorerClearState,
+  fallbackExplorerInit,
+} from '@rainbow-me/redux/fallbackExplorer';
 import logger from 'logger';
 
 export default function useInitializeAccountData() {
@@ -15,6 +18,7 @@ export default function useInitializeAccountData() {
     try {
       InteractionManager.runAfterInteractions(() => {
         logger.sentry('Initialize account data');
+        dispatch(fallbackExplorerClearState());
         dispatch(explorerInit());
         dispatch(fallbackExplorerInit());
       });

--- a/src/hooks/useRefreshAccountData.js
+++ b/src/hooks/useRefreshAccountData.js
@@ -6,7 +6,10 @@ import { uniqueTokensRefreshState } from '../redux/uniqueTokens';
 import { uniswapUpdateLiquidityState } from '../redux/uniswapLiquidity';
 import { fetchWalletNames } from '../redux/wallets';
 import useSavingsAccount from './useSavingsAccount';
-import { fallbackExplorerInit } from '@rainbow-me/redux/fallbackExplorer';
+import {
+  fallbackExplorerClearState,
+  fallbackExplorerInit,
+} from '@rainbow-me/redux/fallbackExplorer';
 import logger from 'logger';
 
 export default function useRefreshAccountData() {
@@ -15,6 +18,7 @@ export default function useRefreshAccountData() {
 
   const refreshAccountData = useCallback(async () => {
     try {
+      await dispatch(fallbackExplorerClearState());
       const getWalletNames = dispatch(fetchWalletNames());
       const getUniswapLiquidity = dispatch(uniswapUpdateLiquidityState());
       const getUniqueTokens = dispatch(uniqueTokensRefreshState());

--- a/src/redux/settings.js
+++ b/src/redux/settings.js
@@ -69,11 +69,12 @@ export const settingsUpdateNetwork = network => async dispatch => {
   try {
     const chainId = ethereumUtils.getChainIdFromNetwork(network);
     await web3SetHttpProvider(network);
-    dispatch({
+    await dispatch({
       payload: { chainId, network },
       type: SETTINGS_UPDATE_NETWORK_SUCCESS,
     });
-    saveNetwork(network);
+    await dispatch(fallbackExplorerClearState());
+    await saveNetwork(network);
     dispatch(fallbackExplorerInit());
     dispatch(walletConnectUpdateSessions());
   } catch (error) {


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Sometimes we don't have depots yet, since we don't use then on mainnet, it may trigger a crash, that's why we need to optional chain it `depots?.[0]` and the other potential problem, is that the fetchBalancesAndPrices function, creates multiple setimout functions to recursively call it, and it was never getting cleanup, so I added a couple of those where needed, there's still stuff to improve though but hopefully non-crashable.
