### PR TITLE
[CS-1721] [CS-1891] Add test coverage for merchant payment flow functions, services and Round Spend value

### DIFF
--- a/cardstack/src/components/Input/InputAmount.tsx
+++ b/cardstack/src/components/Input/InputAmount.tsx
@@ -49,17 +49,23 @@ export const InputAmount = memo(
     return (
       <CenteredContainer flexDirection="row" width="100%" {...containerProps}>
         {hasCurrencySymbol ? (
-          <Text
-            color={inputValue ? 'black' : 'underlineGray'}
-            fontWeight="bold"
-            paddingRight={1}
-            paddingTop={1}
-            size="largeBalance"
+          <Container
+            justifyContent="flex-start"
+            alignItems="center"
+            height="100%"
           >
-            {nativeCurrency === 'SPD'
-              ? '§'
-              : (supportedNativeCurrencies as any)[nativeCurrency].symbol}
-          </Text>
+            <Text
+              color={inputValue ? 'black' : 'underlineGray'}
+              fontWeight="bold"
+              paddingRight={1}
+              paddingTop={1}
+              size="largeBalance"
+            >
+              {nativeCurrency === 'SPD'
+                ? '§'
+                : (supportedNativeCurrencies as any)[nativeCurrency].symbol}
+            </Text>
+          </Container>
         ) : null}
         <Container flex={1} flexGrow={1}>
           <Input
@@ -71,7 +77,7 @@ export const InputAmount = memo(
             fontSize={30}
             fontWeight="bold"
             keyboardType="numeric"
-            maxLength={(inputValue || '').length + 2} // just to avoid possible flicker issue
+            maxLength={(inputValue || '').length + 1} // just to avoid possible flicker issue
             multiline
             onChangeText={onChangeText}
             placeholder="0.00"

--- a/cardstack/src/hooks/merchant/__tests__/usePaymentMerchantUniversalLink.test.ts
+++ b/cardstack/src/hooks/merchant/__tests__/usePaymentMerchantUniversalLink.test.ts
@@ -1,0 +1,127 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRoute } from '@react-navigation/native';
+import { updatedData } from '../../../../test/helpers/mocks/dataMocks';
+import { usePaymentMerchantUniversalLink } from '../usePaymentMerchantUniversalLink';
+import { useRainbowSelector } from '@rainbow-me/redux/hooks';
+import { getSafeData } from '@cardstack/services';
+
+const mockedDID = {
+  did: 'did',
+  name: 'Merchant Name',
+  slug: 'Merchant slug',
+  color: 'blue',
+  textColor: 'white',
+  ownerAddress: '0x00000000000',
+};
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ goBack: jest.fn() }),
+  useRoute: jest.fn(),
+}));
+
+jest.mock('@rainbow-me/hooks', () => ({
+  useWallets: () => ({ selectedWallet: 'fooSelectedWallet' }),
+}));
+
+jest.mock('@rainbow-me/redux/hooks', () => ({
+  useRainbowSelector: jest.fn(),
+}));
+
+jest.mock('@cardstack/models/safes-providers', () => ({
+  getSafesInstance: jest.fn(),
+}));
+
+jest.mock('@cardstack/services', () => ({
+  getSafeData: jest.fn(),
+}));
+
+jest.mock('@cardstack/utils', () => ({
+  useWorker: () => ({
+    callback: jest.fn(),
+    error: false,
+    isLoading: false,
+    setError: jest.fn(),
+    setIsLoading: jest.fn(),
+  }),
+  deviceUtils: { isIOS14: false },
+}));
+
+describe('usePaymentMerchantUniversalLink', () => {
+  beforeEach(() => {
+    (useRainbowSelector as jest.Mock).mockImplementation(
+      () => updatedData.updatedPrepaidCards
+    );
+
+    (getSafeData as jest.Mock).mockImplementation(() => ({
+      infoDID: mockedDID,
+    }));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call usePaymentMerchantUniversalLink', async () => {
+    (useRoute as jest.Mock).mockImplementation(() => ({
+      params: {
+        merchantAddress: '0x7bAeEbbd7Fd1f41f3DA69A08f8E053C8CCBb592b',
+        network: 'sokol',
+        amount: 100,
+        currency: 'SPD',
+      },
+    }));
+
+    const { result } = renderHook(() => usePaymentMerchantUniversalLink());
+
+    expect(result.current.prepaidCards.length).toBe(
+      updatedData.updatedPrepaidCards.length
+    );
+
+    expect(result.current.data).toStrictEqual({
+      type: 'payMerchant',
+      infoDID: undefined,
+      spendAmount: 100,
+      merchantSafe: '0x7bAeEbbd7Fd1f41f3DA69A08f8E053C8CCBb592b',
+      currency: 'SPD',
+    });
+  });
+
+  it('should call usePaymentMerchantUniversalLink and return SPD if no currency specified in url', async () => {
+    (useRoute as jest.Mock).mockImplementation(() => ({
+      params: {
+        merchantAddress: '0x7bAeEbbd7Fd1f41f3DA69A08f8E053C8CCBb592b',
+        network: 'sokol',
+        amount: 100,
+      },
+    }));
+
+    const { result } = renderHook(() => usePaymentMerchantUniversalLink());
+
+    expect(result.current.data.currency).toBe('SPD');
+  });
+
+  it('should call usePaymentMerchantUniversalLink and return amount 0 if no amount is provided in url', async () => {
+    (useRoute as jest.Mock).mockImplementation(() => ({
+      params: {
+        merchantAddress: '0x7bAeEbbd7Fd1f41f3DA69A08f8E053C8CCBb592b',
+        network: 'sokol',
+      },
+    }));
+
+    const { result } = renderHook(() => usePaymentMerchantUniversalLink());
+
+    expect(result.current.data.spendAmount).toBe(0);
+  });
+
+  it('should call usePaymentMerchantUniversalLink and return network sokol if no network is provided in url', async () => {
+    (useRoute as jest.Mock).mockImplementation(() => ({
+      params: {
+        merchantAddress: '0x7bAeEbbd7Fd1f41f3DA69A08f8E053C8CCBb592b',
+      },
+    }));
+
+    const { result } = renderHook(() => usePaymentMerchantUniversalLink());
+
+    expect(result.current.data.spendAmount).toBe(0);
+  });
+});

