### PR TITLE
[Fix]: Build on xcode 13 using M1

### DIFF
--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -1055,10 +1055,6 @@
 				INFOPLIST_FILE = Rainbow/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)",
-				);
 				LLVM_LTO = YES;
 				MARKETING_VERSION = 1.0.2;
 				OTHER_CFLAGS = (
@@ -1114,10 +1110,6 @@
 				INFOPLIST_FILE = Rainbow/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)",
-				);
 				LLVM_LTO = YES;
 				MARKETING_VERSION = 1.0.2;
 				OTHER_CFLAGS = (
@@ -1208,10 +1200,6 @@
 				INFOPLIST_FILE = Rainbow/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)",
-				);
 				LLVM_LTO = YES;
 				MARKETING_VERSION = 1.0.2;
 				OTHER_CFLAGS = (
@@ -1303,10 +1291,6 @@
 				INFOPLIST_FILE = Rainbow/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)",
-				);
 				LLVM_LTO = YES;
 				MARKETING_VERSION = 1.0.2;
 				OTHER_CFLAGS = (


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Apple Silicon builds require a library path tweak for Swift library discovery, otherwise it throws an error, this fix is based on this [RN commit](https://github.com/facebook/react-native/commit/eb938863063f5535735af2be4e706f70647e5b90)

