### PR TITLE
Adding unit tests for Merchant Earned Spend and Prepaid Card Payment strategies

### DIFF
--- a/cardstack/src/utils/__mocks__/merchant-strategies.ts
+++ b/cardstack/src/utils/__mocks__/merchant-strategies.ts
@@ -99,3 +99,153 @@ export const MERCHANT_EARNED_MOCK_DATA: PrepaidCardPaymentFragment = {
     ],
   },
 };
+
+export const MERCHANT_EARNED_SPEND_MOCK_DATA = {
+  __typename: 'MerchantRevenueEvent',
+  historicLifetimeAccumulation: '1497005988023952095',
+  historicUnclaimedBalance: '1489520958083832335',
+  id: '0x5293d95a240c231852724fd31ff6df119e5b5cf7661a7aec38f7cf10893dc2eb',
+  timestamp: '1629156260',
+  prepaidCardPayments: [
+    {
+      __typename: 'PrepaidCardPayment',
+      id: '0x5293d95a240c231852724fd31ff6df119e5b5cf7661a7aec38f7cf10893dc2eb',
+      issuingToken: {
+        __typename: 'Token',
+        id: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+        name: 'Dai Stablecoin.CPXD',
+        symbol: 'DAI',
+      },
+      issuingTokenAmount: '1497005988023952095',
+      issuingTokenUSDPrice: '1.002',
+      merchantSafe: {
+        __typename: 'MerchantSafe',
+        id: '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
+        infoDid: '3a13a41e-e44a-4b0f-b079-2d3d53571870',
+      },
+      prepaidCard: {
+        __typename: 'PrepaidCard',
+        customizationDID: 'c6f4d200-e879-49c2-abdf-432693fd18c3',
+        id: '0x72DB39da38fa313A004770E8C4d9416428068024',
+      },
+      spendAmount: '150',
+      timestamp: '1629156260',
+      transaction: {
+        __typename: 'Transaction',
+        merchantFeePayments: [
+          {
+            __typename: 'MerchantFeePayment',
+            feeCollected: '7485029940119760',
+            issuingToken: { __typename: 'Token', symbol: 'DAI' },
+          },
+        ],
+      },
+    },
+  ],
+  merchantClaims: [null],
+};
+
+export const PREPAID_CARD_PAYMENT_MOCK = {
+  __typename: 'Transaction',
+  bridgeToLayer1Events: [],
+  bridgeToLayer2Events: [],
+  id: '0x7e3d3ad2b3cc284a96339b0f0e0a2eabce1fc7a8438858b358aa2cbd55cef333',
+  merchantClaims: [],
+  merchantCreations: [
+    {
+      __typename: 'MerchantCreation',
+      createdAt: '1629411270',
+      id: '0x8de5D051565dF590A92f00a57B6d24609a17BC01',
+      merchantSafe: { __typename: 'MerchantSafe', infoDid: 'merchant18989898' },
+    },
+  ],
+  merchantFeePayments: [],
+  merchantRegistrationPayments: [
+    {
+      __typename: 'MerchantRegistrationPayment',
+      id: '0x7e3d3ad2b3cc284a96339b0f0e0a2eabce1fc7a8438858b358aa2cbd55cef333',
+    },
+  ],
+  prepaidCardCreations: [],
+  prepaidCardPayments: [
+    {
+      __typename: 'PrepaidCardPayment',
+      id: '0x7e3d3ad2b3cc284a96339b0f0e0a2eabce1fc7a8438858b358aa2cbd55cef333',
+      issuingToken: {
+        __typename: 'Token',
+        id: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+        name: 'Dai Stablecoin.CPXD',
+        symbol: 'DAI',
+      },
+      issuingTokenAmount: '998003992015968063',
+      issuingTokenUSDPrice: '1.002',
+      merchantSafe: {
+        __typename: 'MerchantSafe',
+        id: '0x9Ed84407e5ed5B7c0323E5653A06F4528357e3B5',
+        infoDid: '3a13a41e-e44a-4b0f-b079-2d3d53571870',
+      },
+      prepaidCard: {
+        __typename: 'PrepaidCard',
+        customizationDID:
+          'did:cardstack:1p3fJF6oNCLEz1xhCLYYWq59b05d0d718792153b',
+        id: '0x35Ae15dCEB6930756A59EfcC2169d2b834CdD371',
+      },
+      spendAmount: '100',
+      timestamp: '1629411270',
+      transaction: { __typename: 'Transaction', merchantFeePayments: [] },
+    },
+  ],
+  prepaidCardSplits: [],
+  prepaidCardTransfers: [],
+  spendAccumulations: [],
+  supplierInfoDIDUpdates: [],
+  timestamp: '1629411270',
+  tokenSwaps: [],
+  tokenTransfers: [
+    {
+      __typename: 'TokenTransfer',
+      amount: '998003992015968063',
+      from: '0x35Ae15dCEB6930756A59EfcC2169d2b834CdD371',
+      id:
+        '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1-0x7e3d3ad2b3cc284a96339b0f0e0a2eabce1fc7a8438858b358aa2cbd55cef333-0',
+      timestamp: '1629411270',
+      to: '0xaE5AC3685630b33Ed2677438EEaAe0aD5372c795',
+      token: {
+        __typename: 'Token',
+        id: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+        name: 'Dai Stablecoin.CPXD',
+        symbol: 'DAI',
+      },
+    },
+    {
+      __typename: 'TokenTransfer',
+      amount: '998003992015968063',
+      from: '0xaE5AC3685630b33Ed2677438EEaAe0aD5372c795',
+      id:
+        '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1-0x7e3d3ad2b3cc284a96339b0f0e0a2eabce1fc7a8438858b358aa2cbd55cef333-2',
+      timestamp: '1629411270',
+      to: '0xc267d67cDbb5aCC6f477D4eAb173Dcc54F00e762',
+      token: {
+        __typename: 'Token',
+        id: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+        name: 'Dai Stablecoin.CPXD',
+        symbol: 'DAI',
+      },
+    },
+    {
+      __typename: 'TokenTransfer',
+      amount: '998003992015968063',
+      from: '0xc267d67cDbb5aCC6f477D4eAb173Dcc54F00e762',
+      id:
+        '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1-0x7e3d3ad2b3cc284a96339b0f0e0a2eabce1fc7a8438858b358aa2cbd55cef333-4',
+      timestamp: '1629411270',
+      to: '0x09FBEDDc5f94fA2713CDa75A68457cA8A4527adf',
+      token: {
+        __typename: 'Token',
+        id: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+        name: 'Dai Stablecoin.CPXD',
+        symbol: 'DAI',
+      },
+    },
+  ],
+};

