### PR TITLE
[CS-1757] - Fix infinite re-rendering loop

### DIFF
--- a/cardstack/src/screens/PrepaidCardModal.tsx
+++ b/cardstack/src/screens/PrepaidCardModal.tsx
@@ -1,6 +1,6 @@
 import { useRoute } from '@react-navigation/core';
-import React from 'react';
-import { SectionList } from 'react-native';
+import React, { memo } from 'react';
+import { SectionList, StyleSheet } from 'react-native';
 import { TransactionListLoading } from '../components/TransactionList/TransactionListLoading';
 import {
   CenteredContainer,
@@ -13,6 +13,11 @@ import {
   TransactionItem,
 } from '@cardstack/components';
 import { usePrepaidCardTransactions } from '@cardstack/hooks';
+
+const styles = StyleSheet.create({
+  contentContainerStyle: { paddingBottom: 400 },
+  sectionList: { width: '100%' },
+});
 
 const PrepaidCardModal = () => {
   const {
@@ -49,7 +54,7 @@ const PrepaidCardModal = () => {
         ) : (
           <SectionList
             ListEmptyComponent={<ListEmptyComponent />}
-            contentContainerStyle={{ paddingBottom: 400 }}
+            contentContainerStyle={styles.contentContainerStyle}
             renderItem={props => <TransactionItem {...props} includeBorder />}
             sections={sections}
             renderSectionHeader={({ section: { title } }) => (
@@ -62,7 +67,7 @@ const PrepaidCardModal = () => {
                 <Text color="blueText">{title}</Text>
               </Container>
             )}
-            style={{ width: '100%' }}
+            style={styles.sectionList}
           />
         )}
       </Container>
@@ -78,4 +83,4 @@ const ListEmptyComponent = () => (
   </CenteredContainer>
 );
 
-export default PrepaidCardModal;
+export default memo(PrepaidCardModal);


### PR DESCRIPTION

<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
The condition to set sections was based only when we had transactions, in the prepaidCard modal, we get `transactions` from the query, then pass forward to `useTransactionSections` , this hook, checks if transactions exist and update the state, so once the state is updated, it triggers a re-render in the parent, which checks for the transactions again and pass thru `useTransactionSections` over and over, even though the transactions are the same. This PR changes this behavior so it will only set the state again if the amount of current transactions is different from the previous amount avoiding this infinite loop behavior.


- [x] Completes #(CS-1757)

### Screenshots

<!-- Screenshots or animated GIFs included here -->

Before, we can see how the JS performance drops to 10 and stays low: 
![Simulator Screen Recording - iPhone 11 - 2021-09-01 at 15 22 12](https://user-images.githubusercontent.com/20520102/131723627-f0616c1c-ab54-4f44-8bde-eabaea2af37d.gif)

After fix, it drops to 42 and quickly  gets back to 60:
![Simulator Screen Recording - iPhone 11 - 2021-09-01 at 15 21 17](https://user-images.githubusercontent.com/20520102/131723774-70e4ed49-6fe6-44c9-be73-31080ad55dcd.gif)

