### PR TITLE
[CS-2094] Fix payment confirmation incorrect amount

### DIFF
--- a/cardstack/src/screens/PayMerchant/usePayMerchant.ts
+++ b/cardstack/src/screens/PayMerchant/usePayMerchant.ts
@@ -184,11 +184,11 @@ export const usePayMerchant = () => {
       spendAmount,
       currency:
         nativeCurrency === NativeCurrency.SPD
-          ? initialCurrency
+          ? accountCurrency
           : nativeCurrency,
       prepaidCard: selectedPrepaidCard?.address,
     }),
-    [initialCurrency, data, nativeCurrency, selectedPrepaidCard, spendAmount]
+    [accountCurrency, data, nativeCurrency, selectedPrepaidCard, spendAmount]
   );
 
   return {


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

There was an issue when use `convertSpendForBalanceDisplay`. Btw I think we should update/replace `convertSpendForBalanceDisplay` later with sdk's currency util functions to be consistent with dapp as well, did similar thing in pr#416

<!-- Include a summary of the changes. -->

- [x] Completes #CS-2094

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![image](https://user-images.githubusercontent.com/16714648/137486341-30a7af88-8416-4d3b-898f-cc5762173781.png)
