### PR TITLE
[CS-1876] - Fix tx update after switching accounts

### DIFF
--- a/cardstack/src/components/TransactionList/TransactionList.tsx
+++ b/cardstack/src/components/TransactionList/TransactionList.tsx
@@ -44,13 +44,13 @@ export const TransactionList = memo(
     }, [refetch]);
 
     useEffect(() => {
-      if (isFocused) {
+      if (isFocused && !isFetchingMore && !refetchLoading) {
         // Wait a bit to refresh to get tx from be
         setTimeout(() => {
           onRefresh();
-        }, 1000);
+        }, 500);
       }
-    }, [onRefresh, isFocused]);
+    }, [onRefresh, isFocused, isFetchingMore, refetchLoading]);
 
     const renderSectionHeader = useCallback(
       ({ section: { title } }) => (

--- a/cardstack/src/components/TransactionList/TransactionList.tsx
+++ b/cardstack/src/components/TransactionList/TransactionList.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useEffect } from 'react';
+import React, { memo, useCallback } from 'react';
 import {
   RefreshControl,
   SectionList,
@@ -42,15 +42,6 @@ export const TransactionList = memo(
     const onRefresh = useCallback(() => {
       refetch && refetch();
     }, [refetch]);
-
-    useEffect(() => {
-      if (isFocused && !isFetchingMore && !refetchLoading) {
-        // Wait a bit to refresh to get tx from be
-        setTimeout(() => {
-          onRefresh();
-        }, 500);
-      }
-    }, [onRefresh, isFocused, isFetchingMore, refetchLoading]);
 
     const renderSectionHeader = useCallback(
       ({ section: { title } }) => (

--- a/cardstack/src/hooks/transactions/use-transaction-sections.tsx
+++ b/cardstack/src/hooks/transactions/use-transaction-sections.tsx
@@ -58,13 +58,24 @@ export const useTransactionSections = ({
     state => state.settings.accountAddress
   );
 
-  const prevLastTransaction = usePrevious(transactions?.[0]?.transaction?.id);
-  const currentLastTransaction = transactions?.[0]?.transaction?.id;
+  const prevLastestTx = usePrevious(transactions?.[0]?.transaction?.id);
+  const currentLastestTx = transactions?.[0]?.transaction?.id;
+
+  const prevTxLength = usePrevious(transactions?.length) || 0;
+  const currentTxLength = transactions?.length || 0;
+
+  const isPagination =
+    prevLastestTx === currentLastestTx && currentTxLength > prevTxLength;
+
+  const isNewtx =
+    prevLastestTx !== currentLastestTx && prevTxLength === currentTxLength;
+
+  const isInitialTx = !prevLastestTx;
 
   // Quick workaround to have merchant tx working
   // TODO: refactor and add tests
   const shouldUpdate =
-    prevLastTransaction !== currentLastTransaction || isMerchantTransaction;
+    isInitialTx || isNewtx || isPagination || isMerchantTransaction;
 
   useEffect(() => {
     const setSectionsData = async () => {
@@ -72,8 +83,11 @@ export const useTransactionSections = ({
         setLoading(true);
 
         try {
-          const merchantSafeAddresses = merchantSafes.map(safe => safe.address);
-          const prepaidCardAddresses = prepaidCards.map(safe => safe.address);
+          const merchantSafeAddresses = merchantSafes?.map(
+            safe => safe.address
+          );
+
+          const prepaidCardAddresses = prepaidCards?.map(safe => safe.address);
 
           const transactionMappingContext = new TransactionMappingContext({
             transactions: merchantSafeAddress
@@ -135,7 +149,7 @@ export const useTransactionSections = ({
   ]);
 
   const isLoading = networkStatus === NetworkStatus.loading || loading;
-  const isFetchingMore = sections.length && isLoading;
+  const isFetchingMore = !!sections.length && isLoading;
 
   const onEndReached = useCallback(() => {
     if (!isFetchingMore && fetchMore) {

--- a/cardstack/src/models/web3-provider.ts
+++ b/cardstack/src/models/web3-provider.ts
@@ -29,9 +29,12 @@ const Web3WsProvider = {
         });
 
         //@ts-ignore it's wrongly typed bc it says it doesn't have param, but it does
-        provider.on('error', e => logger.sentry('WS socket error', e));
+        provider?.on('error', e => logger.sentry('WS socket error', e));
         //@ts-ignore
-        provider.on('end', e => logger.sentry('WS socket ended', e));
+        provider?.on('end', e => {
+          provider?.reconnect();
+          logger.sentry('WS socket ended', e);
+        });
       } catch (error) {
         logger.error('provider error', error);
       }


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

<!-- Include a summary of the changes. -->

Fixes the tx update after switching accounts, the validation with current/prev values was missing a case, when both values are undefined so once a account had no values, switching to one that have it wouldn't update because undefined === undefined, also remove the auto refresh, because for some reason I don't understand when we open the modal to switch between accounts it sets isFocused to true, which triggers the refresh, and we don't want that while the user is switching account because you may get the other account transactions. 
Also added a reconnect when the ws ends to see if we get less errors related to that.

- [x] Completes #(Linear ticket)
![tx-update](https://user-images.githubusercontent.com/20520102/134587853-921148d8-f3a8-4aaa-82df-d60b2f66becc.gif)


