### PR TITLE
[CS-1725] [CS-1788]  - Modal Scrolling / Payment Details Screen

### DIFF
--- a/cardstack/src/components/Button/BlockscoutButton.tsx
+++ b/cardstack/src/components/Button/BlockscoutButton.tsx
@@ -1,0 +1,30 @@
+import { getConstantByNetwork } from '@cardstack/cardpay-sdk';
+import React, { useCallback } from 'react';
+import { Linking } from 'react-native';
+import { Button } from '@cardstack/components';
+import { normalizeTxHash } from '@cardstack/utils';
+
+export const BlockscoutButton = ({
+  network,
+  transactionHash,
+}: {
+  network: string;
+  transactionHash: string;
+}) => {
+  const onPress = useCallback(() => {
+    const blockExplorer = getConstantByNetwork('blockExplorer', network);
+    const normalizedHash = normalizeTxHash(transactionHash);
+    Linking.openURL(`${blockExplorer}/tx/${normalizedHash}`);
+  }, [network, transactionHash]);
+
+  return (
+    <Button
+      marginBottom={12}
+      onPress={onPress}
+      variant="smallWhite"
+      width="100%"
+    >
+      View on Blockscout
+    </Button>
+  );
+};

--- a/cardstack/src/components/Button/index.ts
+++ b/cardstack/src/components/Button/index.ts
@@ -1,1 +1,2 @@
 export * from './Button';
+export * from './BlockscoutButton';

--- a/cardstack/src/components/TransactionConfirmationSheet/displays/components/sections/MerchantSectionCard.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/displays/components/sections/MerchantSectionCard.tsx
@@ -1,7 +1,7 @@
 import React, { memo, ReactNode } from 'react';
 
 import { MerchantInformation } from '@cardstack/types';
