### PR TITLE
[CS-1874] [CS-1856] Dismiss drilled down modal without dismissing previous one

### DIFF
--- a/cardstack/src/components/Transactions/Merchant/MerchantClaimTransaction.tsx
+++ b/cardstack/src/components/Transactions/Merchant/MerchantClaimTransaction.tsx
@@ -26,7 +26,7 @@ export const MerchantClaimTransaction = ({
 
   const onPressTransaction = useCallback(
     (assetProps: TransactionBaseProps) =>
-      navigate(Routes.EXPANDED_ASSET_SHEET, {
+      navigate(Routes.EXPANDED_ASSET_SHEET_DRILL, {
         asset: { ...assetProps },
         type: 'merchantTransaction',
       }),

--- a/cardstack/src/components/Transactions/Merchant/MerchantEarnedRevenueTransaction.tsx
+++ b/cardstack/src/components/Transactions/Merchant/MerchantEarnedRevenueTransaction.tsx
@@ -23,7 +23,7 @@ export const MerchantEarnedRevenueTransaction = ({
 
   const onPressTransaction = useCallback(
     (assetProps: TransactionBaseProps) =>
-      navigate(Routes.EXPANDED_ASSET_SHEET, {
+      navigate(Routes.EXPANDED_ASSET_SHEET_DRILL, {
         asset: { ...assetProps },
         type: 'merchantTransaction',
       }),

--- a/cardstack/src/components/Transactions/Merchant/MerchantEarnedSpendAndRevenueTransaction.tsx
+++ b/cardstack/src/components/Transactions/Merchant/MerchantEarnedSpendAndRevenueTransaction.tsx
@@ -44,7 +44,7 @@ export const MerchantEarnedSpendAndRevenueTransaction = ({
           </Container>
           <Container flexDirection="row" alignItems="center">
             <Text size="xs" weight="extraBold" marginRight={2}>
-              {`- ${item.balance.display}`}
+              {`+ ${item.balance.display}`}
             </Text>
             <CoinIcon
               address={item.token.address}

--- a/src/navigation/Routes.ios.js
+++ b/src/navigation/Routes.ios.js
@@ -288,6 +288,11 @@ function NativeStackNavigator() {
         {...expandedAssetSheetConfig}
       />
       <NativeStack.Screen
+        component={ExpandedAssetSheet}
+        name={Routes.EXPANDED_ASSET_SHEET_DRILL}
+        {...expandedAssetSheetConfig}
+      />
+      <NativeStack.Screen
         component={SpeedUpAndCancelSheet}
         name={Routes.SPEED_UP_AND_CANCEL_SHEET}
         options={{

--- a/src/navigation/routesNames.js
+++ b/src/navigation/routesNames.js
@@ -18,6 +18,7 @@ const Routes = {
   EXCHANGE_MODAL: 'ExchangeModal',
   EXPANDED_ASSET_SCREEN: 'ExpandedAssetScreen',
   EXPANDED_ASSET_SHEET: 'ExpandedAssetSheet',
+  EXPANDED_ASSET_SHEET_DRILL: 'ExpandedAssetSheetDrill',
   IMPORT_SCREEN: 'ImportScreen',
   IMPORT_SEED_PHRASE_SHEET: 'ImportSeedPhraseSheet',
   IMPORT_SEED_PHRASE_SHEET_NAVIGATOR: 'ImportSeedPhraseSheetNavigator',


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

- 1874 - Bug: Transactions related to receiving payments show a (-) and need to show a (+)

- 1856 - Modals now are opened in different stances - created a new Stack for drilled down sheets so it won't be a re-render of the same modal from previous screen)

<!-- Include a summary of the changes. -->

- [X] Completes #(1874) #(1856)

### Checklist

- [X] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

![ezgif-7-f2113712e61a](https://user-images.githubusercontent.com/8547776/134272801-e25b13d1-5f23-464a-8b7b-43df3665fc27.gif)


