### PR TITLE
[CS-1918] - Enforce light-content statusbar

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,3 +13,7 @@
 ### Screenshots
 
 <!-- Screenshots or animated GIFs included here -->
+
+<!-- Use this tag to format the screenshot size
+
+<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

--- a/src/App.js
+++ b/src/App.js
@@ -58,7 +58,7 @@ import Logger from 'logger';
 import { Portal } from 'react-native-cool-modals/Portal';
 const WALLETCONNECT_SYNC_DELAY = 500;
 
-StatusBar.pushStackEntry({ animated: true, barStyle: 'dark-content' });
+StatusBar.pushStackEntry({ animated: true, barStyle: 'light-content' });
 
 if (__DEV__) {
   reactNativeDisableYellowBox && LogBox.ignoreAllLogs();

--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -5,7 +5,7 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { LayoutAnimation, NativeModules, StatusBar } from 'react-native';
+import { LayoutAnimation, NativeModules } from 'react-native';
 import { ThemeProvider } from 'styled-components';
 
 import { getTheme, saveTheme } from '../handlers/localstorage/theme';
@@ -44,12 +44,6 @@ export const MainThemeProvider = props => {
     const loadUserPref = async () => {
       const userPref = (await getTheme()) || THEMES.LIGHT;
       const userPrefSystemAdjusted = 'light';
-      StatusBar.setBarStyle(
-        userPrefSystemAdjusted === THEMES.DARK
-          ? 'light-content'
-          : 'dark-content',
-        true
-      );
       currentColors.theme = userPrefSystemAdjusted;
       currentColors.themedColors =
         userPrefSystemAdjusted === THEMES.DARK
@@ -82,12 +76,6 @@ export const MainThemeProvider = props => {
       setTheme: scheme => {
         const schemeSystemAdjusted = 'light';
         currentColors.theme = schemeSystemAdjusted;
-        StatusBar.setBarStyle(
-          schemeSystemAdjusted === THEMES.DARK
-            ? 'light-content'
-            : 'dark-content',
-          true
-        );
         currentColors.themedColors =
           schemeSystemAdjusted === THEMES.DARK
             ? darkModeThemeColors

--- a/src/hooks/useHideSplashScreen.js
+++ b/src/hooks/useHideSplashScreen.js
@@ -14,7 +14,6 @@ export default function useHideSplashScreen() {
     if (android) {
       StatusBar.setBackgroundColor('transparent', false);
       StatusBar.setTranslucent(true);
-      StatusBar.setBarStyle('dark-content', true);
     }
     // show the StatusBar
     (ios && StatusBar.setHidden(false, 'fade')) ||

--- a/src/navigation/nativeStackConfig.js
+++ b/src/navigation/nativeStackConfig.js
@@ -1,5 +1,4 @@
-import { Keyboard, StatusBar } from 'react-native';
-import currentColors from '../context/currentColors';
+import { Keyboard } from 'react-native';
 import { onDidPop, onWillPop } from './Navigation';
 import { appearListener } from './nativeStackHelpers';
 
@@ -22,9 +21,6 @@ export const nativeStackConfig = {
     },
     onWillDismiss: () => {
       onWillPop();
-      if (currentColors.theme === 'light') {
-        StatusBar.setBarStyle('dark-content');
-      }
     },
     showDragIndicator: false,
     springDamping: 0.8,

--- a/src/navigation/onNavigationStateChange.js
+++ b/src/navigation/onNavigationStateChange.js
@@ -8,7 +8,6 @@ import Routes from './routesNames';
 import { Navigation } from './index';
 
 let memRouteName;
-let memState;
 
 let action = null;
 
@@ -27,9 +26,7 @@ export function triggerOnSwipeLayout(newAction) {
   }
 }
 
-export function onNavigationStateChange(currentState) {
-  const prevState = memState;
-  memState = currentState;
+export function onNavigationStateChange() {
   const { name: routeName } = Navigation.getActiveRoute();
   if (isOnSwipeScreen(routeName)) {
     action?.();
@@ -41,81 +38,24 @@ export function onNavigationStateChange(currentState) {
   if (currentColors.theme === 'dark') {
     StatusBar.setBarStyle('light-content');
   } else {
-    if (ios) {
-      const oldBottomSheetStackRoute = prevState?.routes[prevState.index].name;
-      const newBottomSheetStackRoute =
-        currentState?.routes[currentState.index].name;
-
-      const wasCustomSlackOpen =
-        oldBottomSheetStackRoute === Routes.CONFIRM_REQUEST ||
-        oldBottomSheetStackRoute === Routes.RECEIVE_MODAL ||
-        oldBottomSheetStackRoute === Routes.SETTINGS_MODAL;
-      const isCustomSlackOpen =
-        newBottomSheetStackRoute === Routes.CONFIRM_REQUEST ||
-        newBottomSheetStackRoute === Routes.RECEIVE_MODAL ||
-        newBottomSheetStackRoute === Routes.SETTINGS_MODAL;
-
-      if (wasCustomSlackOpen !== isCustomSlackOpen) {
-        StatusBar.setBarStyle(
-          wasCustomSlackOpen ? 'dark-content' : 'light-content'
-        );
+    if (android && routeName !== prevRouteName) {
+      if (
+        routeName === Routes.MAIN_EXCHANGE_SCREEN ||
+        routeName === Routes.SAVINGS_WITHDRAW_MODAL ||
+        routeName === Routes.SEND_SHEET ||
+        routeName === Routes.SPEND_SHEET ||
+        routeName === Routes.SWAP_DETAILS_SCREEN
+      ) {
+        AndroidKeyboardAdjust.setAdjustPan();
+      } else {
+        AndroidKeyboardAdjust.setAdjustResize();
       }
-    } else {
-      if (routeName !== prevRouteName) {
-        if ([prevRouteName, routeName].includes(Routes.RECEIVE_MODAL)) {
-          StatusBar.setBarStyle(
-            routeName === Routes.RECEIVE_MODAL
-              ? 'light-content'
-              : 'dark-content',
-            true
-          );
-        }
 
-        if (
-          routeName === Routes.MAIN_EXCHANGE_SCREEN ||
-          routeName === Routes.SAVINGS_WITHDRAW_MODAL ||
-          routeName === Routes.SEND_SHEET ||
-          routeName === Routes.SPEND_SHEET ||
-          routeName === Routes.SWAP_DETAILS_SCREEN
-        ) {
-          AndroidKeyboardAdjust.setAdjustPan();
-        } else {
-          AndroidKeyboardAdjust.setAdjustResize();
-        }
-
-        if ([prevRouteName, routeName].includes(Routes.QR_SCANNER_SCREEN)) {
-          StatusBar.setBarStyle(
-            routeName === Routes.QR_SCANNER_SCREEN
-              ? 'light-content'
-              : 'dark-content',
-            true
-          );
-        }
-
-        if ([prevRouteName, routeName].includes(Routes.BACKUP_SHEET)) {
-          StatusBar.setBarStyle(
-            !isOnSwipeScreen(routeName) ? 'light-content' : 'dark-content',
-            true
-          );
-        }
-
-        if ([prevRouteName, routeName].includes(Routes.SAVINGS_SHEET)) {
-          StatusBar.setBarStyle(
-            !isOnSwipeScreen(routeName) ? 'light-content' : 'dark-content',
-            true
-          );
-        }
-
-        if (
-          routeName === Routes.EXPANDED_ASSET_SHEET &&
-          Navigation.getActiveRoute().params.type === 'uniswap'
-        ) {
-          StatusBar.setBarStyle('light-content', true);
-        }
-
-        if (prevRouteName === Routes.EXPANDED_ASSET_SHEET) {
-          StatusBar.setBarStyle('dark-content', true);
-        }
+      if (
+        routeName === Routes.EXPANDED_ASSET_SHEET &&
+        Navigation.getActiveRoute().params.type === 'uniswap'
+      ) {
+        StatusBar.setBarStyle('light-content', true);
       }
     }
   }


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

 Rainbow seems to have support for dark/light mode, but our app defaults to light mode, when most of the screens are actually dark, I thought about setting the mode to dark, but was not sure the impact it might have across the whole application, so as discussed in the last mobile meeting, we are temp removing the conditions, if we want to support dark/light mode in the near future we can just reference this PR, or get rid of the whole theme.

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-1918)

<img width="300" alt="Screen Shot 2021-10-04 at 18 35 19" src="https://user-images.githubusercontent.com/20520102/136068496-f71f6f3e-f6d4-4230-87da-6e234251de75.png">

<img width="300" alt="Screen Shot 2021-10-04 at 18 35 19" src="https://user-images.githubusercontent.com/20520102/136068425-55bf64de-2232-4843-9a85-175506bd4667.png">

