### PR TITLE
[CS-1772] - Allow only appropriate activities while sharing a link

### DIFF
--- a/cardstack/src/utils/__tests__/merchant-utils.test.ts
+++ b/cardstack/src/utils/__tests__/merchant-utils.test.ts
@@ -13,12 +13,12 @@ describe('Merchant utils', () => {
     const amount = 100;
 
     it('should return the right payment url given the specific parameters', () => {
-      const url = generateMerchantPaymentUrl(
+      const url = generateMerchantPaymentUrl({
         merchantSafeID,
         amount,
-        'xdai',
-        'USD'
-      );
+        network: 'xdai',
+        currency: 'USD',
+      });
 
       expect(url).toBe(
         `https://wallet.cardstack.com/pay/xdai/0x0000000000000000000000000000000000000000?amount=100&currency=USD`
@@ -26,10 +26,18 @@ describe('Merchant utils', () => {
     });
 
     it('should return the right payment url with default values', () => {
-      const url = generateMerchantPaymentUrl(merchantSafeID, amount);
+      const url = generateMerchantPaymentUrl({ merchantSafeID, amount });
 
       expect(url).toBe(
         `https://wallet.cardstack.com/pay/sokol/0x0000000000000000000000000000000000000000?amount=100&currency=SPD`
+      );
+    });
+
+    it('should return the right payment url without amount', () => {
+      const url = generateMerchantPaymentUrl({ merchantSafeID });
+
+      expect(url).toBe(
+        `https://wallet.cardstack.com/pay/sokol/0x0000000000000000000000000000000000000000?currency=SPD`
       );
     });
   });

--- a/cardstack/src/utils/__tests__/merchant-utils.test.ts
+++ b/cardstack/src/utils/__tests__/merchant-utils.test.ts
@@ -1,0 +1,69 @@
+import { Share } from 'react-native';
+import { Device } from '../device';
+import {
+  generateMerchantPaymentUrl,
+  shareRequestPaymentLink,
+} from '../merchant-utils';
+
+jest.mock('../device');
+
+describe('Merchant utils', () => {
+  describe('generateMerchantPaymentUrl', () => {
+    const merchantSafeID = '0x0000000000000000000000000000000000000000';
+    const amount = 100;
+
+    it('should return the right payment url given the specific parameters', () => {
+      const url = generateMerchantPaymentUrl(
+        merchantSafeID,
+        amount,
+        'xdai',
+        'USD'
+      );
+
+      expect(url).toBe(
+        `https://wallet.cardstack.com/pay/xdai/0x0000000000000000000000000000000000000000?amount=100&currency=USD`
+      );
+    });
+
+    it('should return the right payment url with default values', () => {
+      const url = generateMerchantPaymentUrl(merchantSafeID, amount);
+
+      expect(url).toBe(
+        `https://wallet.cardstack.com/pay/sokol/0x0000000000000000000000000000000000000000?amount=100&currency=SPD`
+      );
+    });
+  });
+
+  describe('shareRequestPaymentLink', () => {
+    const address = '0xd6F3F565E207A4e4B1b2E51F1A86d26D3DBf5811';
+    const paymentRequestLink = `https://wallet.cardstack.com/pay/xdai/0xd6F3F565E207A4e4B1b2E51F1A86d26D3DBf5811?amount=100&currency=USD`;
+
+    const expectedContent = {
+      message: `Payment Request\nTo: 0xd6F3...5811\nURL: https://wallet.cardstack.com/pay/xdai/0xd6F3F565E207A4e4B1b2E51F1A86d26D3DBf5811?amount=100&currency=USD`,
+      title: 'Payment Request',
+    };
+
+    it('should return a share link with right params for iOS', async () => {
+      Device.isIOS = true;
+      const share = jest.spyOn(Share, 'share').mockImplementation(jest.fn());
+
+      await shareRequestPaymentLink(address, paymentRequestLink);
+
+      expect(share).toBeCalledWith(expectedContent, {
+        excludedActivityTypes: [
+          `com.apple.UIKit.activity.CopyToPasteboard`,
+          `com.apple.UIKit.activity.AddToReadingList`,
+        ],
+      });
+    });
+
+    it('should return a share link with right params and without iOS specifics if not iOS', async () => {
+      Device.isIOS = false;
+      const share = jest.spyOn(Share, 'share').mockImplementation(jest.fn());
+
+      await shareRequestPaymentLink(address, paymentRequestLink);
+
+      expect(share).toBeCalledWith(expectedContent, undefined);
+    });
+  });
+});

--- a/cardstack/src/utils/device.ts
+++ b/cardstack/src/utils/device.ts
@@ -1,0 +1,8 @@
+import { Platform } from 'react-native';
+
+const Device = {
+  isIOS: Platform.OS === 'ios',
+  isAndroid: Platform.OS === 'android',
+};
+
+export { Device };

--- a/cardstack/src/utils/merchant-utils.ts
+++ b/cardstack/src/utils/merchant-utils.ts
@@ -1,5 +1,8 @@
 import { Resolver } from 'did-resolver';
 import { getResolver } from '@cardstack/did-resolver';
+import { Share } from 'react-native';
+import { getAddressPreview } from './formatting-utils';
+import { Device } from './device';
 import { MerchantRevenueEventFragment } from '@cardstack/graphql';
 import { MerchantInformation } from '@cardstack/types';
 
@@ -53,13 +56,41 @@ export const fetchMerchantInfoFromDID = async (
   }
 };
 
-// ToDo: Add test once merchant flow finished
 export const generateMerchantPaymentUrl = (
   merchantSafeID: string,
   amount: number,
   network = 'sokol',
   currency = 'SPD'
+) =>
+  `https://wallet.cardstack.com/pay/${network}/${merchantSafeID}?amount=${amount}&currency=${currency}`;
+
+export const shareRequestPaymentLink = (
+  address: string,
+  paymentRequestLink: string
 ) => {
-  // https://wallet.cardstack.com/pay/[sokol|xdai]/[merchant-safe-id]?amount=[amount-in-specified-currency]&currency=[3-letter-symbol]
-  return `https://wallet.cardstack.com/pay/${network}/${merchantSafeID}?amount=${amount}&currency=${currency}`;
+  // Refer to https://developer.apple.com/documentation/uikit/uiactivitytype
+  const activityUiKitPath = 'com.apple.UIKit.activity';
+
+  const excludedActivityTypes = [
+    `${activityUiKitPath}.CopyToPasteboard`,
+    `${activityUiKitPath}.AddToReadingList`,
+  ];
+
+  const options = Device.isIOS
+    ? {
+        excludedActivityTypes,
+      }
+    : undefined;
+
+  const obfuscatedAddress = getAddressPreview(address);
+  const title = 'Payment Request';
+  const message = `${title}\nTo: ${obfuscatedAddress}\nURL: ${paymentRequestLink}`;
+
+  return Share.share(
+    {
+      message,
+      title,
+    },
+    options
+  );
 };

--- a/cardstack/src/utils/merchant-utils.ts
+++ b/cardstack/src/utils/merchant-utils.ts
@@ -56,13 +56,24 @@ export const fetchMerchantInfoFromDID = async (
   }
 };
 
-export const generateMerchantPaymentUrl = (
-  merchantSafeID: string,
-  amount: number,
+interface MerchantPaymentURLParams {
+  merchantSafeID: string;
+  amount?: number;
+  network?: string;
+  currency?: string;
+}
+
+export const generateMerchantPaymentUrl = ({
+  merchantSafeID,
+  amount,
   network = 'sokol',
-  currency = 'SPD'
-) =>
-  `https://wallet.cardstack.com/pay/${network}/${merchantSafeID}?amount=${amount}&currency=${currency}`;
+  currency = 'SPD',
+}: MerchantPaymentURLParams) => {
+  const domain = `https://wallet.cardstack.com`;
+  const handleAmount = amount ? `amount=${amount}&` : '';
+
+  return `${domain}/pay/${network}/${merchantSafeID}?${handleAmount}currency=${currency}`;
+};
 
 export const shareRequestPaymentLink = (
   address: string,

--- a/src/components/expanded-state/PaymentRequestExpandedState.tsx
+++ b/src/components/expanded-state/PaymentRequestExpandedState.tsx
@@ -255,8 +255,16 @@ const AmountAndQRCodeButtons = ({
   const { navigate } = useNavigation();
   const { setClipboard } = useClipboard();
 
+  // for now the amount is in spend, but once we get
+  // the currency selector we should pass the amount with currency
   const paymentRequestLink = useMemo(
-    () => generateMerchantPaymentUrl(address, amountInSpend, network),
+    () =>
+      generateMerchantPaymentUrl({
+        merchantSafeID: address,
+        amount: amountInSpend,
+        network,
+        currency: 'SPD',
+      }),
     [address, amountInSpend, network]
   );
 
@@ -268,8 +276,8 @@ const AmountAndQRCodeButtons = ({
   const handleShareLink = useCallback(async () => {
     try {
       await shareRequestPaymentLink(address, paymentRequestLink);
-    } catch (error) {
-      logger.sentry('Payment Request Link share failed', error.message);
+    } catch (e) {
+      logger.sentry('Payment Request Link share failed', e);
     }
   }, [address, paymentRequestLink]);
 

--- a/src/components/sheet/SlackSheet.js
+++ b/src/components/sheet/SlackSheet.js
@@ -59,12 +59,11 @@ export default function SlackSheet({
   additionalTopPadding = false,
   backgroundColor = undefined,
   borderRadius = 30,
-  children = undefined,
   contentHeight = undefined,
   deferredHeight = false,
   hideHandle = false,
-  renderHeader = undefined,
-  renderFooter = undefined,
+  renderHeader = () => {},
+  renderFooter = () => {},
   scrollEnabled = true,
   discoverSheet = undefined,
   hasKeyboard = false,
@@ -157,7 +156,7 @@ export default function SlackSheet({
             scrollIndicatorInsets={scrollIndicatorInsets}
             y={yPosition}
           >
-            {children}
+            {props.children}
             {!scrollEnabled && (
               <Whitespace backgroundColor={bg} deviceHeight={deviceHeight} />
             )}


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

The ShareSheet allowed to copy the shared full text, which may confuse the user while copying this assuming it's a link but then it has a bunch of other texts, since we have a specific button to copy the link we can safely remove the copy option from the ShareSheet, using `excludedActivityTypes`  also added a couple of new tests

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-1772)
- [x] Completes #(CS-1109)
- [x] Completes #(CS-1728)
- [x] Completes #(CS-1702)

### Screenshots

![image](https://user-images.githubusercontent.com/20520102/131918039-5da994a2-859b-4877-99ef-998f40001ae4.png)

<!-- Screenshots or animated GIFs included here -->