### PR TITLE
[Chore]:  Create reduxLogger middleware

### DIFF
--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -4,15 +4,42 @@ import thunk from 'redux-thunk';
 import reducers from './reducers';
 
 const enableReduxFlipper = false;
+const enableReduxLogger = false;
 
-const middlewares = [thunk];
+// Ignoring types, bc it's just a debug helper
+const reduxLogger = (store: any) => (next: any) => (action: any) => {
+  const reducersKeys = Object.keys(reducers);
 
-if (__DEV__ && enableReduxFlipper) {
-  const createDebugger = require('redux-flipper').default;
-  middlewares.push(createDebugger({ resolveCyclic: true }));
-}
+  // We can specify which keys to log  or log all
+  const singleKeys: string[] = ['wallets', 'appState'];
+  const stateKeys = singleKeys.length ? singleKeys : reducersKeys;
 
-const store = createStore(reducers, applyMiddleware(...middlewares));
+  console.info('dispatching', JSON.stringify(action));
+  let result = next(action);
+
+  stateKeys.forEach(key => {
+    console.log(`${key} state`, JSON.stringify(store.getState()?.[key]));
+  });
+
+  return result;
+};
+
+const configureStore = () => {
+  const middlewares = [thunk];
+
+  if (__DEV__) {
+    enableReduxLogger && middlewares.push(reduxLogger as any);
+
+    if (enableReduxFlipper) {
+      const createDebugger = require('redux-flipper').default;
+      middlewares.push(createDebugger({ resolveCyclic: true }));
+    }
+  }
+
+  return createStore(reducers, applyMiddleware(...middlewares));
+};
+
+const store = configureStore();
 
 export default store;
 


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

<!-- Include a summary of the changes. -->

As I mentioned, using redux-flipper, and trying to log `store.getState()` with `JSON.stringify`  was breaking the redux debug middleware, because of circular deps !? I guess, even using `resolveCyclic` so I decide to create our own logger, this way we can log all redux reducers keys, or specify the keys we want to not flood the entire log.

To get all the reducers assign an empty array to `singleKeys`:
```ts
 const singleKeys: string[] = [];
```
To get specify reducers, just add them to the array: 

```ts
const singleKeys: string[] = ['wallets', 'appState'];
```
and set `enableReduxLogger` to `true``

The keys need to be one of the reducers name, we could try and type this, but I don't think it's worth, since it's pretty straight forward and just for debug purposes.

I'm putting it up so it can help with any redux debugging issue we may face. =)
