### PR TITLE
[Refactor]: Extract cardstack's routes to it's own navigation 

### DIFF
--- a/cardstack/src/navigation/hooks.tsx
+++ b/cardstack/src/navigation/hooks.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Routes } from './routes';
+import { Screens } from './screens';
+
+// Not a big fan of returning components inside hooks,
+// but react-navigation does not allow components other than Screen
+
+export const useCardstackScreens = (Stack: any) => {
+  const screens = Object.entries(
+    Screens
+  ).map(([name, { component, options }]) => (
+    <Stack.Screen
+      component={component}
+      key={name}
+      name={Routes[name as keyof typeof Routes]}
+      options={options}
+    />
+  ));
+
+  return screens;
+};

--- a/cardstack/src/navigation/index.ts
+++ b/cardstack/src/navigation/index.ts
@@ -1,0 +1,4 @@
+export * from './hooks';
+export * from './routes';
+export * from './screens';
+export * from './presetOptions';

--- a/cardstack/src/navigation/presetOptions.ts
+++ b/cardstack/src/navigation/presetOptions.ts
@@ -1,0 +1,9 @@
+import {
+  CardStyleInterpolators,
+  StackNavigationOptions,
+} from '@react-navigation/stack';
+
+export const horizontalInterpolator: StackNavigationOptions = {
+  cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
+  gestureDirection: 'horizontal',
+};

--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -1,0 +1,7 @@
+export const Routes = {
+  CONFIRM_REQUEST: 'ConfirmRequest',
+  DEPOT_SCREEN: 'DepotScreen',
+  MERCHANT_SCREEN: 'MerchantScreen',
+  PREPAID_CARD_MODAL: 'PrepaidCardModal',
+  BUY_PREPAID_CARD: 'BuyPrepaidCard',
+} as const;

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -1,0 +1,33 @@
+import { StackNavigationOptions } from '@react-navigation/stack';
+import { Routes } from './routes';
+import { horizontalInterpolator } from './presetOptions';
+import {
+  BuyPrepaidCard,
+  DepotScreen,
+  MerchantScreen,
+  PrepaidCardModal,
+  TransactionConfirmation,
+} from '@cardstack/screen';
+import { expandedPreset } from '@rainbow-me/navigation/effects';
+
+interface ScreenNavigation {
+  component: React.ComponentType<any>;
+  options?: StackNavigationOptions;
+}
+
+export const Screens: Record<keyof typeof Routes, ScreenNavigation> = {
+  DEPOT_SCREEN: { component: DepotScreen, options: horizontalInterpolator },
+  MERCHANT_SCREEN: {
+    component: MerchantScreen,
+    options: horizontalInterpolator,
+  },
+  PREPAID_CARD_MODAL: {
+    component: PrepaidCardModal,
+    options: expandedPreset as StackNavigationOptions,
+  },
+  BUY_PREPAID_CARD: { component: BuyPrepaidCard },
+  CONFIRM_REQUEST: {
+    component: TransactionConfirmation,
+    options: { gestureEnabled: false },
+  },
+};