-import { Container, Text } from '@cardstack/components';
+import { Container, Icon, Text } from '@cardstack/components';
 import { ContactAvatar } from '@rainbow-me/components/contacts';
 
 const MerchantSectionCard = ({
@@ -17,13 +17,17 @@ const MerchantSectionCard = ({
     borderRadius={10}
     padding={8}
   >
-    <ContactAvatar
-      color={merchantInfoDID?.color}
-      size="xlarge"
-      value={merchantInfoDID?.name}
-      textColor={merchantInfoDID?.textColor}
-    />
-    <Container paddingTop={3}>
+    {merchantInfoDID ? (
+      <ContactAvatar
+        color={merchantInfoDID?.color}
+        size="xlarge"
+        value={merchantInfoDID?.name}
+        textColor={merchantInfoDID?.textColor}
+      />
+    ) : (
+      <Icon name="user" size={80} />
+    )}
+    <Container paddingTop={3} marginBottom={4}>
       <Text
         weight="extraBold"
         size="medium"

--- a/cardstack/src/components/Transactions/PrepaidCard/PrepaidCardPaymentTransaction.tsx
+++ b/cardstack/src/components/Transactions/PrepaidCard/PrepaidCardPaymentTransaction.tsx
@@ -1,12 +1,15 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
+import { useNavigation } from '@react-navigation/core';
 import {
   TransactionBase,
   TransactionBaseCustomizationProps,
+  TransactionBaseProps,
 } from '../TransactionBase';
 import { PrepaidCardTransactionHeader } from './PrepaidCardTransactionHeader';
 import { Icon } from '@cardstack/components';
 import { PrepaidCardPaymentTransactionType } from '@cardstack/types';
+import Routes from '@rainbow-me/routes';
 
 interface PrepaidCardPaymentTransactionProps
   extends TransactionBaseCustomizationProps {
@@ -17,6 +20,17 @@ export const PrepaidCardPaymentTransaction = ({
   item,
   ...props
 }: PrepaidCardPaymentTransactionProps) => {
+  const { navigate } = useNavigation();
+
+  const onPressTransaction = useCallback(
+    (assetProps: TransactionBaseProps) =>
+      navigate(Routes.EXPANDED_ASSET_SHEET, {
+        asset: { ...assetProps },
+        type: 'paymentConfirmationTransaction',
+      }),
+    [navigate]
+  );
+
   return (
     <TransactionBase
       {...props}
@@ -32,6 +46,7 @@ export const PrepaidCardPaymentTransaction = ({
       primaryText={`- ${item.spendBalanceDisplay}`}
       subText={item.nativeBalanceDisplay}
       transactionHash={item.transactionHash}
+      onPressTransaction={onPressTransaction}
     />
   );
 };

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/prepaid-card-payment-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/prepaid-card-payment-strategy.ts
@@ -6,6 +6,7 @@ import {
 import {
   convertSpendForBalanceDisplay,
   fetchCardCustomizationFromDID,
+  fetchMerchantInfoFromDID,
 } from '@cardstack/utils';
 
 export class PrepaidCardPaymentStrategy extends BaseStrategy {
@@ -29,11 +30,20 @@ export class PrepaidCardPaymentStrategy extends BaseStrategy {
     }
 
     let cardCustomization;
+    let merchantInfo;
 
-    if (prepaidCardPaymentTransaction.prepaidCard.customizationDID) {
+    if (prepaidCardPaymentTransaction.prepaidCard?.customizationDID) {
       try {
         cardCustomization = await fetchCardCustomizationFromDID(
           prepaidCardPaymentTransaction.prepaidCard.customizationDID
+        );
+      } catch (error) {}
+    }
+
+    if (prepaidCardPaymentTransaction.merchantSafe?.infoDid) {
+      try {
+        merchantInfo = await fetchMerchantInfoFromDID(
+          prepaidCardPaymentTransaction.merchantSafe?.infoDid
         );
       } catch (error) {}
     }
@@ -54,6 +64,7 @@ export class PrepaidCardPaymentStrategy extends BaseStrategy {
       spendBalanceDisplay: spendDisplay.tokenBalanceDisplay,
       nativeBalanceDisplay: spendDisplay.nativeBalanceDisplay,
       transactionHash: this.transaction.id,
+      merchantInfo: merchantInfo,
     };
   }
 }

--- a/cardstack/src/types/transaction-types.ts
+++ b/cardstack/src/types/transaction-types.ts
@@ -135,6 +135,7 @@ export interface PrepaidCardPaymentTransactionType {
   nativeBalanceDisplay: string;
   type: TransactionTypes.PREPAID_CARD_PAYMENT;
   transactionHash: string;
+  merchantInfo?: MerchantInformation;
 }
 
 export interface MerchantEarnedRevenueTransactionTypeTxn {

--- a/cardstack/src/utils/date-utils.ts
+++ b/cardstack/src/utils/date-utils.ts
@@ -113,3 +113,11 @@ export const groupAccumulations = (
 
   return '0';
 };
+
+export const dateFormatter = (ts: number) => {
+  const timestamp = new Date(ts * 1000);
+  return `${format(timestamp, 'MMM-dd-yyyy')} \n${format(
+    timestamp,
+    'h:mm:ss a'
+  )} UTC+`;
+};

--- a/cardstack/src/utils/dimension-utils.ts
+++ b/cardstack/src/utils/dimension-utils.ts
@@ -1,3 +1,4 @@
 import { Dimensions } from 'react-native';
 
 export const screenWidth = Dimensions.get('screen').width;
+export const screenHeight = Dimensions.get('screen').height;

--- a/src/components/expanded-state/AvailableBalancesExpandedState.tsx
+++ b/src/components/expanded-state/AvailableBalancesExpandedState.tsx
@@ -68,7 +68,7 @@ export default function AvailableBalancesExpandedState(
   }, [setOptions]);
 
   return (
-    <SlackSheet flex={1}>
+    <SlackSheet flex={1} scrollEnabled={false}>
       <Container paddingHorizontal={5} paddingTop={3}>
         <Text size="medium">Available balances</Text>
         <Container flexDirection="row" justifyContent="space-between">

--- a/src/components/expanded-state/PaymentConfirmationExpandedState.tsx
+++ b/src/components/expanded-state/PaymentConfirmationExpandedState.tsx
@@ -1,0 +1,159 @@
+import React, { useEffect } from 'react';
+import { SlackSheet } from '../sheet';
+import { BlockscoutButton, Container, Text } from '@cardstack/components';
+import MerchantSectionCard from '@cardstack/components/TransactionConfirmationSheet/displays/components/sections/MerchantSectionCard';
+import {
+  TransactionRow,
+  TransactionRowProps,
+} from '@cardstack/components/Transactions/TransactionBase';
+import { PrepaidCardPaymentTransactionType } from '@cardstack/types';
+import { dateFormatter, screenHeight } from '@cardstack/utils';
+import { ContactAvatar } from '@rainbow-me/components/contacts';
+import { useNavigation } from '@rainbow-me/navigation';
+import { useRainbowSelector } from '@rainbow-me/redux/hooks';
+
+interface PaymentConfirmationExpandedStateProps {
+  asset: Asset;
+  type: string;
+}
+
+interface Asset extends TransactionRowProps {
+  CoinIcon: JSX.Element;
+  Header: any;
+  includeBorder: boolean;
+  index: number;
+  isFullWidth: boolean;
+  primaryText: string;
+  section: Section;
+  statusText: string;
+  subText: string;
+  transactionHash: string;
+}
+
+interface Section {
+  data: PrepaidCardPaymentTransactionType[];
+  title: string;
+}
+
+const PaymentDetailsItem = ({
+  title,
+  color,
+  textColor,
+  name,
+  info,
+  isTimestamp = false,
+}: {
+  title: string;
+  color?: string;
+  textColor?: string;
+  info: any;
+  name?: string;
+  isTimestamp?: boolean;
+}) => {
+  return (
+    <Container marginBottom={6} paddingHorizontal={6}>
+      <Text color="blueText" fontSize={13} marginBottom={2} weight="extraBold">
+        {title}
+      </Text>
+      {name ? (
+        <>
+          <Container flexDirection="row" marginBottom={1}>
+            <Container flex={2} />
+            <Container flex={8}>
+              <Text color="blueText" fontSize={10} weight="bold">
+                MERCHANT
+              </Text>
+            </Container>
+          </Container>
+          <Container flexDirection="row">
+            <Container alignItems="center" flex={2}>
+              <ContactAvatar
+                color={color}
+                size="smaller"
+                textColor={textColor}
+                value={name}
+              />
+            </Container>
+            <Container flex={8} marginBottom={1}>
+              <Text weight="extraBold">{name}</Text>
+            </Container>
+          </Container>
+        </>
+      ) : null}
+      <Container flexDirection="row" marginBottom={1}>
+        <Container flex={2} />
+        <Container flex={8}>
+          <Text color="blueText" fontSize={13}>
+            {isTimestamp ? dateFormatter(info) : info}
+          </Text>
+        </Container>
+      </Container>
+    </Container>
+  );
+};
+
+const CHART_HEIGHT = screenHeight * 0.8;
+
+export default function PaymentConfirmationExpandedState(
+  props: PaymentConfirmationExpandedStateProps
+) {
+  const { setOptions } = useNavigation();
+
+  useEffect(() => {
+    setOptions({
+      longFormHeight: CHART_HEIGHT,
+    });
+  }, [setOptions]);
+  const {
+    merchantInfo,
+    spendAmount,
+    nativeBalanceDisplay,
+    timestamp,
+    transactionHash,
+  } = props.asset?.section?.data[props.asset.index];
+  const { ownerAddress } = merchantInfo || {};
+
+  const network = useRainbowSelector(state => state.settings.network);
+  return (
+    <SlackSheet flex={1} scrollEnabled>
+      <Container backgroundColor="white" marginBottom={16} padding={8}>
+        <Text marginBottom={10} size="medium">
+          Payment Confirmation
+        </Text>
+        <MerchantSectionCard merchantInfoDID={merchantInfo}>
+          <Container alignItems="center" paddingBottom={3}>
+            <Text fontSize={40} fontWeight="700">
+              §{spendAmount || ''}
+            </Text>
+            <Text color="blueText" fontSize={12}>
+              {nativeBalanceDisplay || ''}
+            </Text>
+          </Container>
+        </MerchantSectionCard>
+        <Container marginBottom={3} />
+        <Container
+          backgroundColor="white"
+          borderColor="borderGray"
+          borderRadius={10}
+          borderWidth={1}
+          marginBottom={8}
+          overflow="scroll"
+        >
+          {props.asset.Header}
+          <TransactionRow {...props.asset} hasBottomDivider />
+          <PaymentDetailsItem
+            title="TO:"
+            {...merchantInfo}
+            info={ownerAddress}
+          />
+          <PaymentDetailsItem info={transactionHash} title="TXN HASH:" />
+          <PaymentDetailsItem info={timestamp} isTimestamp title="TIME:" />
+        </Container>
+        <BlockscoutButton
+          network={network}
+          transactionHash={props.asset.transactionHash}
+        />
+      </Container>
+    </SlackSheet>
+  );
+}

--- a/src/components/expanded-state/RecentActivityExpandedState.tsx
+++ b/src/components/expanded-state/RecentActivityExpandedState.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ActivityIndicator, RefreshControl, SectionList } from 'react-native';
 import { SlackSheet } from '../sheet';
 import {
@@ -11,10 +11,20 @@ import {
 import { useMerchantTransactions } from '@cardstack/hooks';
 import { MerchantSafeType } from '@cardstack/types';
 import { sectionStyle } from '@cardstack/utils/layouts';
+import { useNavigation } from '@rainbow-me/navigation';
+
+const CHART_HEIGHT = 650;
 
 export default function UnclaimedRevenueExpandedState(props: {
   asset: MerchantSafeType;
 }) {
+  const { setOptions } = useNavigation();
+
+  useEffect(() => {
+    setOptions({
+      longFormHeight: CHART_HEIGHT,
+    });
+  }, [setOptions]);
   return (
     <SlackSheet flex={1} scrollEnabled>
       <Container paddingHorizontal={5} paddingVertical={3}>

--- a/src/components/expanded-state/index.js
+++ b/src/components/expanded-state/index.js
@@ -9,5 +9,6 @@ export { default as LifetimeEarningsExpandedState } from './LifetimeEarningsExpa
 export { default as UnclaimedRevenueExpandedState } from './UnclaimedRevenueExpandedState';
 export { default as AvailableBalancesExpandedState } from './AvailableBalancesExpandedState';
 export { default as MerchantTransactionExpandedState } from './MerchantTransactionExpandedState';
+export { default as PaymentConfirmationExpandedState } from './PaymentConfirmationExpandedState';
 export { default as PaymentRequestExpandedState } from './PaymentRequestExpandedState';
 export { default as RecentActivityExpandedState } from './RecentActivityExpandedState';

--- a/src/screens/ExpandedAssetSheet.js
+++ b/src/screens/ExpandedAssetSheet.js
@@ -11,6 +11,7 @@ import {
   LifetimeEarningsExpandedState,
   LiquidityPoolExpandedState,
   MerchantTransactionExpandedState,
+  PaymentConfirmationExpandedState,
   PaymentRequestExpandedState,
   RecentActivityExpandedState,
   UnclaimedRevenueExpandedState,
@@ -32,6 +33,7 @@ const ScreenTypes = {
   [ExpandedMerchantRoutes.paymentRequest]: PaymentRequestExpandedState,
   [ExpandedMerchantRoutes.recentActivity]: RecentActivityExpandedState,
   merchantTransaction: MerchantTransactionExpandedState,
+  paymentConfirmationTransaction: PaymentConfirmationExpandedState,
 };
 
 const Container = styled(Centered).attrs({


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

- Recent activity and unclaimed revenues modals were not allowing the user to dismiss them. There's a property on Slacksheet component that needs to be passed by navigation via `setOptions` in order to set their height (really weird, but that's how it works) 

- Adding the  Transaction details screen on Transactions EOA ([reference to the designs](https://linear.app/cardstack/issue/CS-1725/transaction-detail-from-eoa-transaction-screen))
<!-- Include a summary of the changes. -->

- [X] Completes #(1725) (1788)

### Checklist

- [X] All UI changes have been tested on a small device


### Screenshots
![Sep-14-2021 17-56-36-paymt-confirmation](https://user-images.githubusercontent.com/8547776/133332969-265f939f-c056-4176-ad43-cadf55ff9e65.gif)
![Sep-14-2021 17-55-46-scrolling](https://user-images.githubusercontent.com/8547776/133333002-2b92057d-3031-4a7a-9822-e861e4ae3119.gif)



<!-- Screenshots or animated GIFs included here -->