--- a/cardstack/src/hooks/merchant/__tests__/usePaymentMerchantUniversalLink.test.ts
+++ b/cardstack/src/hooks/merchant/__tests__/usePaymentMerchantUniversalLink.test.ts
@@ -46,6 +46,18 @@ jest.mock('@cardstack/utils', () => ({
   deviceUtils: { isIOS14: false },
 }));
 
+jest.mock('@cardstack/models/web3-instance', () => ({
+  Web3Instance: () => ({
+    get: jest.fn(),
+  }),
+}));
+
+jest.mock('@cardstack/models/hd-provider', () => ({
+  HDProvider: () => ({
+    reset: jest.fn(),
+  }),
+}));
+
 describe('usePaymentMerchantUniversalLink', () => {
   beforeEach(() => {
     (useRainbowSelector as jest.Mock).mockImplementation(

--- a/cardstack/src/hooks/merchant/usePaymentMerchantUniversalLink.ts
+++ b/cardstack/src/hooks/merchant/usePaymentMerchantUniversalLink.ts
@@ -37,6 +37,12 @@ export const usePaymentMerchantUniversalLink = () => {
     params: { merchantAddress, amount = '0', network, currency },
   } = useRoute<RouteType>();
 
+  const networkName: Network = ['sokol', 'xdai'].includes(network)
+    ? network
+    : Network.sokol;
+
+  const currencyName = currency || 'SPD';
+
   const { goBack } = useNavigation();
 
   const [infoDID, setInfoDID] = useState<string | undefined>();
@@ -79,7 +85,7 @@ export const usePaymentMerchantUniversalLink = () => {
     ) => {
       const web3 = await Web3Instance.get({
         selectedWallet,
-        network,
+        network: networkName,
       });
 
       const prepaidCardInstance: PrepaidCard = await getSDK(
@@ -115,9 +121,9 @@ export const usePaymentMerchantUniversalLink = () => {
       infoDID,
       spendAmount,
       merchantSafe: merchantAddress,
-      currency,
+      currency: currencyName,
     }),
-    [infoDID, spendAmount, merchantAddress, currency]
+    [infoDID, spendAmount, merchantAddress, currencyName]
   );
 
   return { prepaidCards, goBack, onConfirm, isLoadingTx, isLoading, data };

--- a/cardstack/src/utils/__tests__/currency-utils.test.ts
+++ b/cardstack/src/utils/__tests__/currency-utils.test.ts
@@ -1,0 +1,90 @@
+import { formatNative, nativeCurrencyToSpend } from '../currency-utils';
+
+jest.mock('../device');
+
+describe('Currency utils', () => {
+  describe('formatNative', () => {
+    it('should return empty string if undefined value is provided', () => {
+      const formattedValue = formatNative(undefined);
+
+      expect(formattedValue).toBe('');
+    });
+
+    it('should return only number if non-number is provided', () => {
+      const formattedValue = formatNative('123A');
+
+      expect(formattedValue).toBe('123');
+    });
+
+    it("should not get rid of .(dot) even if it's not number", () => {
+      const formattedValue = formatNative('12345.');
+
+      expect(formattedValue).toBe('12,345.');
+    });
+
+    it('should return formatted number', () => {
+      const formattedValue = formatNative('12345.6789');
+
+      expect(formattedValue).toBe('12,345.6789');
+    });
+
+    it("should not get rid of 0 at the end if it's after decimal dot", () => {
+      const formattedValue = formatNative('12345.67890');
+
+      expect(formattedValue).toBe('12,345.67890');
+    });
+
+    it('should work for difference currencies', () => {
+      const formattedValue = formatNative('12345.67890', 'SPD');
+
+      expect(formattedValue).toBe('12,345.67890');
+    });
+  });
+
+  describe('nativeCurrencyToSpend', () => {
+    it('should return spend for provided usd', () => {
+      const formattedValue = nativeCurrencyToSpend('1', 1);
+
+      expect(formattedValue).toStrictEqual({
+        tokenBalanceDisplay: '§100',
+        spendAmount: 100,
+      });
+    });
+
+    it('should return spend with suffix for suffix is enabled', () => {
+      const formattedValue = nativeCurrencyToSpend('1', 1, true);
+
+      expect(formattedValue).toStrictEqual({
+        tokenBalanceDisplay: '§100 SPEND',
+        spendAmount: 100,
+      });
+    });
+
+    it('should round and return spend amount', () => {
+      const formattedValue = nativeCurrencyToSpend('0.2345', 1, true);
+
+      expect(formattedValue).toStrictEqual({
+        tokenBalanceDisplay: '§23 SPEND',
+        spendAmount: 23,
+      });
+    });
+
+    it('should round and return spend amount for different currency rate', () => {
+      const formattedValue = nativeCurrencyToSpend('0.2345', 1.2, true);
+
+      expect(formattedValue).toStrictEqual({
+        tokenBalanceDisplay: '§20 SPEND',
+        spendAmount: 20,
+      });
+    });
+
+    it('should return formatted valid spend amount for native formatted input value', () => {
+      const formattedValue = nativeCurrencyToSpend('1,234.1234', 1.2, true);
+
+      expect(formattedValue).toStrictEqual({
+        tokenBalanceDisplay: '§102,844 SPEND',
+        spendAmount: 102844,
+      });
+    });
+  });
+});

--- a/cardstack/src/utils/currency-utils.ts
+++ b/cardstack/src/utils/currency-utils.ts
@@ -1,8 +1,6 @@
 import BigNumber from 'bignumber.js';
-import { formatFixedDecimals } from '@cardstack/cardpay-sdk';
 
 const USD_TO_SPEND_RATE = 100;
-const SPEND_DECIMAL_PLACES = 4;
 
 export const getDollarsFromDai = (dai: number) => dai / 100;
 
@@ -16,6 +14,7 @@ export function localCurrencyToAbsNum(value: string): number {
   return result;
 }
 
+// format amount for amount TextInput box experience
 export function formatNative(value: string | undefined, currency = 'USD') {
   if (!value) {
     return '';
@@ -51,6 +50,7 @@ export const nativeCurrencyToAmountInSpend = (
     ? new BigNumber(localCurrencyToAbsNum(amount))
         .times(USD_TO_SPEND_RATE)
         .div(nativeCurrencyRate)
+        .integerValue() // round spend value to integer
         .toNumber()
     : 0;
 };
@@ -60,17 +60,12 @@ export const nativeCurrencyToSpend = (
   nativeCurrencyRate: number,
   includeSuffix?: boolean
 ) => {
-  const spendAmount = parseFloat(
-    formatFixedDecimals(
-      nativeCurrencyToAmountInSpend(amount, nativeCurrencyRate),
-      SPEND_DECIMAL_PLACES
-    )
-  );
+  const spendAmount = nativeCurrencyToAmountInSpend(amount, nativeCurrencyRate);
 
   return {
     tokenBalanceDisplay: `§${spendAmount.toLocaleString('en-US')}${
       includeSuffix ? ' SPEND' : ''
     }`,
-    spendAmount,
+    spendAmount: spendAmount,
   };
 };

--- a/cardstack/test/components/InputAmount.test.tsx
+++ b/cardstack/test/components/InputAmount.test.tsx
@@ -1,0 +1,82 @@
+import Chance from 'chance';
+import React from 'react';
+
+import { render } from '../test-utils';
+import { Input, InputAmount } from '../../src/components/Input';
+import { Text } from '../../src/components/Text';
+import { Icon } from '../../src/components/Icon';
+import * as utils from '@cardstack/utils';
+
+jest.mock('../../../src/components/animations/ButtonPressAnimation', () =>
+  jest.fn(({ children }) => children)
+);
+
+jest.mock('@cardstack/components/Icon', () => ({
+  Icon: jest.fn(() => null),
+}));
+
+jest.mock('@cardstack/components/Text', () => ({
+  Text: jest.fn(({ children }) => children),
+}));
+
+jest.mock('@cardstack/utils');
+
+const chance = new Chance();
+
+describe('Button', () => {
+  let expectedTextStyle: Record<string, string>,
+    expectedDisabledTextStyle: Record<string, string>;
+
+  const { useVariantValue } = utils as jest.Mocked<typeof utils>;
+
+  beforeEach(() => {
+    expectedTextStyle = {
+      [chance.string()]: chance.string(),
+    };
+
+    expectedDisabledTextStyle = {
+      [chance.string()]: chance.string(),
+    };
+
+    useVariantValue.mockImplementation((themeKey, key) => {
+      if (key === 'disabledTextStyle') {
+        return expectedDisabledTextStyle;
+      }
+
+      return expectedTextStyle;
+    });
+  });
+
+  afterEach(() => {
+    useVariantValue.mockReset();
+  });
+
+  it('should render the children', () => {
+    const inputValue = chance.string();
+    const setInputValue = jest.fn();
+    const nativeCurrency = 'USD';
+
+    const props = {
+      hasCurrencySymbol: false,
+      nativeCurrency: 'USD',
+      inputValue,
+      setInputValue,
+    };
+
+    render(<InputAmount {...props} />);
+
+    expect(Input).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: inputValue,
+      }),
+      {}
+    );
+
+    expect(Text).toHaveBeenCalledWith(
+      expect.objectContaining(nativeCurrency),
+      {}
+    );
+
+    expect(Icon).toHaveBeenCalledTimes(1);
+  });
+});

--- a/cardstack/test/jest-setup.js
+++ b/cardstack/test/jest-setup.js
@@ -1,1 +1,11 @@
 import '@testing-library/jest-native/extend-expect';
+
+jest.mock('react-native-background-timer', () => ({
+  start: jest.fn(),
+  stop: jest.fn(),
+  setTimeout: jest.fn(),
+  clearTimeout: jest.fn(),
+}));
+
+global.ios = true;
+global.android = false;

--- a/cardstack/test/jest-setup.js
+++ b/cardstack/test/jest-setup.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import '@testing-library/jest-native/extend-expect';
 
 jest.mock('react-native-background-timer', () => ({
@@ -5,6 +6,96 @@ jest.mock('react-native-background-timer', () => ({
   stop: jest.fn(),
   setTimeout: jest.fn(),
   clearTimeout: jest.fn(),
+}));
+
+jest.mock('react-native-keychain', () => ({
+  getSupportedBiometryType: jest.fn(),
+  ACCESSIBLE: 'AccessibleAlways',
+}));
+
+jest.mock('react-native-device-info', () => ({
+  DeviceInfo: {
+    isEmulator: () => false,
+  },
+}));
+
+jest.mock('react-native-reanimated', () => {
+  const View = require('react-native/Libraries/Components/View/View');
+  return {
+    Value: jest.fn(),
+    event: jest.fn(),
+    add: jest.fn(),
+    eq: jest.fn(),
+    set: jest.fn(),
+    cond: jest.fn(),
+    interpolate: jest.fn(),
+    View,
+    Extrapolate: { CLAMP: jest.fn() },
+    Clock: jest.fn(),
+    greaterThan: jest.fn(),
+    lessThan: jest.fn(),
+    startClock: jest.fn(),
+    stopClock: jest.fn(),
+    clockRunning: jest.fn(),
+    not: jest.fn(),
+    or: jest.fn(),
+    and: jest.fn(),
+    spring: jest.fn(),
+    decay: jest.fn(),
+    defined: jest.fn(),
+    call: jest.fn(),
+    Code: View,
+    block: jest.fn(),
+    abs: jest.fn(),
+    greaterOrEq: jest.fn(),
+    lessOrEq: jest.fn(),
+    debug: jest.fn(),
+    Easing: {
+      in: jest.fn(),
+      out: jest.fn(),
+    },
+    Transition: {
+      Out: 'Out',
+    },
+  };
+});
+
+jest.mock('react-native-gesture-handler', () => {
+  const View = require('react-native/Libraries/Components/View/View');
+  return {
+    Swipeable: View,
+    DrawerLayout: View,
+    State: {},
+    ScrollView: View,
+    Slider: View,
+    Switch: View,
+    TextInput: View,
+    ToolbarAndroid: View,
+    ViewPagerAndroid: View,
+    DrawerLayoutAndroid: View,
+    WebView: View,
+    NativeViewGestureHandler: View,
+    TapGestureHandler: View,
+    FlingGestureHandler: View,
+    ForceTouchGestureHandler: View,
+    LongPressGestureHandler: View,
+    PanGestureHandler: View,
+    PinchGestureHandler: View,
+    RotationGestureHandler: View,
+    /* Buttons */
+    RawButton: View,
+    BaseButton: View,
+    RectButton: View,
+    BorderlessButton: View,
+    /* Other */
+    FlatList: View,
+    gestureHandlerRootHOC: jest.fn(),
+    Directions: {},
+  };
+});
+
+jest.mock('@react-navigation/material-top-tabs', () => ({
+  createMaterialTopTabNavigator: jest.fn(),
 }));
 
 global.ios = true;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 const { pathsToModuleNameMapper } = require('ts-jest/utils');
-const { compilerOptions } = require('./tsconfig');
+const { compilerOptions } = require('./tsconfig.json');
 
 module.exports = {
   collectCoverageFrom: [


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

- Add test coverage for usePaymentMerchantUniversalLink, currency util funcs, inputAmount(will need to recall this after test's setup properly)
- Round spend amount to nearest whole spend

<!-- Include a summary of the changes. -->

- [x] Completes #CS-1721
- [x] Completes #CS-1891

### Screenshots

<!-- Screenshots or animated GIFs included here -->