### PR TITLE
[CS-1838][CS-1900] - Handle deep link when app is closed and update info

### DIFF
--- a/cardstack/src/hooks/merchant/__tests__/usePaymentMerchantUniversalLink.test.ts
+++ b/cardstack/src/hooks/merchant/__tests__/usePaymentMerchantUniversalLink.test.ts
@@ -21,6 +21,7 @@ jest.mock('@react-navigation/native', () => ({
 
 jest.mock('@rainbow-me/hooks', () => ({
   useWallets: () => ({ selectedWallet: 'fooSelectedWallet' }),
+  useAssetListData: () => ({ isLoadingAssets: false }),
 }));
 
 jest.mock('@rainbow-me/redux/hooks', () => ({

--- a/cardstack/src/hooks/merchant/usePaymentMerchantUniversalLink.ts
+++ b/cardstack/src/hooks/merchant/usePaymentMerchantUniversalLink.ts
@@ -13,7 +13,7 @@ import { getSafeData } from '@cardstack/services';
 import { useWorker } from '@cardstack/utils';
 import { Network } from '@rainbow-me/helpers/networkTypes';
 import { useRainbowSelector } from '@rainbow-me/redux/hooks';
-import { useWallets } from '@rainbow-me/hooks';
+import { useAssetListData, useWallets } from '@rainbow-me/hooks';
 import Web3Instance from '@cardstack/models/web3-instance';
 import HDProvider from '@cardstack/models/hd-provider';
 
@@ -51,6 +51,8 @@ export const usePaymentMerchantUniversalLink = () => {
     state => state.data.prepaidCards
   );
 
+  const { isLoadingAssets } = useAssetListData();
+
   const { selectedWallet } = useWallets();
 
   const spendAmount = parseFloat(amount);
@@ -64,7 +66,11 @@ export const usePaymentMerchantUniversalLink = () => {
   }, [merchantAddress]);
 
   useEffect(() => {
-    if (prepaidCards.length === 0) {
+    getMerchantSafeData();
+  }, [getMerchantSafeData]);
+
+  useEffect(() => {
+    if (!isLoadingAssets && prepaidCards.length === 0) {
       handleAlertError(
         `You don't own a Prepaid card!\nYou can create one at app.cardstack.com`
       );
@@ -73,9 +79,7 @@ export const usePaymentMerchantUniversalLink = () => {
 
       return;
     }
-
-    getMerchantSafeData();
-  }, [getMerchantSafeData, goBack, prepaidCards.length]);
+  }, [isLoadingAssets, goBack, prepaidCards.length]);
 
   const { isLoading: isLoadingTx, callback: onConfirm, error } = useWorker(
     async (
@@ -126,5 +130,12 @@ export const usePaymentMerchantUniversalLink = () => {
     [infoDID, spendAmount, merchantAddress, currencyName]
   );
 
-  return { prepaidCards, goBack, onConfirm, isLoadingTx, isLoading, data };
+  return {
+    prepaidCards,
+    goBack,
+    onConfirm,
+    isLoadingTx,
+    isLoading: isLoading || isLoadingAssets,
+    data,
+  };
 };

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -14,6 +14,7 @@ import {
 } from '@cardstack/screen';
 import { expandedPreset, sheetPreset } from '@rainbow-me/navigation/effects';
 import { nativeStackModalConfig } from '@rainbow-me/navigation/config';
+import RainbowRoutes from '@rainbow-me/navigation/routesNames';
 
 interface ScreenNavigation {
   component: React.ComponentType<any>;
@@ -74,7 +75,16 @@ export const linking = {
   ],
   config: {
     screens: {
-      [MainRoutes.PAY_MERCHANT]: 'pay/:network/:merchantAddress',
+      [RainbowRoutes.STACK]: {
+        screens: {
+          [RainbowRoutes.MAIN_NAVIGATOR]: {
+            initialRouteName: RainbowRoutes.SWIPE_LAYOUT,
+            screens: {
+              [MainRoutes.PAY_MERCHANT]: 'pay/:network/:merchantAddress',
+            },
+          },
+        },
+      },
     },
   },
 };

--- a/cardstack/src/screens/PayMerchant/ChoosePrepaidCard.tsx
+++ b/cardstack/src/screens/PayMerchant/ChoosePrepaidCard.tsx
@@ -19,7 +19,7 @@ import { hitSlop } from '@cardstack/utils/layouts';
 
 export interface ChoosePrepaidCardProps {
   prepaidCards: PrepaidCardType[];
-  selectedCard: PrepaidCardType;
+  selectedCard?: PrepaidCardType;
   onSelectPrepaidCard: (prepaidCard: PrepaidCardType) => void;
   spendAmount: number;
   onPressEditAmount: () => void;
@@ -56,7 +56,7 @@ const ChoosePrepaidCard = ({
       <PrepaidCardItem
         item={item}
         onPress={onSelect}
-        selectedAddress={selectedCard.address}
+        selectedAddress={selectedCard?.address}
         networkName={networkName}
         nativeCurrency={nativeCurrency}
         currencyConversionRates={currencyConversionRates}
@@ -70,7 +70,7 @@ const ChoosePrepaidCard = ({
       networkName,
       onSelect,
       prepaidCards.length,
-      selectedCard.address,
+      selectedCard,
       spendAmount,
     ]
   );
@@ -145,7 +145,7 @@ const Header = memo(
 interface PrepaidCardItemProps {
   item: PrepaidCardType;
   onPress: (item: PrepaidCardType) => void;
-  selectedAddress: string;
+  selectedAddress?: string;
   networkName: string;
   nativeCurrency: string;
   currencyConversionRates: {

--- a/cardstack/src/screens/PayMerchant/PayMerchant.tsx
+++ b/cardstack/src/screens/PayMerchant/PayMerchant.tsx
@@ -37,6 +37,8 @@ const PayMerchant = memo(() => {
     onStepChange,
     onSelectPrepaidCard,
     setInputValue,
+    onAmountNext,
+    onCancelConfirmation,
   } = usePayMerchant();
 
   if (isLoading) {
@@ -47,11 +49,12 @@ const PayMerchant = memo(() => {
     );
   }
 
-  if (payStep === PAY_STEP.EDIT_AMOUNT) {
+  // Checking cards length to avoid keyboard flickring case user has no cards
+  if (payStep === PAY_STEP.EDIT_AMOUNT && !!prepaidCards.length) {
     return (
       <CustomAmountBody
         merchantInfoDID={merchantInfoDID}
-        onNextPress={onStepChange(PAY_STEP.CHOOSE_PREPAID_CARD)}
+        onNextPress={onAmountNext}
         inputValue={inputValue}
         setInputValue={setInputValue}
         isLoading={isLoading}
@@ -60,13 +63,13 @@ const PayMerchant = memo(() => {
     );
   }
 
-  if (payStep === PAY_STEP.CONFIRMATION && prepaidCards.length > 0) {
+  if (payStep === PAY_STEP.CONFIRMATION) {
     return (
       <TransactionConfirmationSheet
         loading={isLoading}
         onConfirmLoading={onConfirmLoading}
         data={txSheetData}
-        onCancel={onStepChange(PAY_STEP.CHOOSE_PREPAID_CARD)}
+        onCancel={onCancelConfirmation}
         onConfirm={onConfirm}
       />
     );

--- a/cardstack/src/screens/PayMerchant/PayMerchant.tsx
+++ b/cardstack/src/screens/PayMerchant/PayMerchant.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from 'react';
+import { ActivityIndicator } from 'react-native';
 import ChoosePrepaidCard from './ChoosePrepaidCard';
 import { usePayMerchant, PAY_STEP } from './usePayMerchant';
 import MerchantSectionCard from '@cardstack/components/TransactionConfirmationSheet/displays/components/sections/MerchantSectionCard';
@@ -10,6 +11,7 @@ import {
   Text,
   Button,
   TransactionConfirmationSheet,
+  CenteredContainer,
 } from '@cardstack/components';
 import { MerchantInformation } from '@cardstack/types';
 import {
@@ -36,6 +38,14 @@ const PayMerchant = memo(() => {
     onSelectPrepaidCard,
     setInputValue,
   } = usePayMerchant();
+
+  if (isLoading) {
+    return (
+      <CenteredContainer flex={1}>
+        <ActivityIndicator size="large" />
+      </CenteredContainer>
+    );
+  }
 
   if (payStep === PAY_STEP.EDIT_AMOUNT) {
     return (

--- a/cardstack/src/screens/PayMerchant/usePayMerchant.ts
+++ b/cardstack/src/screens/PayMerchant/usePayMerchant.ts
@@ -55,7 +55,17 @@ export const usePayMerchant = () => {
     `${initialSpendAmount ? initialSpendAmount.toString() : 0}`
   );
 
-  const [payStep, setPayStep] = useState<Step>(PAY_STEP.CHOOSE_PREPAID_CARD);
+  const hasMultipleCards = prepaidCards.length > 1;
+
+  const initialStep = hasMultipleCards
+    ? PAY_STEP.CHOOSE_PREPAID_CARD
+    : PAY_STEP.EDIT_AMOUNT;
+
+  const nextStep = hasMultipleCards
+    ? PAY_STEP.CHOOSE_PREPAID_CARD
+    : PAY_STEP.CONFIRMATION;
+
+  const [payStep, setPayStep] = useState<Step>(initialStep);
 
   const { merchantInfoDID } = useMerchantInfoFromDID(infoDID);
   const { paymentChangeCurrency } = usePayment();
@@ -163,6 +173,12 @@ export const usePayMerchant = () => {
     []
   );
 
+  const onCancelConfirmation = useCallback(onStepChange(initialStep), [
+    onStepChange,
+  ]);
+
+  const onAmountNext = useCallback(onStepChange(nextStep), [onStepChange]);
+
   const txSheetData = useMemo(
     () => ({
       ...data,
@@ -184,9 +200,12 @@ export const usePayMerchant = () => {
     prepaidCards,
     isLoading,
     onConfirmLoading,
+    hasMultipleCards,
     onConfirm: onCustomConfirm,
     onStepChange,
     onSelectPrepaidCard,
     setInputValue,
+    onCancelConfirmation,
+    onAmountNext,
   };
 };

--- a/cardstack/src/utils/__tests__/merchant-utils.test.ts
+++ b/cardstack/src/utils/__tests__/merchant-utils.test.ts
@@ -4,7 +4,6 @@ import {
   generateMerchantPaymentUrl,
   getMerchantClaimTransactionDetails,
   getMerchantEarnedTransactionDetails,
-  parseMerchantPaymentDeepLinkUrl,
   shareRequestPaymentLink,
 } from '../merchant-utils';
 import {
@@ -131,22 +130,6 @@ describe('Merchant utils', () => {
         protocolFee: '0.0025 DAI',
         protocolFeeUsd: '$0.0025 USD',
         spendConversionRate: '$0.01 USD',
-      });
-    });
-  });
-
-  describe('Parse Merchant Payment deeplink url', () => {
-    const merchantPaymentDeepLink =
-      'cardwallet://pay/sokol/0x4721BeE9248389393460344Ff03f218Aee44a05c?amount=12300&currency=SPD';
-
-    it('Should return merchant payment info for the provided deeplink url', () => {
-      expect(
-        parseMerchantPaymentDeepLinkUrl(merchantPaymentDeepLink)
-      ).toStrictEqual({
-        amount: '12300',
-        currency: 'SPD',
-        merchantAddress: '0x4721BeE9248389393460344Ff03f218Aee44a05c',
-        network: 'sokol',
       });
     });
   });

--- a/cardstack/src/utils/merchant-utils.ts
+++ b/cardstack/src/utils/merchant-utils.ts
@@ -210,26 +210,3 @@ export function getMerchantEarnedTransactionDetails(
     ).nativeBalanceDisplay,
   };
 }
-
-export const parseMerchantPaymentDeepLinkUrl = (
-  deeplink: string
-): MerchantPaymentURLParams => {
-  const [merchantInfo, network] = deeplink.split('/').reverse();
-  const [merchantAddress, params] = merchantInfo.split('?');
-
-  // https://stackoverflow.com/questions/8648892/how-to-convert-url-parameters-to-a-javascript-object
-  const parsedParams = JSON.parse(
-    '{"' +
-      decodeURI(params)
-        .replace(/"/g, '\\"')
-        .replace(/&/g, '","')
-        .replace(/[=]/g, '":"') +
-      '"}'
-  );
-
-  return {
-    merchantAddress,
-    network,
-    ...parsedParams,
-  } as MerchantPaymentURLParams;
-};

--- a/src/hooks/useScanner.js
+++ b/src/hooks/useScanner.js
@@ -1,7 +1,11 @@
 import { isValidMerchantPaymentUrl } from '@cardstack/cardpay-sdk';
 import lang from 'i18n-js';
 import { useCallback, useEffect, useState } from 'react';
-import { InteractionManager, Alert as NativeAlert } from 'react-native';
+import {
+  InteractionManager,
+  Linking,
+  Alert as NativeAlert,
+} from 'react-native';
 import { PERMISSIONS, request } from 'react-native-permissions';
 import { Alert } from '../components/alerts';
 import handleDeepLink from '../handlers/deeplinks';
@@ -11,7 +15,6 @@ import { useNavigation } from '../navigation/Navigation';
 import usePrevious from './usePrevious';
 import useWalletConnectConnections from './useWalletConnectConnections';
 import useWallets from './useWallets';
-import { parseMerchantPaymentDeepLinkUrl } from '@cardstack/utils';
 import { enableActionsOnReadOnlyWallet } from '@rainbow-me/config/debug';
 import Routes from '@rainbow-me/routes';
 import { addressUtils, haptics } from '@rainbow-me/utils';
@@ -150,8 +153,8 @@ export default function useScanner(enabled) {
         return handleDeepLink(deeplink.split('?link=')[1]);
       }
       if (isValidMerchantPaymentUrl(deeplink)) {
-        const params = parseMerchantPaymentDeepLinkUrl(deeplink);
-        return navigate(Routes.PAY_MERCHANT, params);
+        haptics.notificationSuccess();
+        return Linking.openURL(deeplink);
       }
       return handleScanInvalid(data);
     },
@@ -161,7 +164,6 @@ export default function useScanner(enabled) {
       handleScanAddress,
       handleScanWalletConnect,
       handleScanInvalid,
-      navigate,
     ]
   );
 


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
We have nested navigators and although the previous config seemed correct because it was working when app was open, once it's closed it doesn't know where to go, plus when it's closed we don't have the prepaidCards and stuff ready yet when we go to the screen, so this PR:

- Opens app on right screen when it's closed 
- Adds loading on deep link cold start, to get redux data, there's a workaround with fake loading (open to suggestions if anyone has a better idea), because on first render prepaidcards are empty
- With the right link path, now we can use the `Linking.openUrl` to handle the QRcode
- Added hepatics when QR code is recognized
Update
- Handles single prepaid card case, if user has only one card it goes to InputScreen directly
- 
<!-- Include a summary of the changes. -->

- [x] Completes #(CS-1838)
- [x] Completes #(CS-1900)

### Screenshots

<!-- Screenshots or animated GIFs included here -->
Open QR code app closed:
![pay-merchant-close](https://user-images.githubusercontent.com/20520102/134691372-3746fad8-c3cf-497f-9e57-63735a5cf0b8.gif)
Open a different QR code:
![pay-merchant-update](https://user-images.githubusercontent.com/20520102/134691395-0a880d9d-c4f9-4e35-8205-6d3c395b5c1c.gif)
Single card: 
![single-card](https://user-images.githubusercontent.com/20520102/134741084-72cb0514-7e36-4201-a67f-20bf22c00131.gif)


