### PR TITLE
[CS-2096]: Don't show empty PrepaidCard on Layer1

### DIFF
--- a/src/hooks/useAssetListData.tsx
+++ b/src/hooks/useAssetListData.tsx
@@ -1,6 +1,7 @@
 import { getConstantByNetwork } from '@cardstack/cardpay-sdk';
 import { orderBy } from 'lodash';
 import { BalanceCoinRowWrapper } from '../components/coin-row';
+import useAccountSettings from './useAccountSettings';
 import {
   PinnedHiddenSectionOption,
   usePinnedAndHiddenItemOptions,
@@ -20,6 +21,7 @@ import {
   MerchantSafeType,
   PrepaidCardType,
 } from '@cardstack/types';
+import { isLayer1 } from '@cardstack/utils';
 import { parseAssetsNativeWithTotals } from '@rainbow-me/parsers';
 import { useRainbowSelector } from '@rainbow-me/redux/hooks';
 
@@ -155,6 +157,7 @@ export const useAssetListData = () => {
   const isLoadingAssets = useRainbowSelector(
     state => state.data.isLoadingAssets
   );
+  const { network } = useAccountSettings();
 
   // order of sections in asset list
   const orderedSections = [
@@ -168,7 +171,8 @@ export const useAssetListData = () => {
   const sections = orderedSections.filter(
     section =>
       section?.data?.length ||
-      section?.header.type === PinnedHiddenSectionOption.PREPAID_CARDS
+      (section?.header.type === PinnedHiddenSectionOption.PREPAID_CARDS &&
+        !isLayer1(network))
   );
 
   const isEmpty = !sections.length;


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Hide PrepaidCard Empty state on layer1, since it's not possible to buy a prepaidCard on it.

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2096)


### Screenshots

<!-- Screenshots or animated GIFs included here -->


<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/20520102/137395705-46da99f5-b984-4acf-98c1-ada4b3156ff0.png"> 

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/20520102/137395864-d4422fea-ed73-4352-b530-16d9be2d464e.png"> 
