### PR TITLE
[CS-1848 1883] - Rounding unclaimed revenue / Dismiss modal bug

### DIFF
--- a/cardstack/src/services/gnosis-service.ts
+++ b/cardstack/src/services/gnosis-service.ts
@@ -119,10 +119,18 @@ export const getTokensWithPrice = async (
           ? usdBalance
           : currencyConversionRates[nativeCurrency] * usdBalance;
 
+      const isAmountDust = nativeBalance < 0.01;
+
+      //decimal places formatting for residual crypto values
+      const bufferValue = isAmountDust ? 0 : undefined;
       return {
         ...tokenItem,
         balance: {
-          ...convertRawAmountToBalance(tokenItem.balance, tokenItem.token),
+          ...convertRawAmountToBalance(
+            tokenItem.balance,
+            tokenItem.token,
+            bufferValue
+          ),
           wei: tokenItem.balance,
         },
         native: {
@@ -130,7 +138,8 @@ export const getTokensWithPrice = async (
             amount: nativeBalance,
             display: convertAmountToNativeDisplay(
               nativeBalance,
-              nativeCurrency
+              nativeCurrency,
+              bufferValue
             ),
           },
         },

--- a/cardstack/src/theme/buttonVariants.ts
+++ b/cardstack/src/theme/buttonVariants.ts
@@ -66,6 +66,17 @@ const invalid = {
   },
 };
 
+const disabled = {
+  backgroundColor: 'grayBackground',
+  borderColor: 'transparent',
+  textStyle: {
+    color: 'blueText',
+  },
+  disabledTextStyle: {
+    color: 'white',
+  },
+};
+
 export const buttonVariants = {
   defaults: {
     alignItems: 'center',
@@ -136,6 +147,7 @@ export const buttonVariants = {
       fontSize: 26,
     },
   },
+  disabled,
 };
 
 export type ButtonVariants = keyof typeof buttonVariants;

--- a/src/components/expanded-state/LifetimeEarningsExpandedState.tsx
+++ b/src/components/expanded-state/LifetimeEarningsExpandedState.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, RefreshControl, SectionList } from 'react-native';
 import {
   ChartFilterOptions,
@@ -50,15 +50,17 @@ export default function LifetimeEarningsExpandedState(props: {
     });
   }, [setOptions]);
 
-  return (
-    // @ts-ignore doesn't understand the JS props
-    <SlackSheet bottomInset={42} height="100%" scrollEnabled>
-      <ChartSection address={address} />
-      <Container paddingHorizontal={5}>
-        <HorizontalDivider />
-      </Container>
-      <ActivitiesSection address={address} />
-    </SlackSheet>
+  return useMemo(
+    () => (
+      <SlackSheet bottomInset={42} height="100%" scrollEnabled>
+        <ChartSection address={address} />
+        <Container paddingHorizontal={5}>
+          <HorizontalDivider />
+        </Container>
+        <ActivitiesSection address={address} />
+      </SlackSheet>
+    ),
+    [address]
   );
 }
 

