### PR TITLE
[CS-1790] - Fix crashing on merchant tx

### DIFF
--- a/cardstack/src/hooks/transactions/use-merchant-transactions.tsx
+++ b/cardstack/src/hooks/transactions/use-merchant-transactions.tsx
@@ -68,6 +68,7 @@ export const useMerchantTransactions = (
     fetchMore,
     merchantSafeAddress: safeAddress,
     transactionStrategies: strategies,
+    isMerchantTransaction: true,
   });
 
   return {

--- a/cardstack/src/hooks/transactions/use-transaction-sections.tsx
+++ b/cardstack/src/hooks/transactions/use-transaction-sections.tsx
@@ -25,6 +25,7 @@ interface UseTransactionSectionsProps {
   fetchMore?: (props: any) => void;
   merchantSafeAddress?: string;
   transactionStrategies?: TransactionMappingStrategy[];
+  isMerchantTransaction?: boolean;
 }
 
 export const useTransactionSections = ({
@@ -35,6 +36,7 @@ export const useTransactionSections = ({
   fetchMore,
   merchantSafeAddress,
   transactionStrategies,
+  isMerchantTransaction = false,
 }: UseTransactionSectionsProps) => {
   const [sections, setSections] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
@@ -56,12 +58,17 @@ export const useTransactionSections = ({
     state => state.settings.accountAddress
   );
 
-  const prevLastTransaction = usePrevious(transactions?.[0]?.transaction.id);
-  const currentLastTransaction = transactions?.[0]?.transaction.id;
+  const prevLastTransaction = usePrevious(transactions?.[0]?.transaction?.id);
+  const currentLastTransaction = transactions?.[0]?.transaction?.id;
+
+  // Quick workaround to have merchant tx working
+  // TODO: refactor and add tests
+  const shouldUpdate =
+    prevLastTransaction !== currentLastTransaction || isMerchantTransaction;
 
   useEffect(() => {
     const setSectionsData = async () => {
-      if (transactions && prevLastTransaction !== currentLastTransaction) {
+      if (transactions && shouldUpdate) {
         setLoading(true);
 
         try {
@@ -124,8 +131,7 @@ export const useTransactionSections = ({
     transactionStrategies,
     merchantSafes,
     prepaidCards,
-    prevLastTransaction,
-    currentLastTransaction,
+    shouldUpdate,
   ]);
 
   const isLoading = networkStatus === NetworkStatus.loading || loading;


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

The merchant transactions array have a different structure from the others transactions, which means that it doens't have the `transaction` key in it, so while checking for prev and current with `transactions?.[0].transaction` for the merchant tx, it was causing a crash, the solution for now, is to add a diff behavior if we are handling merchant transactions, but the goal is to add tests, and properly type this flow, since it's use across the whole application, and on every change, it's possible to break something else 



### Screenshots

<!-- Screenshots or animated GIFs included here -->

![crash](https://user-images.githubusercontent.com/20520102/132536409-4f16c6c4-fcc5-40b7-bd6a-cfcf9fd7c637.gif)