--- a/cardstack/test/strategies/merchant-earned-spend.test.ts
+++ b/cardstack/test/strategies/merchant-earned-spend.test.ts
@@ -1,0 +1,69 @@
+import { MerchantEarnedSpendStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-strategy';
+import { MERCHANT_EARNED_SPEND_MOCK_DATA } from '@cardstack/utils/__mocks__/merchant-strategies';
+
+jest.mock('../../../src/utils', () => ({ deviceUtils: { isIOS14: false } }));
+
+jest.mock('@rainbow-me/references', () => ({
+  shitcoins: 'JSON-MOCK-RETURN',
+}));
+
+const result = {
+  address: '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
+  infoDid: '3a13a41e-e44a-4b0f-b079-2d3d53571870',
+  nativeBalanceDisplay: '$1.50 USD',
+  spendBalanceDisplay: '§150 SPEND',
+  timestamp: '1629156260',
+  transactionHash:
+    '0x5293d95a240c231852724fd31ff6df119e5b5cf7661a7aec38f7cf10893dc2eb',
+  type: 'merchantEarnedSpend',
+};
+
+describe('MerchantEarnedSpendStrategy', () => {
+  const contructorParams = {
+    accountAddress: '0x64Fbf34FaC77696112F1Abaa69D28211214d76c7',
+    currencyConversionRates: {
+      AUD: 1.362445,
+      CAD: 1.262345,
+      CNY: 6.432498,
+      EUR: 0.846102,
+      GBP: 0.72197,
+      INR: 73.445498,
+      JPY: 109.350353,
+      KRW: 1166.819664,
+      NZD: 1.402265,
+      RUB: 72.280298,
+      TRY: 8.429594,
+      USD: 1,
+      ZAR: 14.41804,
+    },
+    depotAddress: '0xF48c7B663DFCa76E1954bC44f7Fc006e2e04b09C',
+    merchantSafeAddress: '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
+    merchantSafeAddresses: [
+      '0x51217e4769DFD61a42f8A509d4DCcC5683BFCB21',
+      '0xb891ad9b23826e61F010D5cd90d6a24Ea55010Bd',
+      '0x1D2BCdFb26319d1F5919aa66b105AE972946b9fE',
+      '0x6A4946bF21df59C58d4129802e0a37Ac649e6ae7',
+      '0x8de5D051565dF590A92f00a57B6d24609a17BC01',
+      '0x372582b0290cab3fcEb009A0F3869D50a00276D2',
+      '0x9Ed84407e5ed5B7c0323E5653A06F4528357e3B5',
+      '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
+    ],
+    nativeCurrency: 'USD',
+    prepaidCardAddresses: ['0x35Ae15dCEB6930756A59EfcC2169d2b834CdD371'],
+    transaction: MERCHANT_EARNED_SPEND_MOCK_DATA,
+  };
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const MerchantInstance = new MerchantEarnedSpendStrategy(contructorParams);
+
+  test('returns the proper object', async () => {
+    MerchantInstance.mapTransaction().then(value => {
+      expect(value).toBe(result);
+    });
+  });
+
+  test('returns true with proper constructors', () => {
+    expect(MerchantInstance.handlesTransaction()).toBeTruthy();
+  });
+});

--- a/cardstack/test/strategies/prepaid-card-payment-strategy.test.ts
+++ b/cardstack/test/strategies/prepaid-card-payment-strategy.test.ts
@@ -1,0 +1,151 @@
+import { PREPAID_CARD_PAYMENT_MOCK } from '@cardstack/utils/__mocks__/merchant-strategies';
+import { PrepaidCardPaymentStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/prepaid-card-payment-strategy';
+
+jest.mock('../../../src/utils', () => ({ deviceUtils: { isIOS14: false } }));
+
+jest.mock('@rainbow-me/references', () => ({
+  shitcoins: 'JSON-MOCK-RETURN',
+}));
+
+jest.mock('@cardstack/utils', () => ({
+  fetchMerchantInfoFromDID: jest.fn().mockReturnValue({
+    color: '#0e058a',
+    did: 'did:cardstack:1mwFFZYzNyaeQwTCANBEMU167d6c9aa51321ea21',
+    name: 'NFTs For All!',
+    ownerAddress: '0xf3274Df212D2D8ff1eA3B2ADe81277cdbEA67A6D',
+    slug: 'nfty',
+    textColor: '#ffffff',
+  }),
+  convertSpendForBalanceDisplay: jest.fn().mockReturnValue({
+    nativeBalanceDisplay: '$1.00 USD',
+    tokenBalanceDisplay: '§100 SPEND',
+  }),
+  fetchCardCustomizationFromDID: jest.fn().mockReturnValue({
+    background: '#C3FC33',
+    issuerName: 'Test Card',
+    patternColor: 'white',
+    patternUrl:
+      'https://app.cardstack.com/images/prepaid-card-customizations/pattern-1.svg',
+    textColor: 'black',
+  }),
+}));
+
+const result = {
+  address: '0x35Ae15dCEB6930756A59EfcC2169d2b834CdD371',
+  cardCustomization: {
+    background: '#C3FC33',
+    issuerName: 'Test Card',
+    patternColor: 'white',
+    patternUrl:
+      'https://app.cardstack.com/images/prepaid-card-customizations/pattern-1.svg',
+    textColor: 'black',
+  },
+  merchantInfo: {
+    color: '#0e058a',
+    did: 'did:cardstack:1mwFFZYzNyaeQwTCANBEMU167d6c9aa51321ea21',
+    name: 'NFTs For All!',
+    ownerAddress: '0xf3274Df212D2D8ff1eA3B2ADe81277cdbEA67A6D',
+    slug: 'nfty',
+    textColor: '#ffffff',
+  },
+  nativeBalanceDisplay: '$1.00 USD',
+  spendAmount: '100',
+  spendBalanceDisplay: '§100 SPEND',
+  timestamp: '1629411270',
+  transactionHash:
+    '0x7e3d3ad2b3cc284a96339b0f0e0a2eabce1fc7a8438858b358aa2cbd55cef333',
+  type: 'prepaidCardPayment',
+};
+
+describe('PrepaidCardPaymentStrategy', () => {
+  const contructorParams = {
+    accountAddress: '0x64Fbf34FaC77696112F1Abaa69D28211214d76c7',
+    currencyConversionRates: {
+      AUD: 1.362445,
+      CAD: 1.262345,
+      CNY: 6.432498,
+      EUR: 0.846102,
+      GBP: 0.72197,
+      INR: 73.445498,
+      JPY: 109.350353,
+      KRW: 1166.819664,
+      NZD: 1.402265,
+      RUB: 72.280298,
+      TRY: 8.429594,
+      USD: 1,
+      ZAR: 14.41804,
+    },
+    depotAddress: '0xF48c7B663DFCa76E1954bC44f7Fc006e2e04b09C',
+    merchantSafeAddresses: [
+      '0x51217e4769DFD61a42f8A509d4DCcC5683BFCB21',
+      '0xb891ad9b23826e61F010D5cd90d6a24Ea55010Bd',
+      '0x1D2BCdFb26319d1F5919aa66b105AE972946b9fE',
+      '0x6A4946bF21df59C58d4129802e0a37Ac649e6ae7',
+      '0x8de5D051565dF590A92f00a57B6d24609a17BC01',
+      '0x372582b0290cab3fcEb009A0F3869D50a00276D2',
+      '0x9Ed84407e5ed5B7c0323E5653A06F4528357e3B5',
+      '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
+    ],
+    nativeCurrency: 'USD',
+    prepaidCardAddresses: ['0x35Ae15dCEB6930756A59EfcC2169d2b834CdD371'],
+    transaction: PREPAID_CARD_PAYMENT_MOCK,
+  };
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const PrepaidCardPayment = new PrepaidCardPaymentStrategy(contructorParams);
+
+  test('returns the proper object', async () => {
+    PrepaidCardPayment.mapTransaction()
+      .then(value => {
+        expect(value).toEqual(result);
+      })
+      .catch(err => console.log('Error: ', err));
+  });
+
+  test('returns the proper object without merchant info and card customization', async () => {
+    const newParams = {
+      ...contructorParams,
+      transaction: {
+        prepaidCardPayments: [
+          {
+            ...contructorParams.transaction.prepaidCardPayments[0],
+            merchantSafe: null,
+            prepaidCard: {
+              ...contructorParams.transaction.prepaidCardPayments[0]
+                .prepaidCard,
+              customizationDID: null,
+            },
+          },
+        ],
+      },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    new PrepaidCardPaymentStrategy(newParams)
+      .mapTransaction()
+      .then(value => {
+        expect(value).toHaveProperty('merchantInfo', undefined);
+        expect(value).toHaveProperty('cardCustomization', undefined);
+      })
+      .catch(err => console.log('Error: ', err));
+  });
+
+  test('returns true with proper constructors', () => {
+    expect(PrepaidCardPayment.handlesTransaction()).toBeTruthy();
+  });
+
+  test('returns false with empty prepaidCardPayments', () => {
+    const newParams = {
+      ...contructorParams,
+      transaction: { prepaidCardPayments: [] },
+    };
+
+    expect(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      new PrepaidCardPaymentStrategy(newParams).handlesTransaction()
+    ).toBeFalsy();
+  });
+});


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Following tests made by Dani, I thought it was important to start unit testing strategies, since they carry some important data flows across the app.

I wrote some for two strategies and was able to understand how we can mock some deps. I hope it serves as a `template` in case someone needs to change some of'em.

<!-- Include a summary of the changes. -->

### Screenshots

![image](https://user-images.githubusercontent.com/8547776/133545325-6d260ca8-32ff-44f3-b4fa-f489ce898785.png)


<!-- Screenshots or animated GIFs included here -->