--- a/src/components/expanded-state/MerchantTransactionExpandedState.tsx
+++ b/src/components/expanded-state/MerchantTransactionExpandedState.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { SlackSheet } from '../sheet';
 import {
   BlockscoutButton,
@@ -172,35 +172,38 @@ export default function MerchantTransactionExpandedState(
 
   const network = useRainbowSelector(state => state.settings.network);
   const earnedTxnData = { ...transactionData, subText: props.asset?.subText };
-  return (
-    <SlackSheet flex={1} scrollEnabled>
-      <Container backgroundColor="white" marginBottom={32} padding={8}>
-        <Text marginBottom={10} size="medium">
-          Transaction details
-        </Text>
-        <Container
-          backgroundColor="white"
-          borderColor="borderGray"
-          borderRadius={10}
-          borderWidth={1}
-          marginBottom={8}
-          overflow="scroll"
-          paddingHorizontal={2}
-        >
-          <TransactionRow {...props.asset} hasBottomDivider />
-          <Container padding={6}>
-            {props.asset.statusText === CLAIMED_STATUS ? (
-              <ClaimedTransaction {...transactionData} />
-            ) : (
-              <EarnedTransaction {...earnedTxnData} />
-            )}
+  return useMemo(
+    () => (
+      <SlackSheet flex={1} scrollEnabled>
+        <Container backgroundColor="white" marginBottom={32} padding={8}>
+          <Text marginBottom={10} size="medium">
+            Transaction details
+          </Text>
+          <Container
+            backgroundColor="white"
+            borderColor="borderGray"
+            borderRadius={10}
+            borderWidth={1}
+            marginBottom={8}
+            overflow="scroll"
+            paddingHorizontal={2}
+          >
+            <TransactionRow {...props.asset} hasBottomDivider />
+            <Container padding={6}>
+              {props.asset.statusText === CLAIMED_STATUS ? (
+                <ClaimedTransaction {...transactionData} />
+              ) : (
+                <EarnedTransaction {...earnedTxnData} />
+              )}
+            </Container>
           </Container>
+          <BlockscoutButton
+            network={network}
+            transactionHash={props.asset.transactionHash}
+          />
         </Container>
-        <BlockscoutButton
-          network={network}
-          transactionHash={props.asset.transactionHash}
-        />
-      </Container>
-    </SlackSheet>
+      </SlackSheet>
+    ),
+    [props.asset]
   );
 }

--- a/src/components/expanded-state/PaymentConfirmationExpandedState.tsx
+++ b/src/components/expanded-state/PaymentConfirmationExpandedState.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { SlackSheet } from '../sheet';
 import { BlockscoutButton, Container, Text } from '@cardstack/components';
 import MerchantSectionCard from '@cardstack/components/TransactionConfirmationSheet/displays/components/sections/MerchantSectionCard';
@@ -92,7 +92,7 @@ const PaymentDetailsItem = ({
   );
 };
 
-const CHART_HEIGHT = screenHeight * 0.8;
+const CHART_HEIGHT = screenHeight * 0.75;
 
 export default function PaymentConfirmationExpandedState(
   props: PaymentConfirmationExpandedStateProps
@@ -103,7 +103,7 @@ export default function PaymentConfirmationExpandedState(
     setOptions({
       longFormHeight: CHART_HEIGHT,
     });
-  }, [setOptions]);
+  });
   const {
     merchantInfo,
     spendAmount,
@@ -114,46 +114,49 @@ export default function PaymentConfirmationExpandedState(
   const { ownerAddress } = merchantInfo || {};
 
   const network = useRainbowSelector(state => state.settings.network);
-  return (
-    <SlackSheet flex={1} scrollEnabled>
-      <Container backgroundColor="white" marginBottom={16} padding={8}>
-        <Text marginBottom={10} size="medium">
-          Payment Confirmation
-        </Text>
-        <MerchantSectionCard merchantInfoDID={merchantInfo}>
-          <Container alignItems="center" paddingBottom={3}>
-            <Text fontSize={40} fontWeight="700">
-              §{spendAmount || ''}
-            </Text>
-            <Text color="blueText" fontSize={12}>
-              {nativeBalanceDisplay || ''}
-            </Text>
+  return useMemo(
+    () => (
+      <SlackSheet flex={1} scrollEnabled>
+        <Container backgroundColor="white" marginBottom={16} padding={8}>
+          <Text marginBottom={10} size="medium">
+            Payment Confirmation
+          </Text>
+          <MerchantSectionCard merchantInfoDID={merchantInfo}>
+            <Container alignItems="center" paddingBottom={3}>
+              <Text fontSize={40} fontWeight="700">
+                §{spendAmount || ''}
+              </Text>
+              <Text color="blueText" fontSize={12}>
+                {nativeBalanceDisplay || ''}
+              </Text>
+            </Container>
+          </MerchantSectionCard>
+          <Container marginBottom={3} />
+          <Container
+            backgroundColor="white"
+            borderColor="borderGray"
+            borderRadius={10}
+            borderWidth={1}
+            marginBottom={8}
+            overflow="scroll"
+          >
+            {props.asset.Header}
+            <TransactionRow {...props.asset} hasBottomDivider />
+            <PaymentDetailsItem
+              title="TO:"
+              {...merchantInfo}
+              info={ownerAddress}
+            />
+            <PaymentDetailsItem info={transactionHash} title="TXN HASH:" />
+            <PaymentDetailsItem info={timestamp} isTimestamp title="TIME:" />
           </Container>
-        </MerchantSectionCard>
-        <Container marginBottom={3} />
-        <Container
-          backgroundColor="white"
-          borderColor="borderGray"
-          borderRadius={10}
-          borderWidth={1}
-          marginBottom={8}
-          overflow="scroll"
-        >
-          {props.asset.Header}
-          <TransactionRow {...props.asset} hasBottomDivider />
-          <PaymentDetailsItem
-            title="TO:"
-            {...merchantInfo}
-            info={ownerAddress}
+          <BlockscoutButton
+            network={network}
+            transactionHash={props.asset.transactionHash}
           />
-          <PaymentDetailsItem info={transactionHash} title="TXN HASH:" />
-          <PaymentDetailsItem info={timestamp} isTimestamp title="TIME:" />
         </Container>
-        <BlockscoutButton
-          network={network}
-          transactionHash={props.asset.transactionHash}
-        />
-      </Container>
-    </SlackSheet>
+      </SlackSheet>
+    ),
+    [props.asset]
   );
 }

--- a/src/components/expanded-state/RecentActivityExpandedState.tsx
+++ b/src/components/expanded-state/RecentActivityExpandedState.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { ActivityIndicator, RefreshControl, SectionList } from 'react-native';
 import { SlackSheet } from '../sheet';
 import {
@@ -10,10 +10,11 @@ import {
 } from '@cardstack/components';
 import { useMerchantTransactions } from '@cardstack/hooks';
 import { MerchantSafeType } from '@cardstack/types';
+import { screenHeight } from '@cardstack/utils';
 import { sectionStyle } from '@cardstack/utils/layouts';
 import { useNavigation } from '@rainbow-me/navigation';
 
-const CHART_HEIGHT = 650;
+const CHART_HEIGHT = screenHeight * 0.75;
 
 export default function UnclaimedRevenueExpandedState(props: {
   asset: MerchantSafeType;
@@ -25,13 +26,16 @@ export default function UnclaimedRevenueExpandedState(props: {
       longFormHeight: CHART_HEIGHT,
     });
   }, [setOptions]);
-  return (
-    <SlackSheet flex={1} scrollEnabled>
-      <Container paddingHorizontal={5} paddingVertical={3}>
-        <Text size="medium">Recent activity</Text>
-        <Activities address={props.asset.address} />
-      </Container>
-    </SlackSheet>
+  return useMemo(
+    () => (
+      <SlackSheet flex={1} scrollEnabled>
+        <Container paddingHorizontal={5} paddingVertical={3}>
+          <Text size="medium">Recent activity</Text>
+          <Activities address={props.asset.address} />
+        </Container>
+      </SlackSheet>
+    ),
+    [props.asset.address]
   );
 }
 

--- a/src/components/expanded-state/UnclaimedRevenueExpandedState.tsx
+++ b/src/components/expanded-state/UnclaimedRevenueExpandedState.tsx
@@ -1,7 +1,7 @@
 import { getSDK } from '@cardstack/cardpay-sdk';
 import BigNumber from 'bignumber.js';
 import HDWalletProvider from 'parity-hdwallet-provider';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import CoinIcon from 'react-coin-icon';
 import { ActivityIndicator, RefreshControl, SectionList } from 'react-native';
 import Web3 from 'web3';
@@ -103,23 +103,33 @@ export default function UnclaimedRevenueExpandedState(props: {
     setLoading(false);
   }, [merchantSafe.address, network, revenueBalances, selectedWallet.id]);
 
-  return (
-    <SlackSheet flex={1} scrollEnabled>
-      <Container paddingHorizontal={5} paddingVertical={3}>
-        <Text size="medium">Unclaimed revenue</Text>
-        <Container flexDirection="column" marginTop={5}>
-          {revenueBalances.map(token => (
-            <TokenItem key={token.tokenAddress} token={token} />
-          ))}
+  const nativeAmount = revenueBalances[0].native.balance.amount;
+  const isDust = parseFloat(nativeAmount) < 0.01;
+  return useMemo(
+    () => (
+      <SlackSheet flex={1} scrollEnabled>
+        <Container paddingHorizontal={5} paddingVertical={3}>
+          <Text size="medium">Unclaimed revenue</Text>
+          <Container flexDirection="column" marginTop={5}>
+            {revenueBalances.map(token => (
+              <TokenItem key={token.tokenAddress} token={token} />
+            ))}
+          </Container>
+          <Button
+            loading={loading}
+            marginTop={8}
+            onPress={isDust ? () => {} : onClaimAll}
+            variant={isDust ? 'disabled' : undefined}
+          >
+            Claim All
+          </Button>
+          <HorizontalDivider />
+          <Text size="medium">Activities</Text>
+          <Activities address={props.asset.address} />
         </Container>
-        <Button loading={loading} marginTop={8} onPress={onClaimAll}>
-          Claim All
-        </Button>
-        <HorizontalDivider />
-        <Text size="medium">Activities</Text>
-        <Activities address={props.asset.address} />
-      </Container>
-    </SlackSheet>
+      </SlackSheet>
+    ),
+    [props.asset]
   );
 }
 


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

1) Rounding unclaimed revenue needs an extra parameter (buffer) to round to `0.00`. That should only happen if the value is < 0.001

2) Dismiss modal is buggy because redux was updating the async state update on FallBackExplorer (
```
store.dispatch(addressAssetsReceived(
```
and that disables dismissing the <Slacksheet /> modal  if it's on fullscreen state

The fix was to use `useMemo` in order to avoid re-renders and, hence, incompatibilities with the modal

That was a bug that was happening to `ALL` modals. 

If you want to reproduce it, (you can see it on Testflight 282):
- start the app
- go to any modal right away 
- pull up to make it fullscreen and wait
- screen will blink (re-render) and won't be able to dismiss the modal

<!-- Include a summary of the changes. -->

### Checklist

- [X] Completes #(1848) #(1883)

- [X] All UI changes have been tested on a small device

### Screenshots
<!-- Screenshots or animated GIFs included here -->
![image](https://user-images.githubusercontent.com/8547776/133712417-5fbdb0d1-4819-4c75-8832-7966db966a4c.png)

![image](https://user-images.githubusercontent.com/8547776/133709486-af117ac2-741e-4e3c-91b7-e213e69b592d.png)

![Sep-16-2021 22-49-20](https://user-images.githubusercontent.com/8547776/133711203-1a7de65f-7ee5-4cf1-ad1d-c41adb6e3083.gif)
![Sep-16-2021 22-54-21](https://user-images.githubusercontent.com/8547776/133711425-aeee991a-5681-4444-be13-16556888395d.gif)