--- a/cardstack/src/screens/DepotScreen.tsx
+++ b/cardstack/src/screens/DepotScreen.tsx
@@ -211,6 +211,7 @@ const Balances = ({ tokens }: BalancesProps) => {
     () =>
       tokens.map(token => (
         <TokenBalance
+          key={token.tokenAddress}
           address={token.tokenAddress}
           includeBorder
           marginHorizontal={5}

--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -1,3 +1,4 @@
+import { useCardstackScreens } from '@cardstack/navigation';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import React, { useContext, useMemo } from 'react';
@@ -17,7 +18,6 @@ import SavingsSheet from '../screens/SavingsSheet';
 import SendSheet from '../screens/SendSheet';
 import SettingsModal from '../screens/SettingsModal';
 import SpeedUpAndCancelSheet from '../screens/SpeedUpAndCancelSheet';
-import TransactionConfirmationScreen from '../screens/TransactionConfirmationScreen';
 import WalletConnectApprovalSheet from '../screens/WalletConnectApprovalSheet';
 import WalletConnectRedirectSheet from '../screens/WalletConnectRedirectSheet';
 import WelcomeScreen from '../screens/WelcomeScreen';
@@ -107,6 +107,7 @@ function AddCashFlowNavigator() {
 
 function MainNavigator() {
   const initialRoute = useContext(InitialRouteContext);
+  const cardstackScreens = useCardstackScreens(Stack);
 
   return (
     <Stack.Navigator
@@ -129,11 +130,6 @@ function MainNavigator() {
         component={ChangeWalletSheet}
         name={Routes.CHANGE_WALLET_SHEET}
         options={expandedPreset}
-      />
-      <Stack.Screen
-        component={TransactionConfirmationScreen}
-        name={Routes.CONFIRM_REQUEST}
-        options={exchangePreset}
       />
       <Stack.Screen
         component={SpeedUpAndCancelSheet}
@@ -215,6 +211,7 @@ function MainNavigator() {
         component={AddCashFlowNavigator}
         name={Routes.WYRE_WEBVIEW_NAVIGATOR}
       />
+      {cardstackScreens}
     </Stack.Navigator>
   );
 }

--- a/src/navigation/Routes.ios.js
+++ b/src/navigation/Routes.ios.js
@@ -1,8 +1,6 @@
+import { useCardstackScreens } from '@cardstack/navigation/hooks';
 import { NavigationContainer } from '@react-navigation/native';
-import {
-  CardStyleInterpolators,
-  createStackNavigator,
-} from '@react-navigation/stack';
+import { createStackNavigator } from '@react-navigation/stack';
 import { omit } from 'lodash';
 import React, { useContext } from 'react';
 import { StatusBar } from 'react-native';
@@ -50,13 +48,6 @@ import { nativeStackConfig } from './nativeStackConfig';
 import { onNavigationStateChange } from './onNavigationStateChange';
 import Routes from './routesNames';
 import { ExchangeModalNavigator } from './index';
-import {
-  BuyPrepaidCard,
-  DepotScreen,
-  MerchantScreen,
-  PrepaidCardModal,
-  TransactionConfirmation,
-} from '@cardstack/screen';
 import { colors } from '@cardstack/theme';
 import isNativeStackAvailable from '@rainbow-me/helpers/isNativeStackAvailable';
 import createNativeStackNavigator from 'react-native-cool-modals/createNativeStackNavigator';
@@ -144,6 +135,7 @@ function AddCashFlowNavigator() {
 
 function MainNavigator() {
   const initialRoute = useContext(InitialRouteContext);
+  const cardstackScreens = useCardstackScreens(Stack);
 
   return (
     <Stack.Navigator
@@ -153,35 +145,6 @@ function MainNavigator() {
     >
       <Stack.Screen component={SwipeNavigator} name={Routes.SWIPE_LAYOUT} />
       <Stack.Screen component={WelcomeScreen} name={Routes.WELCOME_SCREEN} />
-      <Stack.Screen component={BuyPrepaidCard} name={Routes.BUY_PREPAID_CARD} />
-      <Stack.Screen
-        component={DepotScreen}
-        name={Routes.DEPOT_SCREEN}
-        options={{
-          cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
-          gestureDirection: 'horizontal',
-        }}
-      />
-      <Stack.Screen
-        component={MerchantScreen}
-        name={Routes.MERCHANT_SCREEN}
-        options={{
-          cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
-          gestureDirection: 'horizontal',
-        }}
-      />
-      <Stack.Screen
-        component={PrepaidCardModal}
-        name={Routes.PREPAID_CARD_MODAL}
-        options={expandedPreset}
-      />
-      <Stack.Screen
-        component={TransactionConfirmation}
-        name={Routes.CONFIRM_REQUEST}
-        options={{
-          gestureEnabled: false,
-        }}
-      />
       <Stack.Screen
         component={AvatarBuilder}
         name={Routes.AVATAR_BUILDER}
@@ -197,6 +160,7 @@ function MainNavigator() {
         name={Routes.WALLET_CONNECT_REDIRECT_SHEET}
         options={bottomSheetPreset}
       />
+      {cardstackScreens}
     </Stack.Navigator>
   );
 }

--- a/src/navigation/routesNames.js
+++ b/src/navigation/routesNames.js
@@ -1,3 +1,4 @@
+import { Routes as CSRoutes } from '@cardstack/navigation/routes';
 import isNativeStackAvailable from '../helpers/isNativeStackAvailable';
 
 const Routes = {
@@ -6,14 +7,9 @@ const Routes = {
   AVATAR_BUILDER: 'AvatarBuilder',
   BACKUP_SCREEN: 'BackupScreen',
   BACKUP_SHEET: 'BackupSheet',
-  BUY_PREPAID_CARD: 'BuyPrepaidCard',
   CHANGE_WALLET_SHEET: 'ChangeWalletSheet',
   CHANGE_WALLET_SHEET_NAVIGATOR: 'ChangeWalletSheetNavigator',
-  CONFIRM_REQUEST: 'ConfirmRequest',
   CURRENCY_SELECT_SCREEN: 'CurrencySelectScreen',
-  DEPOT_SCREEN: 'DepotScreen',
-  MERCHANT_SCREEN: 'MerchantScreen',
-  PREPAID_CARD_MODAL: 'PrepaidCardModal',
   EXAMPLE_SCREEN: 'ExampleScreen',
   EXCHANGE_MODAL: 'ExchangeModal',
   EXPANDED_ASSET_SCREEN: 'ExpandedAssetScreen',
@@ -53,6 +49,8 @@ const Routes = {
   WELCOME_SCREEN: 'WelcomeScreen',
   WYRE_WEBVIEW: 'WyreWebview',
   WYRE_WEBVIEW_NAVIGATOR: 'WyreWebviewNavigator',
+  // Cardstack Screens
+  ...CSRoutes,
 };
 
 export const NATIVE_ROUTES = [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -61,6 +61,8 @@
       "@cardstack/graphql/*": ["cardstack/src/graphql/*"],
       "@cardstack/hooks": ["cardstack/src/hooks"],
       "@cardstack/hooks/*": ["cardstack/src/hooks/*"],
+      "@cardstack/navigation": ["cardstack/src/navigation"],
+      "@cardstack/navigation/*": ["cardstack/src/navigation/*"],
       "@cardstack/transaction-mapping-strategies": [
         "cardstack/src/transaction-mapping-strategies"
       ],


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

<!-- Include a summary of the changes. -->

For my current task I need to create a new screen, and  since we were creating everything just for the iOS stack, I took the liberty to extract all cardstack  routes to one place, this way we can use across android and ios, without duplicating code. 
From now on, we can just add the screens into the `Screens` object, it's straight forward but if you have any doubts lmk.

