### PR TITLE
[CS-2139] - Mnemonic only wallet and iCloud backup

### DIFF
--- a/cardstack/docs/initDiagram.drawio
+++ b/cardstack/docs/initDiagram.drawio
@@ -1,0 +1,195 @@
+<mxfile host="65bd71144e">
+    <diagram id="QZ-MXoioudwLhQ9d-GXE" name="Page-1">
+        <mxGraphModel dx="2070" dy="840" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="5" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="2" target="3" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="2" value="App" style="rounded=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="320" y="20" width="130" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="8" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="3" target="6" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="9" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="3" target="7" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-55" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=15;" parent="1" source="3" target="10" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="3" value="Has &lt;br&gt;address on keychain?" style="rhombus;whiteSpace=wrap;html=1;rounded=1;" parent="1" vertex="1">
+                    <mxGeometry x="330" y="150" width="110" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-12" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="6" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="605" y="280" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="6" value="Welcome_Screen" style="rounded=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="525" y="165" width="160" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-22" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="7" target="Y6MugdShxAgaUpJ7odk5-21" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="7" value="Swipe_Layout" style="rounded=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="100" y="167.5" width="150" height="75" as="geometry"/>
+                </mxCell>
+                <mxCell id="10" value="Yes" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="280" y="180" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="11" value="No&lt;span style=&quot;color: rgba(0 , 0 , 0 , 0) ; font-family: monospace ; font-size: 0px&quot;&gt;%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%2F%3E%3CmxCell%20id%3D%221%22%20parent%3D%220%22%2F%3E%3CmxCell%20id%3D%222%22%20value%3D%22App%22%20style%3D%22rounded%3D1%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%3CmxGeometry%20x%3D%22480%22%20y%3D%22170%22%20width%3D%22120%22%20height%3D%2260%22%20as%3D%22geometry%22%2F%3E%3C%2FmxCell%3E%3C%2Froot%3E%3C%2FmxGraphModel%3E&lt;/span&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="437.5" y="180" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-67" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=15;" parent="1" source="Y6MugdShxAgaUpJ7odk5-21" target="Y6MugdShxAgaUpJ7odk5-66" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-21" value="Wallet_Screen" style="rounded=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="-150" y="167.5" width="150" height="75" as="geometry"/>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-47" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=15;" parent="1" source="Y6MugdShxAgaUpJ7odk5-31" target="Y6MugdShxAgaUpJ7odk5-41" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="460" y="325" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-53" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=15;" parent="1" source="Y6MugdShxAgaUpJ7odk5-31" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="770" y="340" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-31" value="&lt;meta charset=&quot;utf-8&quot;&gt;&lt;span style=&quot;color: rgb(240, 240, 240); font-family: helvetica; font-size: 12px; font-style: normal; font-weight: 400; letter-spacing: normal; text-align: center; text-indent: 0px; text-transform: none; word-spacing: 0px; background-color: rgb(42, 42, 42); display: inline; float: none;&quot;&gt;Check for cloud data availability&amp;nbsp;&lt;/span&gt;" style="shape=process;whiteSpace=wrap;html=1;backgroundOutline=1;rounded=1;glass=0;sketch=0;fontSize=15;" parent="1" vertex="1">
+                    <mxGeometry x="530" y="295" width="160" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-54" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.475;entryY=0.018;entryDx=0;entryDy=0;fontSize=15;exitX=0.487;exitY=0.988;exitDx=0;exitDy=0;exitPerimeter=0;entryPerimeter=0;" parent="1" source="Y6MugdShxAgaUpJ7odk5-39" target="41" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="843.416666666667" y="365" as="sourcePoint"/>
+                        <mxPoint x="840" y="440" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-44" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=1;entryDx=0;entryDy=0;fontSize=15;" parent="1" source="Y6MugdShxAgaUpJ7odk5-41" target="7" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="297.5" y="325" as="sourcePoint"/>
+                        <Array as="points">
+                            <mxPoint x="175" y="340"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-56" value="emptyWallet: true&lt;br&gt;initialized: undefined" style="text;html=1;strokeColor=#3700CC;fillColor=#6a00ff;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontColor=#ffffff;" parent="1" vertex="1">
+                    <mxGeometry x="190" y="295" width="120" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-57" value="" style="shape=actor;whiteSpace=wrap;html=1;rounded=1;glass=0;sketch=0;fontSize=15;" parent="1" vertex="1">
+                    <mxGeometry x="365" y="270" width="35" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-41" value="Add new account&amp;nbsp;&lt;br&gt;onCreateWallet" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fontSize=15;" parent="1" vertex="1">
+                    <mxGeometry x="320" y="320" width="130" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-39" value="Add existing account&amp;nbsp;&lt;br&gt;showRestoreSheet" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fontSize=15;" parent="1" vertex="1">
+                    <mxGeometry x="765" y="320" width="160" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-58" value="" style="shape=actor;whiteSpace=wrap;html=1;rounded=1;glass=0;sketch=0;fontSize=15;" parent="1" vertex="1">
+                    <mxGeometry x="825" y="270" width="35" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-64" value="userCloudData" style="text;html=1;strokeColor=#3700CC;fillColor=#6a00ff;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontColor=#ffffff;" parent="1" vertex="1">
+                    <mxGeometry x="792.5" y="390" width="100" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="39" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="Y6MugdShxAgaUpJ7odk5-66" target="12">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-66" value="Initialized" style="rhombus;whiteSpace=wrap;html=1;rounded=1;" parent="1" vertex="1">
+                    <mxGeometry x="-117.5" y="390" width="85" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="Y6MugdShxAgaUpJ7odk5-70" value="No&lt;span style=&quot;color: rgba(0 , 0 , 0 , 0) ; font-family: monospace ; font-size: 0px&quot;&gt;%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%2F%3E%3CmxCell%20id%3D%221%22%20parent%3D%220%22%2F%3E%3CmxCell%20id%3D%222%22%20value%3D%22App%22%20style%3D%22rounded%3D1%3BwhiteSpace%3Dwrap%3Bhtml%3D1%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%3CmxGeometry%20x%3D%22480%22%20y%3D%22170%22%20width%3D%22120%22%20height%3D%2260%22%20as%3D%22geometry%22%2F%3E%3C%2FmxCell%3E%3C%2Froot%3E%3C%2FmxGraphModel%3E&lt;/span&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="-117.5" y="470" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="12" value="InitializeWallet " style="swimlane;" vertex="1" parent="1">
+                    <mxGeometry x="-220" y="539" width="470" height="270" as="geometry">
+                        <mxRectangle x="-220" y="539" width="120" height="21" as="alternateBounds"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="15" value="createWallet" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="12">
+                    <mxGeometry x="157.5" y="210" width="80" height="35" as="geometry"/>
+                </mxCell>
+                <mxCell id="26" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="12" source="18">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="310" y="90" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="36" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="12" source="18" target="15">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="18" value="existing&lt;br&gt;wallet" style="rhombus;whiteSpace=wrap;html=1;rounded=1;" vertex="1" parent="12">
+                    <mxGeometry x="155" y="50" width="85" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="22" value="&lt;font face=&quot;helvetica&quot;&gt;Yes&lt;/font&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="12">
+                    <mxGeometry x="75" y="200" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="23" value="&lt;font face=&quot;helvetica&quot;&gt;No&lt;/font&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="12">
+                    <mxGeometry x="190" y="160" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="29" value="&lt;font face=&quot;helvetica&quot;&gt;Yes&lt;/font&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="12">
+                    <mxGeometry x="250" y="75" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="35" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="12" source="31" target="18">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="31" value="Importing" style="rhombus;whiteSpace=wrap;html=1;rounded=1;" vertex="1" parent="12">
+                    <mxGeometry x="20" y="45" width="85" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="32" value="&lt;font face=&quot;helvetica&quot;&gt;No&lt;/font&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="12">
+                    <mxGeometry x="115" y="65" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="33" value="&lt;meta charset=&quot;utf-8&quot;&gt;&lt;span style=&quot;color: rgb(240, 240, 240); font-family: helvetica; font-size: 12px; font-style: normal; font-weight: 400; letter-spacing: normal; text-align: center; text-indent: 0px; text-transform: none; word-spacing: 0px; background-color: rgb(42, 42, 42); display: inline; float: none;&quot;&gt;return wallet address&lt;/span&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="12">
+                    <mxGeometry x="310" y="65" width="100" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="34" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.571;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="12" source="31" target="15">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="60" y="230" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="63" y="230"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="44" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="41" target="42">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="45" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="41" target="43">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="41" value="&lt;span style=&quot;color: rgb(240 , 240 , 240) ; font-family: &amp;#34;helvetica&amp;#34; ; font-size: 12px ; font-style: normal ; font-weight: 400 ; letter-spacing: normal ; text-align: center ; text-indent: 0px ; text-transform: none ; word-spacing: 0px ; background-color: rgb(42 , 42 , 42) ; display: inline ; float: none&quot;&gt;Restore Sheet&lt;/span&gt;" style="shape=process;whiteSpace=wrap;html=1;backgroundOutline=1;rounded=1;glass=0;sketch=0;fontSize=15;" vertex="1" parent="1">
+                    <mxGeometry x="760" y="455" width="162.5" height="75" as="geometry"/>
+                </mxCell>
+                <mxCell id="47" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="42" target="46">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="50" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="42" target="12">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="605" y="674"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="42" value="ImportSheet" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="530" y="458.75" width="150" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="43" value="iCloudBackup" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="1020" y="456.25" width="150" height="72.5" as="geometry"/>
+                </mxCell>
+                <mxCell id="48" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="46" target="42">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="350" y="439"/>
+                            <mxPoint x="605" y="439"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="46" value="WalletProfile" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="275" y="457.5" width="150" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="51" value="&lt;span style=&quot;color: rgb(240 , 240 , 240) ; font-family: &amp;#34;helvetica&amp;#34; ; font-size: 12px ; font-style: normal ; font-weight: 400 ; letter-spacing: normal ; text-align: center ; text-indent: 0px ; text-transform: none ; word-spacing: 0px ; background-color: rgb(42 , 42 , 42) ; display: inline ; float: none&quot;&gt;isImporting = true&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="370" y="650" width="100" height="30" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/cardstack/src/components/OptionItem/OptionItem.tsx
+++ b/cardstack/src/components/OptionItem/OptionItem.tsx
@@ -51,7 +51,7 @@ export const OptionItem = ({
           <Icon color="settingsTeal" {...iconProps} />
         </CenteredContainer>
       )}
-      <Container>
+      <Container flexShrink={1}>
         <Text fontWeight="600" {...textProps}>
           {title}
         </Text>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -899,7 +899,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 33c82491102f20ecddb6c6a2c273696ace3191e0
   FBReactNativeSpec: df8f81d2a7541ee6755a047b398a5cb5a72acd0e
   Firebase: bc9325d5ee2041524bac78a5213d0e530c651309
@@ -918,7 +918,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: aec2d931adeee48a07bab1ea8bcc8a6bb87dfce4
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
   GoogleDataTransport: 85fd18ff3019bb85d3f2c551d04c481dedf71fc9
   GoogleUtilities: 8de2a97a17e15b6b98e38e8770e2d129a57c0040
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913

--- a/ios/Rainbow/Rainbow.entitlements
+++ b/ios/Rainbow/Rainbow.entitlements
@@ -6,8 +6,6 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:cardpay.page.link</string>
-		<string>webcredentials:cardstack.com</string>
 		<string>applinks:wallet.cardstack.com</string>
 		<string>applinks:wallet-staging.stack.cards</string>
 	</array>

--- a/ios/Rainbow/RainbowDebug.entitlements
+++ b/ios/Rainbow/RainbowDebug.entitlements
@@ -6,8 +6,6 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:cardpay.page.link</string>
-		<string>webcredentials:cardstack.com</string>
 		<string>applinks:wallet.cardstack.com</string>
 		<string>applinks:wallet-staging.stack.cards</string>
 	</array>

--- a/ios/Rainbow/RainbowRelease.entitlements
+++ b/ios/Rainbow/RainbowRelease.entitlements
@@ -6,9 +6,7 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:cardpay.page.link</string>
 		<string>applinks:wallet.cardstack.com</string>
-		<string>webcredentials:cardstack.com</string>
 		<string>applinks:wallet-staging.stack.cards</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>

--- a/package.json
+++ b/package.json
@@ -318,6 +318,7 @@
     "metro-plugin-anisotropic-transform": "rainbow-me/metro-plugin-anisotropic-transform#463b4ca9f5631f9c5e6028d22a450f6f0e54214f",
     "metro-react-native-babel-preset": "^0.66.0",
     "prettier": "^2.2.1",
+    "react-devtools": "^4.19.1",
     "react-native-codegen": "^0.0.7",
     "react-native-storybook-loader": "^2.0.2",
     "react-native-svg-transformer": "^0.14.3",
@@ -344,7 +345,8 @@
     "**/yargs-parser": "20.2.5",
     "**/@hapi/hoek": "8.5.1",
     "**/@typescript-eslint/eslint-plugin": "4.31.0",
-    "**/@typescript-eslint/parser": "4.31.0"
+    "**/@typescript-eslint/parser": "4.31.0",
+    "**/react-devtools-core": "4.19.1"
   },
   "detox": {
     "configurations": {

--- a/src/App.js
+++ b/src/App.js
@@ -260,7 +260,7 @@ const CheckSystemReqs = ({ children }) => {
     if (hasMaintenanceStatus && hasMinimumVersion) {
       setReady(true);
     }
-  }, [hasMaintenanceStatus, hasMinimumVersion, hideSplashScreen]);
+  }, [hasMaintenanceStatus, hasMinimumVersion]);
 
   if (ready) {
     if (maintenanceStatus.maintenanceActive) {
@@ -274,9 +274,9 @@ const CheckSystemReqs = ({ children }) => {
     if (forceUpdate) {
       return <MinimumVersion />;
     }
-  }
 
-  hideSplashScreen();
+    hideSplashScreen();
+  }
 
   return children;
 };

--- a/src/components/backup/RestoreCloudStep.js
+++ b/src/components/backup/RestoreCloudStep.js
@@ -96,21 +96,24 @@ export default function RestoreCloudStep({ userData }) {
   return (
     <BackupSheetKeyboardLayout
       footer={
-        <Button
-          disabled={!validPassword}
-          iconProps={
-            !incorrectPassword
-              ? {
-                  iconSize: 'medium',
-                  marginRight: 3,
-                  name: 'refresh-2',
-                }
-              : null
-          }
-          onPress={onPasswordSubmit}
-        >
-          {label}
-        </Button>
+        <Container>
+          <Button
+            disabled={!validPassword}
+            iconProps={
+              !incorrectPassword
+                ? {
+                    iconSize: 'large',
+                    stroke: validPassword ? 'black' : undefined,
+                    marginRight: 3,
+                    name: 'refresh',
+                  }
+                : null
+            }
+            onPress={onPasswordSubmit}
+          >
+            {label}
+          </Button>
+        </Container>
       }
     >
       <Container

--- a/src/components/backup/RestoreSheetFirstStep.js
+++ b/src/components/backup/RestoreSheetFirstStep.js
@@ -1,86 +1,47 @@
 import React from 'react';
-import styled from 'styled-components';
 
-import { Column } from '../layout';
-import { OptionItem, Text } from '@cardstack/components';
-
-const Wrapper = styled(Column)`
-  margin-top: -8;
-`;
+import { Container, OptionItem, Text } from '@cardstack/components';
 
 export default function RestoreSheetFirstStep({
   onManualRestore,
-  onWatchAddress,
+  enableCloudRestore,
+  onCloudRestore,
+  walletsBackedUp,
 }) {
-  // Temp disabling iCloud restore
-
-  // const { setParams } = useNavigation();
-
-  // const walletsBackedUp = useMemo(() => {
-  //   let count = 0;
-  //   forEach(userData?.wallets, wallet => {
-  //     console.log({ userData });
-  //     if (wallet.backedUp && wallet.backupType === WalletBackupTypes.cloud) {
-  //       count++;
-  //     }
-  //   });
-  //   console.log({ count });
-  //   return count;
-  // }, [userData]);
-
-  // const enableCloudRestore = android || walletsBackedUp > 0;
-  // useEffect(() => {
-  //   setParams({ enableCloudRestore });
-  // }, [enableCloudRestore, setParams]);
-
   return (
-    <Wrapper>
+    <Container marginTop={2} paddingHorizontal={2}>
       <Text
         fontSize={18}
         fontWeight="700"
-        marginBottom={10}
+        marginBottom={5}
         marginTop={2}
         textAlign="center"
       >
         Add account
       </Text>
-      {/* {enableCloudRestore && (
+      {enableCloudRestore && (
         <OptionItem
-          horizontalSpacing={4}
           iconProps={{
             name: 'download-cloud',
             size: 25,
           }}
-          marginVertical={4}
+          marginBottom={4}
           onPress={onCloudRestore}
           subText={`${walletsBackedUp} ${
             walletsBackedUp > 1 ? 'accounts are' : 'account is'
           } backed up in your iCloud`}
           title="Restore from backup"
         />
-      )} */}
+      )}
       <OptionItem
-        horizontalSpacing={4}
         iconProps={{
           name: 'lock',
           size: 25,
         }}
-        marginVertical={4}
         onPress={onManualRestore}
-        subText="Use the private key for your crypto account"
+        subText="Use the private secret phare for your crypto account"
         title="Import via secret recovery phrase"
       />
-      <OptionItem
-        horizontalSpacing={4}
-        iconProps={{
-          name: 'search',
-          size: 25,
-        }}
-        marginVertical={4}
-        onPress={onWatchAddress}
-        subText="Track an ENS name or public address"
-        title="Monitor an Ethereum address"
-      />
-    </Wrapper>
+    </Container>
   );
 }

--- a/src/components/backup/RestoreSheetFirstStep.js
+++ b/src/components/backup/RestoreSheetFirstStep.js
@@ -39,7 +39,7 @@ export default function RestoreSheetFirstStep({
           size: 25,
         }}
         onPress={onManualRestore}
-        subText="Use the private secret phare for your crypto account"
+        subText="Use the private secret phrase for your crypto account"
         title="Import via secret recovery phrase"
       />
     </Container>

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -80,12 +80,11 @@ export default function WalletProfileState({
       name: nameEmoji ? `${nameEmoji} ${value}` : value,
     });
 
-    if (actionType !== 'Import') {
-      goBack();
+    // Dismiss WalletProfileModal
+    goBack();
 
-      if (actionType === 'Create' && isNewProfile) {
-        navigate(Routes.CHANGE_WALLET_SHEET);
-      }
+    if (actionType === 'Create' && isNewProfile) {
+      navigate(Routes.CHANGE_WALLET_SHEET);
     }
   }, [
     actionType,

--- a/src/components/secret-display/SecretDisplaySection.js
+++ b/src/components/secret-display/SecretDisplaySection.js
@@ -91,7 +91,6 @@ export default function SecretDisplaySection({
                 }}
                 onPress={handlePressCopySeed}
                 variant="white"
-                width="100%"
               >
                 Copy to clipboard
               </Button>

--- a/src/handlers/localstorage/accountLocal.js
+++ b/src/handlers/localstorage/accountLocal.js
@@ -85,14 +85,14 @@ export const getAccountEmptyState = (accountAddress, network) =>
 
 /**
  * @desc save account empty state
- * @param  {Boolean}    [val]
+ * @param  {Boolean}  [isEmpty]
  * @param  {String}   [address]
  * @param  {String}   [network]
  */
-export const saveAccountEmptyState = (val, accountAddress, network) =>
+export const saveAccountEmptyState = (isEmpty, accountAddress, network) =>
   saveAccountLocal(
     ACCOUNT_EMPTY,
-    val,
+    isEmpty,
     accountAddress,
     network,
     accountEmptyVersion

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -62,7 +62,7 @@ export const checkIsValidAddressOrDomain = async address => {
  * @param  {String} seed phrase mnemonic
  * @return {Boolean}
  */
-const isValidSeedPhrase = seedPhrase => {
+export const isValidSeedPhrase = seedPhrase => {
   const sanitizedSeedPhrase = sanitizeSeedPhrase(seedPhrase);
   return (
     sanitizedSeedPhrase.split(' ').length >= 12 &&

--- a/src/hooks/useInitializeWallet.js
+++ b/src/hooks/useInitializeWallet.js
@@ -100,9 +100,6 @@ export default function useInitializeWallet() {
 
         if (isNil(walletAddress)) {
           logger.sentry('walletAddress is nil');
-          Alert.alert(
-            'Import failed due to an invalid private key. Please try again.'
-          );
           if (!isImporting) {
             dispatch(appStateUpdate({ walletReady: true }));
           }

--- a/src/hooks/useInitializeWallet.js
+++ b/src/hooks/useInitializeWallet.js
@@ -37,14 +37,14 @@ export default function useInitializeWallet() {
   const providerUrl = web3Provider?.connection?.url;
 
   const initializeWallet = useCallback(
-    async (
-      seedPhrase,
+    async ({
+      seedPhrase = undefined,
       color = null,
       name = null,
       shouldRunMigrations = false,
       overwrite = false,
-      checkedWallet = null
-    ) => {
+      checkedWallet = null,
+    } = {}) => {
       try {
         logger.sentry('Start wallet setup');
 
@@ -54,12 +54,13 @@ export default function useInitializeWallet() {
         const isImporting = !!seedPhrase;
         logger.sentry('isImporting?', isImporting);
 
+        // TODO: move to fallbackExplorer, shouldn't be related with initializating a wallet
         await Promise.all([
           loadCoingeckoCoins(),
           loadCurrencyConversionRates(),
         ]);
 
-        if (shouldRunMigrations && !seedPhrase) {
+        if (shouldRunMigrations && !isImporting) {
           logger.sentry('shouldRunMigrations && !seedPhrase? => true');
           await dispatch(walletsLoadState());
           logger.sentry('walletsLoadState call #1');
@@ -92,7 +93,7 @@ export default function useInitializeWallet() {
           walletAddress,
         });
 
-        if (seedPhrase || isNew) {
+        if (isImporting || isNew) {
           logger.sentry('walletsLoadState call #2');
           await dispatch(walletsLoadState());
         }
@@ -108,16 +109,13 @@ export default function useInitializeWallet() {
           return null;
         }
 
-        if (!(isNew || isImporting)) {
-          await loadGlobalData();
-          logger.sentry('loaded global data...');
-        }
-
         await dispatch(settingsUpdateAccountAddress(walletAddress));
         logger.sentry('updated settings address', walletAddress);
 
         // Newly created / imported accounts have no data in localstorage
         if (!(isNew || isImporting)) {
+          await loadGlobalData();
+          logger.sentry('loaded global data...');
           await loadAccountData(network);
           logger.sentry('loaded account data', network);
         }

--- a/src/hooks/useRefreshAccountData.js
+++ b/src/hooks/useRefreshAccountData.js
@@ -3,9 +3,7 @@ import delay from 'delay';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { uniqueTokensRefreshState } from '../redux/uniqueTokens';
-import { uniswapUpdateLiquidityState } from '../redux/uniswapLiquidity';
 import { fetchWalletNames } from '../redux/wallets';
-import useSavingsAccount from './useSavingsAccount';
 import {
   fallbackExplorerClearState,
   fallbackExplorerInit,
@@ -14,30 +12,28 @@ import logger from 'logger';
 
 export default function useRefreshAccountData() {
   const dispatch = useDispatch();
-  const { refetchSavings } = useSavingsAccount();
 
   const refreshAccountData = useCallback(async () => {
     try {
       await dispatch(fallbackExplorerClearState());
       const getWalletNames = dispatch(fetchWalletNames());
-      const getUniswapLiquidity = dispatch(uniswapUpdateLiquidityState());
       const getUniqueTokens = dispatch(uniqueTokensRefreshState());
       const explorer = dispatch(fallbackExplorerInit());
 
       return Promise.all([
-        delay(1250), // minimum duration we want the "Pull to Refresh" animation to last
-        getWalletNames,
-        getUniswapLiquidity,
-        getUniqueTokens,
-        refetchSavings(),
         explorer,
+        getWalletNames,
+        getUniqueTokens,
+        // We will remove this and track the loading based on fallbackExplorer
+        // This is a workaround to have the animation while updating the assets
+        delay(12000), // minimum duration we want the "Pull to Refresh" animation to last
       ]);
     } catch (error) {
       logger.log('Error refreshing data', error);
       captureException(error);
       throw error;
     }
-  }, [dispatch, refetchSavings]);
+  }, [dispatch]);
 
   return refreshAccountData;
 }

--- a/src/screens/ImportSeedPhraseSheet.js
+++ b/src/screens/ImportSeedPhraseSheet.js
@@ -304,14 +304,12 @@ export default function ImportSeedPhraseSheet() {
           : sanitizeSeedPhrase(seedPhrase);
 
         const previousWalletCount = keys(wallets).length;
-        initializeWallet(
-          input,
+        initializeWallet({
+          seedPhrase: input,
           color,
-          name ? name : '',
-          false,
-          false,
-          checkedWallet
-        )
+          name: name || '',
+          checkedWallet,
+        })
           .then(success => {
             handleSetImporting(false);
             if (success) {

--- a/src/screens/ImportSeedPhraseSheet.js
+++ b/src/screens/ImportSeedPhraseSheet.js
@@ -1,6 +1,5 @@
 import { getConstantByNetwork } from '@cardstack/cardpay-sdk';
 import { JsonRpcProvider } from '@ethersproject/providers';
-import { isValidAddress } from 'ethereumjs-util';
 import { keys } from 'lodash';
 import React, {
   useCallback,
@@ -9,8 +8,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Alert, InteractionManager, StatusBar } from 'react-native';
-import { IS_TESTING } from 'react-native-dotenv';
+import { InteractionManager, StatusBar } from 'react-native';
 import { KeyboardArea } from 'react-native-keyboard-area';
 import styled from 'styled-components';
 
@@ -23,14 +21,11 @@ import {
 import { useTheme } from '../context/ThemeContext';
 import NetworkTypes, { networkTypes } from '../helpers/networkTypes';
 import { Button, Input, Text } from '@cardstack/components';
-import { resolveUnstoppableDomain } from '@rainbow-me/handlers/web3';
 import isNativeStackAvailable from '@rainbow-me/helpers/isNativeStackAvailable';
 import {
-  isENSAddressFormat,
-  isUnstoppableAddressFormat,
+  isValidSeedPhrase,
   isValidWallet,
 } from '@rainbow-me/helpers/validators';
-import WalletBackupStepTypes from '@rainbow-me/helpers/walletBackupStepTypes';
 import walletLoadingStates from '@rainbow-me/helpers/walletLoadingStates';
 import {
   useAccountSettings,
@@ -38,14 +33,12 @@ import {
   useDimensions,
   useInitializeWallet,
   useInvalidPaste,
-  useIsWalletEthZero,
   useKeyboardHeight,
   useMagicAutofocus,
   usePrevious,
-  useTimeout,
   useWallets,
 } from '@rainbow-me/hooks';
-import { Navigation, useNavigation } from '@rainbow-me/navigation';
+import { useNavigation } from '@rainbow-me/navigation';
 import { sheetVerticalOffset } from '@rainbow-me/navigation/effects';
 import Routes from '@rainbow-me/routes';
 import { borders, padding } from '@rainbow-me/styles';
@@ -105,39 +98,19 @@ const Sheet = styled(Column).attrs({
   z-index: 1;
 `;
 
-const placeholderBasedOnChain = chainName => {
-  switch (chainName) {
-    case networkTypes.kovan:
-      return 'Enter seed phrase, private key, Kovan address, or Kovan ENS name';
-    case networkTypes.mainnet:
-      return 'Enter seed phrase, private key, Ethereum address, or ENS name';
-    case networkTypes.sokol:
-      return 'Enter seed phrase, private key, or Sokol address';
-    case networkTypes.xdai:
-      return 'Enter seed phrase, private key, or xDai address';
-    default:
-      return 'Enter seed phrase, private key, Ethereum address, or ENS name';
-  }
-};
-
 export default function ImportSeedPhraseSheet() {
-  const { accountAddress, network } = useAccountSettings();
-  const { selectedWallet, setIsWalletLoading, wallets } = useWallets();
+  const { accountAddress } = useAccountSettings();
+  const { setIsWalletLoading, wallets } = useWallets();
   const { getClipboard, hasClipboardData, clipboard } = useClipboard();
   const { onInvalidPaste } = useInvalidPaste();
   const { isSmallPhone } = useDimensions();
   const keyboardHeight = useKeyboardHeight();
   const { goBack, navigate, replace, setParams } = useNavigation();
   const initializeWallet = useInitializeWallet();
-  const isWalletEthZero = useIsWalletEthZero();
   const [isImporting, setImporting] = useState(false);
   const [seedPhrase, setSeedPhrase] = useState('');
-  const [color, setColor] = useState(null);
-  const [name, setName] = useState(null);
   const [busy, setBusy] = useState(false);
   const [checkedWallet, setCheckedWallet] = useState(null);
-  const [resolvedAddress, setResolvedAddress] = useState(null);
-  const [startAnalyticsTimeout] = useTimeout();
   const wasImporting = usePrevious(isImporting);
 
   const inputRef = useRef(null);
@@ -158,9 +131,9 @@ export default function ImportSeedPhraseSheet() {
     [accountAddress, clipboard, hasClipboardData]
   );
 
-  const isSecretValid = useMemo(() => {
-    return seedPhrase !== accountAddress && isValidWallet(seedPhrase);
-  }, [accountAddress, seedPhrase]);
+  const isSecretValid = useMemo(() => isValidSeedPhrase(seedPhrase), [
+    seedPhrase,
+  ]);
 
   const handleSetImporting = useCallback(
     newImportingState => {
@@ -178,6 +151,66 @@ export default function ImportSeedPhraseSheet() {
     [isImporting]
   );
 
+  const handleImportAccount = useCallback(
+    async ({ name = null, color = null }) => {
+      handleSetImporting(true);
+
+      if (!wasImporting) {
+        const input = sanitizeSeedPhrase(seedPhrase);
+
+        const previousWalletCount = keys(wallets).length;
+        const isFreshWallet = previousWalletCount === 0;
+
+        try {
+          const wallet = await initializeWallet({
+            seedPhrase: input,
+            color,
+            name: name || '',
+            checkedWallet,
+          });
+
+          handleSetImporting(false);
+          // Early return to not dismiss the sheet on error
+          if (!wallet) return;
+
+          InteractionManager.runAfterInteractions(async () => {
+            // Fresh imported wallet
+            if (isFreshWallet) {
+              // Dismisses ImportSeedPhraseSheet
+              goBack();
+              // Replaces bc no route exist yet
+              replace(Routes.SWIPE_LAYOUT, {
+                params: { initialized: true },
+                screen: Routes.WALLET_SCREEN,
+              });
+            } else {
+              navigate(Routes.WALLET_SCREEN, {
+                initialized: true,
+              });
+            }
+          });
+        } catch (error) {
+          handleSetImporting(false);
+          logger.error('error importing seed phrase: ', error);
+          setTimeout(() => {
+            inputRef.current?.focus();
+          }, 100);
+        }
+      }
+    },
+    [
+      checkedWallet,
+      goBack,
+      handleSetImporting,
+      initializeWallet,
+      navigate,
+      replace,
+      seedPhrase,
+      wallets,
+      wasImporting,
+    ]
+  );
+
   const showWalletProfileModal = useCallback(
     name => {
       navigate(Routes.MODAL_SCREEN, {
@@ -185,17 +218,13 @@ export default function ImportSeedPhraseSheet() {
         additionalPadding: true,
         asset: [],
         isNewProfile: true,
-        onCloseModal: ({ color, name }) => {
-          if (color !== null) setColor(color);
-          if (name) setName(name);
-          handleSetImporting(true);
-        },
+        onCloseModal: handleImportAccount,
         profile: { name },
         type: 'wallet_profile',
         withoutStatusBar: true,
       });
     },
-    [handleSetImporting, navigate]
+    [handleImportAccount, navigate]
   );
 
   const handlePressImportButton = useCallback(async () => {
@@ -207,76 +236,22 @@ export default function ImportSeedPhraseSheet() {
       NetworkTypes.mainnet
     );
 
-    let name = null;
-    // Validate ENS
-    if (isENSAddressFormat(input)) {
-      try {
-        const address = await mainnetProvider.resolveName(input);
-        if (!address) {
-          Alert.alert('This is not a valid ENS name');
-          return;
-        }
-        setResolvedAddress(address);
-        name = input;
-        showWalletProfileModal(name);
-      } catch (e) {
-        Alert.alert(
-          'Sorry, we cannot add this ENS name at this time. Please try again later!'
-        );
-        return;
-      }
-      // Look up ENS for 0x address
-    } else if (isUnstoppableAddressFormat(input)) {
-      try {
-        const address = await resolveUnstoppableDomain(input);
-        if (!address) {
-          Alert.alert('This is not a valid Unstoppable name');
-          return;
-        }
-        setResolvedAddress(address);
-        name = input;
-        showWalletProfileModal(name);
-      } catch (e) {
-        Alert.alert(
-          'Sorry, we cannot add this Unstoppable name at this time. Please try again later!'
-        );
-        return;
-      }
-    } else if (isValidAddress(input)) {
-      try {
-        const ens = mainnetProvider.lookupAddress
-          ? await mainnetProvider.lookupAddress(input)
-          : null;
-        if (ens && ens !== input) {
-          name = ens;
-        }
-        showWalletProfileModal(name);
-      } catch (error) {
-        console.log({ error });
-      }
-    } else {
-      try {
-        setBusy(true);
-        setTimeout(async () => {
-          const walletResult = await ethereumUtils.deriveAccountFromWalletInput(
-            input
-          );
-          setCheckedWallet(walletResult);
+    try {
+      setBusy(true);
+      const walletResult = await ethereumUtils.deriveAccountFromWalletInput(
+        input
+      );
 
-          const ens = mainnetProvider.lookupAddress
-            ? await mainnetProvider.lookupAddress(walletResult.address)
-            : null;
+      setCheckedWallet(walletResult);
 
-          if (ens && ens !== input) {
-            name = ens;
-          }
-          setBusy(false);
-          showWalletProfileModal(name);
-        }, 100);
-      } catch (error) {
-        logger.log('Error looking up ENS for imported HD type wallet', error);
-        setBusy(false);
-      }
+      const ens =
+        (await mainnetProvider.lookupAddress?.(walletResult.address)) || null;
+
+      setBusy(false);
+      showWalletProfileModal(ens);
+    } catch (error) {
+      logger.log('Error looking up ENS for imported HD type wallet', error);
+      setBusy(false);
     }
   }, [isSecretValid, seedPhrase, showWalletProfileModal]);
 
@@ -297,96 +272,13 @@ export default function ImportSeedPhraseSheet() {
   ]);
 
   useEffect(() => {
-    if (!wasImporting && isImporting) {
-      startAnalyticsTimeout(async () => {
-        const input = resolvedAddress
-          ? resolvedAddress
-          : sanitizeSeedPhrase(seedPhrase);
-
-        const previousWalletCount = keys(wallets).length;
-        initializeWallet({
-          seedPhrase: input,
-          color,
-          name: name || '',
-          checkedWallet,
-        })
-          .then(success => {
-            handleSetImporting(false);
-            if (success) {
-              goBack();
-              InteractionManager.runAfterInteractions(async () => {
-                if (previousWalletCount === 0) {
-                  goBack();
-                  replace(Routes.SWIPE_LAYOUT, {
-                    params: { initialized: true },
-                    screen: Routes.WALLET_SCREEN,
-                  });
-                } else {
-                  goBack();
-                  navigate(Routes.WALLET_SCREEN, { initialized: true });
-                }
-
-                setTimeout(() => {
-                  // If it's not read only, show the backup sheet
-                  if (
-                    !(
-                      isENSAddressFormat(input) ||
-                      isUnstoppableAddressFormat(input) ||
-                      isValidAddress(input)
-                    )
-                  ) {
-                    IS_TESTING !== 'true' &&
-                      Navigation.handleAction(Routes.BACKUP_SHEET, {
-                        single: true,
-                        step: WalletBackupStepTypes.imported,
-                      });
-                  }
-                }, 1000);
-              });
-            } else {
-              // Wait for error messages then refocus
-              setTimeout(() => {
-                inputRef.current?.focus();
-                initializeWallet();
-              }, 100);
-            }
-          })
-          .catch(error => {
-            handleSetImporting(false);
-            logger.error('error importing seed phrase: ', error);
-            setTimeout(() => {
-              inputRef.current?.focus();
-              initializeWallet();
-            }, 100);
-          });
-      }, 50);
-    }
-  }, [
-    checkedWallet,
-    color,
-    isWalletEthZero,
-    handleSetImporting,
-    goBack,
-    initializeWallet,
-    isImporting,
-    name,
-    navigate,
-    replace,
-    resolvedAddress,
-    seedPhrase,
-    selectedWallet.id,
-    selectedWallet.type,
-    startAnalyticsTimeout,
-    wallets,
-    wasImporting,
-  ]);
-
-  useEffect(() => {
     setIsWalletLoading(
       isImporting ? walletLoadingStates.IMPORTING_WALLET : null
     );
   }, [isImporting, setIsWalletLoading]);
+
   const { colors } = useTheme();
+
   return (
     <Container testID="import-sheet">
       <StatusBar barStyle="dark-content" />
@@ -411,7 +303,7 @@ export default function ImportSeedPhraseSheet() {
             onChangeText={handleSetSeedPhrase}
             onFocus={handleFocus}
             onSubmitEditing={handlePressImportButton}
-            placeholder={placeholderBasedOnChain(network)}
+            placeholder="Enter seed phrase or secret recovery phrase"
             placeholderTextColor={colors.alpha(colors.blueGreyDark, 0.3)}
             ref={inputRef}
             returnKeyType="done"

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -93,7 +93,7 @@ export default function WalletScreen() {
   useEffect(() => {
     if (!initialized) {
       // We run the migrations only once on app launch
-      initializeWallet(null, null, null, true);
+      initializeWallet({ shouldRunMigrations: true });
       setInitialized(true);
       setNotifications();
     }

--- a/src/utils/ethereumUtils.js
+++ b/src/utils/ethereumUtils.js
@@ -31,11 +31,7 @@ import { isNativeToken, normalizeTxHash } from '@cardstack/utils';
 import networkTypes from '@rainbow-me/helpers/networkTypes';
 
 import WalletTypes from '@rainbow-me/helpers/walletTypes';
-import {
-  DEFAULT_HD_PATH,
-  identifyWalletType,
-  WalletLibraryType,
-} from '@rainbow-me/model/wallet';
+import { DEFAULT_HD_PATH, WalletLibraryType } from '@rainbow-me/model/wallet';
 import store from '@rainbow-me/redux/store';
 import { chains } from '@rainbow-me/references';
 import logger from 'logger';

--- a/src/utils/ethereumUtils.js
+++ b/src/utils/ethereumUtils.js
@@ -257,20 +257,7 @@ const deriveAccountFromPrivateKey = privateKey => {
 };
 
 const deriveAccountFromWalletInput = input => {
-  const type = identifyWalletType(input);
-  if (type === WalletTypes.privateKey) {
-    return deriveAccountFromPrivateKey(input);
-  } else if (type === WalletTypes.readOnly) {
-    const ethersWallet = { address: addHexPrefix(input), privateKey: null };
-    return {
-      address: addHexPrefix(input),
-      isHDWallet: false,
-      root: null,
-      type: WalletTypes.readOnly,
-      wallet: ethersWallet,
-      walletType: WalletLibraryType.ethers,
-    };
-  }
+  // We only allow mnemonic derived account for now.
   return deriveAccountFromMnemonic(input);
 };
 

--- a/src/utils/keychainConstants.js
+++ b/src/utils/keychainConstants.js
@@ -5,3 +5,4 @@ export const selectedWalletKey = 'rainbowSelectedWalletKey';
 export const allWalletsKey = 'rainbowAllWalletsKey';
 export const oldSeedPhraseMigratedKey = 'rainbowOldSeedPhraseMigratedKey';
 export const pinKey = 'rainbowPinKey';
+export const iCloudKey = 'cardstackIcloudKey';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1642,6 +1642,22 @@
   dependencies:
     "@types/hammerjs" "^2.0.36"
 
+"@electron/get@^1.0.1":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.13.0.tgz#95c6bcaff4f9a505ea46792424f451efea89228c"
+  integrity sha512-+SjZhRuRo+STTO1Fdhzqnv9D2ZhjxXP6egsJ9kiO8dtP68cDx7dFCwWi64dlMQV7sWcfW1OYCW4wviEBzmRsfQ==
+  dependencies:
+    debug "^4.1.1"
+    env-paths "^2.2.0"
+    fs-extra "^8.1.0"
+    got "^9.6.0"
+    progress "^2.0.3"
+    semver "^6.2.0"
+    sumchecker "^3.0.1"
+  optionalDependencies:
+    global-agent "^2.0.2"
+    global-tunnel-ng "^2.7.1"
+
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
@@ -4877,6 +4893,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
   integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
 
+"@types/node@^12.0.12":
+  version "12.20.29"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.29.tgz#f80f1e2156a376a23838d90905f68b816d486733"
+  integrity sha512-dU2ypz+gO5va1OBvs0iT3BNHG5SgTqRvq8r+kU3e/LAseKapUJ8zTUE9Ve9fTpi27tN/7ahOAhCJwQWsffvsyw==
+
 "@types/node@^12.12.6":
   version "12.20.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.10.tgz#4dcb8a85a8f1211acafb88d72fafc7e3d2685583"
@@ -5648,6 +5669,13 @@ anser@^1.4.9:
   version "1.4.10"
   resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.10.tgz#befa3eddf282684bd03b63dcda3927aef8c2e35b"
   integrity sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==
+
+ansi-align@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
+  integrity sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=
+  dependencies:
+    string-width "^2.0.0"
 
 ansi-colors@^4.1.1:
   version "4.1.1"
@@ -6747,6 +6775,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+boolean@^3.0.1:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.1.4.tgz#f51a2fb5838a99e06f9b6ec1edb674de67026435"
+  integrity sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w==
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -6760,6 +6793,19 @@ boom@7.x.x:
   integrity sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==
   dependencies:
     hoek "6.x.x"
+
+boxen@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
+  integrity sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==
+  dependencies:
+    ansi-align "^2.0.0"
+    camelcase "^4.0.0"
+    chalk "^2.0.1"
+    cli-boxes "^1.0.0"
+    string-width "^2.0.0"
+    term-size "^1.2.0"
+    widest-line "^2.0.0"
 
 bplist-creator@0.0.8:
   version "0.0.8"
@@ -6932,6 +6978,11 @@ btoa@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
   integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
+
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
@@ -7116,7 +7167,7 @@ camelcase@5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
   integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
 
-camelcase@^4.1.0:
+camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
@@ -7161,6 +7212,11 @@ capture-exit@^2.0.0:
   integrity sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==
   dependencies:
     rsvp "^4.8.4"
+
+capture-stack-trace@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
+  integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
 
 caseless@^0.12.0, caseless@~0.12.0:
   version "0.12.0"
@@ -7348,6 +7404,11 @@ chroma-js@^2.1.0:
   dependencies:
     cross-env "^6.0.3"
 
+ci-info@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+  integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
@@ -7396,6 +7457,11 @@ clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+
+cli-boxes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
+  integrity sha1-T6kXw+WclKAEzWH47lCdplFocUM=
 
 cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   version "2.1.0"
@@ -7749,7 +7815,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.4.4:
+concat-stream@^1.4.4, concat-stream@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -7758,6 +7824,26 @@ concat-stream@^1.4.4:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+config-chain@^1.1.11:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
+  integrity sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
+
+configstore@^3.0.0:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.5.tgz#e9af331fadc14dabd544d3e7e76dc446a09a530f"
+  integrity sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==
+  dependencies:
+    dot-prop "^4.2.1"
+    graceful-fs "^4.1.2"
+    make-dir "^1.0.0"
+    unique-string "^1.0.0"
+    write-file-atomic "^2.0.0"
+    xdg-basedir "^3.0.0"
 
 confusing-browser-globals@^1.0.9:
   version "1.0.10"
@@ -7971,6 +8057,13 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.5.3"
 
+create-error-class@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
+  integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
+  dependencies:
+    capture-stack-trace "^1.0.0"
+
 create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
@@ -8052,6 +8145,15 @@ cross-spawn@^4.0.2:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -8118,6 +8220,11 @@ crypto-js@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
   integrity sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==
+
+crypto-random-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+  integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
 
 css-color-keywords@^1.0.0:
   version "1.0.0"
@@ -8580,6 +8687,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+detect-node@^2.0.4:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
+
 detective-amd@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/detective-amd/-/detective-amd-3.0.1.tgz#aca8eddb1f405821953faf4a893d9b9e0430b09e"
@@ -8832,6 +8944,13 @@ dot-case@^3.0.3, dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+dot-prop@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
+  integrity sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==
+  dependencies:
+    is-obj "^1.0.0"
+
 dot-prop@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
@@ -8898,6 +9017,15 @@ electron-to-chromium@^1.3.723:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.725.tgz#04fc83f9189169aff50f0a00c6b4090b910cba85"
   integrity sha512-2BbeAESz7kc6KBzs7WVrMc1BY5waUphk4D4DX5dSQXJhsc3tP5ZFaiyuL0AB7vUKzDYpIeYwTYlEfxyjsGUrhw==
 
+electron@^11.1.0:
+  version "11.5.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-11.5.0.tgz#f1650543b9d8f2047d3807755bdb120153ed210f"
+  integrity sha512-WjNDd6lGpxyiNjE3LhnFCAk/D9GIj1rU3GSDealVShhkkkPR3Vh4q8ErXGDl1OAO/faomVa10KoFPUN/pLbNxg==
+  dependencies:
+    "@electron/get" "^1.0.1"
+    "@types/node" "^12.0.12"
+    extract-zip "^1.0.3"
+
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
@@ -8950,7 +9078,7 @@ emotion-theming@^10.0.19:
     "@emotion/weak-memoize" "0.2.5"
     hoist-non-react-statics "^3.3.0"
 
-encodeurl@~1.0.2:
+encodeurl@^1.0.2, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
@@ -9159,7 +9287,7 @@ es5-ext@^0.10.35, es5-ext@^0.10.50:
     es6-symbol "~3.1.3"
     next-tick "~1.0.0"
 
-es6-error@^4.0.2:
+es6-error@^4.0.2, es6-error@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
@@ -10127,6 +10255,19 @@ exec-sh@^0.3.2:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
   integrity sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==
 
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  integrity sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
@@ -10324,6 +10465,16 @@ extract-files@9.0.0, extract-files@^9.0.0:
   resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-9.0.0.tgz#8a7744f2437f81f5ed3250ed9f1550de902fe54a"
   integrity sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==
 
+extract-zip@^1.0.3:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927"
+  integrity sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==
+  dependencies:
+    concat-stream "^1.6.2"
+    debug "^2.6.9"
+    mkdirp "^0.5.4"
+    yauzl "^2.10.0"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -10480,6 +10631,13 @@ fbjs@^3.0.0:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
+
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
+  dependencies:
+    pend "~1.2.0"
 
 fetch-ponyfill@^4.0.0:
   version "4.1.0"
@@ -11100,6 +11258,26 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-agent@^2.0.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/global-agent/-/global-agent-2.2.0.tgz#566331b0646e6bf79429a16877685c4a1fbf76dc"
+  integrity sha512-+20KpaW6DDLqhG7JDiJpD1JvNvb8ts+TNl7BPOYcURqCrXqnN1Vf+XVOrkKJAFPqfX+oEhsdzOj1hLWkBTdNJg==
+  dependencies:
+    boolean "^3.0.1"
+    core-js "^3.6.5"
+    es6-error "^4.1.1"
+    matcher "^3.0.0"
+    roarr "^2.15.3"
+    semver "^7.3.2"
+    serialize-error "^7.0.1"
+
+global-dirs@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
+  integrity sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=
+  dependencies:
+    ini "^1.3.4"
+
 global-modules@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-2.0.0.tgz#997605ad2345f27f51539bea26574421215c7780"
@@ -11115,6 +11293,16 @@ global-prefix@^3.0.0:
     ini "^1.3.5"
     kind-of "^6.0.2"
     which "^1.3.1"
+
+global-tunnel-ng@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz#d03b5102dfde3a69914f5ee7d86761ca35d57d8f"
+  integrity sha512-4s+DyciWBV0eK148wqXxcmVAbFVPqtc3sEtUE/GTQfuU80rySLcMhUmHKSHI7/LDj8q0gDYI1lIhRRB7ieRAqg==
+  dependencies:
+    encodeurl "^1.0.2"
+    lodash "^4.17.10"
+    npm-conf "^1.1.3"
+    tunnel "^0.0.6"
 
 global@^4.3.2, global@^4.4.0, global@~4.4.0:
   version "4.4.0"
@@ -11135,6 +11323,13 @@ globals@^13.6.0, globals@^13.9.0:
   integrity sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==
   dependencies:
     type-fest "^0.20.2"
+
+globalthis@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.2.tgz#2a235d34f4d8036219f7e34929b5de9e18166b8b"
+  integrity sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==
+  dependencies:
+    define-properties "^1.1.3"
 
 globby@11.0.3:
   version "11.0.3"
@@ -11205,7 +11400,7 @@ good-listener@^1.2.2:
   dependencies:
     delegate "^3.1.2"
 
-got@9.6.0:
+got@9.6.0, got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
   integrity sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==
@@ -11221,6 +11416,23 @@ got@9.6.0:
     p-cancelable "^1.0.0"
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
+
+got@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
+  integrity sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=
+  dependencies:
+    create-error-class "^3.0.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    is-redirect "^1.0.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    lowercase-keys "^1.0.0"
+    safe-buffer "^5.0.1"
+    timed-out "^4.0.0"
+    unzip-response "^2.0.1"
+    url-parse-lax "^1.0.0"
 
 got@^7.1.0:
   version "7.1.0"
@@ -11805,6 +12017,11 @@ import-from@3.0.0:
   dependencies:
     resolve-from "^5.0.0"
 
+import-lazy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
+  integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
+
 import-lazy@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
@@ -11973,7 +12190,7 @@ ip-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
   integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
-ip@^1.1.5:
+ip@^1.1.4, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
@@ -12079,6 +12296,13 @@ is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
   integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
+
+is-ci@^1.0.10:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
+  integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
+  dependencies:
+    ci-info "^1.5.0"
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -12224,6 +12448,14 @@ is-hexadecimal@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
   integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
+is-installed-globally@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
+  integrity sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=
+  dependencies:
+    global-dirs "^0.1.0"
+    is-path-inside "^1.0.0"
+
 is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
@@ -12261,6 +12493,11 @@ is-negative-zero@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
   integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+
+is-npm@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
+  integrity sha1-8vtjpl5JBbQGyGBydloaTceTufQ=
 
 is-number-object@^1.0.4:
   version "1.0.6"
@@ -12308,6 +12545,13 @@ is-observable@^1.1.0:
   dependencies:
     symbol-observable "^1.1.0"
 
+is-path-inside@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+  integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
+  dependencies:
+    path-is-inside "^1.0.1"
+
 is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
@@ -12349,6 +12593,11 @@ is-property@^1.0.0, is-property@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
   integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
+
+is-redirect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
+  integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
 
 is-regex@^1.0.4, is-regex@^1.1.1:
   version "1.1.1"
@@ -13541,7 +13790,7 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -13771,6 +14020,13 @@ language-tags@^1.0.5:
   integrity sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=
   dependencies:
     language-subtag-registry "~0.3.2"
+
+latest-version@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
+  integrity sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=
+  dependencies:
+    package-json "^4.0.0"
 
 lazy-cache@^0.2.3:
   version "0.2.7"
@@ -14399,6 +14655,13 @@ make-color-more-chill@^0.1.1:
   dependencies:
     chroma-js "^2.1.0"
 
+make-dir@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
+  integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
+  dependencies:
+    pify "^3.0.0"
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -14490,6 +14753,13 @@ match-sorter@^4.0.2:
   dependencies:
     "@babel/runtime" "^7.10.5"
     remove-accents "0.4.2"
+
+matcher@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/matcher/-/matcher-3.0.0.tgz#bd9060f4c5b70aa8041ccc6f80368760994f30ca"
+  integrity sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==
+  dependencies:
+    escape-string-regexp "^4.0.0"
 
 material-colors@^1.2.1:
   version "1.2.6"
@@ -15061,7 +15331,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@1.2.0, minimist@1.2.3, minimist@^1.1.1, minimist@^1.1.2, minimist@^1.2.0, minimist@^1.2.5:
+minimist@1.2.0, minimist@1.2.3, minimist@^1.1.1, minimist@^1.1.2, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.3.tgz#3db5c0765545ab8637be71f333a104a965a9ca3f"
   integrity sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==
@@ -15124,7 +15394,7 @@ mkdirp@*, mkdirp@1.0.4, mkdirp@1.x, mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.5, mkdirp@~0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -15474,6 +15744,14 @@ normalize-url@^4.1.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
   integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
+
+npm-conf@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/npm-conf/-/npm-conf-1.1.3.tgz#256cc47bd0e218c259c4e9550bf413bc2192aff9"
+  integrity sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==
+  dependencies:
+    config-chain "^1.1.11"
+    pify "^3.0.0"
 
 npm-logical-tree@^1.2.1:
   version "1.2.1"
@@ -16010,6 +16288,16 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+package-json@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
+  integrity sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=
+  dependencies:
+    got "^6.7.1"
+    registry-auth-token "^3.0.1"
+    registry-url "^3.0.3"
+    semver "^5.1.0"
+
 pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
@@ -16235,6 +16523,11 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
+path-is-inside@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+  integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
+
 path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
@@ -16310,6 +16603,11 @@ pbkdf2@^3.0.14, pbkdf2@^3.0.17, pbkdf2@^3.0.3, pbkdf2@^3.0.9:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -16764,6 +17062,11 @@ property-information@^5.0.0:
   dependencies:
     xtend "^4.0.0"
 
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
+  integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
+
 proxy-addr@~2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.6.tgz#fdc2336505447d3f2f2c638ed272caf614bbb2bf"
@@ -16958,7 +17261,7 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.2.7:
+rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -16989,13 +17292,25 @@ react-color@^2.17.0:
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
 
-react-devtools-core@^4.6.0:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.8.2.tgz#4465f2e8de7795564aa20f28b2f3a9737586db23"
-  integrity sha512-3Lv3nI8FPAwKqUco35oOlgf+4j8mgYNnIcDv2QTfxEqg2G69q17ZJ8ScU9aBnymS28YC1OW+kTxLmdIQeTN8yg==
+react-devtools-core@4.19.1, react-devtools-core@4.19.2, react-devtools-core@^4.6.0:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.19.1.tgz#bc37c2ef2f48f28c6af4c7292be9dca1b63deace"
+  integrity sha512-2wJiGffPWK0KggBjVwnTaAk+Z3MSxKInHmdzPTrBh1mAarexsa93Kw+WMX88+XjN+TtYgAiLe9xeTqcO5FfJTw==
   dependencies:
     shell-quote "^1.6.1"
     ws "^7"
+
+react-devtools@^4.19.1:
+  version "4.19.2"
+  resolved "https://registry.yarnpkg.com/react-devtools/-/react-devtools-4.19.2.tgz#e2a6532defe016418a5cdf865ee1c02784c83fc3"
+  integrity sha512-bDfVZiujfM8R6qqW5nIIp+U7DA9HFLzRdRIrYz4CtR62haDn6naN9RDcNfIpOEzzh+gB+vAYQ2x82vkMT0yX3g==
+  dependencies:
+    cross-spawn "^5.0.1"
+    electron "^11.1.0"
+    ip "^1.1.4"
+    minimist "^1.2.3"
+    react-devtools-core "4.19.2"
+    update-notifier "^2.1.0"
 
 react-error-boundary@^3.1.0:
   version "3.1.3"
@@ -17948,6 +18263,21 @@ regexpu-core@^4.7.1:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.2.0"
 
+registry-auth-token@^3.0.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.4.0.tgz#d7446815433f5d5ed6431cd5dca21048f66b397e"
+  integrity sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==
+  dependencies:
+    rc "^1.1.6"
+    safe-buffer "^5.0.1"
+
+registry-url@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
+  integrity sha1-PU74cPc93h138M+aOBQyRE4XSUI=
+  dependencies:
+    rc "^1.0.1"
+
 regjsgen@^0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.2.tgz#92ff295fb1deecbf6ecdab2543d207e91aa33733"
@@ -18389,6 +18719,18 @@ rn-nodeify@10.2.0:
     semver "^5.0.1"
     xtend "^4.0.0"
 
+roarr@^2.15.3:
+  version "2.15.4"
+  resolved "https://registry.yarnpkg.com/roarr/-/roarr-2.15.4.tgz#f5fe795b7b838ccfe35dc608e0282b9eba2e7afd"
+  integrity sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==
+  dependencies:
+    boolean "^3.0.1"
+    detect-node "^2.0.4"
+    globalthis "^1.0.1"
+    json-stringify-safe "^5.0.1"
+    semver-compare "^1.0.0"
+    sprintf-js "^1.1.2"
+
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
@@ -18557,7 +18899,14 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-"semver@2 || 3 || 4 || 5", semver@7.0.0, semver@7.3.2, semver@7.x, semver@^5.0.1, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semver@^7.0.0, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@~2.3.1, semver@~5.4.1:
+semver-diff@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
+  integrity sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=
+  dependencies:
+    semver "^5.0.3"
+
+"semver@2 || 3 || 4 || 5", semver@7.0.0, semver@7.3.2, semver@7.x, semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0, semver@^7.0.0, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@~2.3.1, semver@~5.4.1:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
@@ -18594,6 +18943,13 @@ serialize-error@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"
   integrity sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=
+
+serialize-error@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-7.0.1.tgz#f1360b0447f61ffb483ec4157c737fab7d778e18"
+  integrity sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==
+  dependencies:
+    type-fest "^0.13.1"
 
 serve-static@1.14.1, serve-static@^1.13.1:
   version "1.14.1"
@@ -19030,6 +19386,11 @@ sponge-case@^1.0.1:
   integrity sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==
   dependencies:
     tslib "^2.0.3"
+
+sprintf-js@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -19506,6 +19867,13 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
+sumchecker@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-3.0.1.tgz#6377e996795abb0b6d348e9b3e1dfb24345a8e42"
+  integrity sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==
+  dependencies:
+    debug "^4.1.0"
+
 superstruct@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.6.2.tgz#c5eb034806a17ff98d036674169ef85e4c7f6a1c"
@@ -19753,6 +20121,13 @@ tempfile@^2.0.0:
   dependencies:
     temp-dir "^1.0.0"
     uuid "^3.0.1"
+
+term-size@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
+  integrity sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=
+  dependencies:
+    execa "^0.7.0"
 
 terminal-link@^2.0.0:
   version "2.1.1"
@@ -20121,6 +20496,11 @@ tunnel-agent@0.6.0, tunnel-agent@^0.6.0, tunnel-agent@~0.4.1:
   dependencies:
     safe-buffer "^5.0.1"
 
+tunnel@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
+
 tweetnacl-util@^0.15.0:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
@@ -20159,6 +20539,11 @@ type-fest@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+
+type-fest@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
+  integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
 
 type-fest@^0.20.2:
   version "0.20.2"
@@ -20318,6 +20703,13 @@ uniq@^1.0.1:
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
   integrity sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=
 
+unique-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
+  integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
+  dependencies:
+    crypto-random-string "^1.0.0"
+
 unist-util-find-all-after@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/unist-util-find-all-after/-/unist-util-find-all-after-1.0.5.tgz#5751a8608834f41d117ad9c577770c5f2f1b2899"
@@ -20420,6 +20812,27 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+unzip-response@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
+  integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
+
+update-notifier@^2.1.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
+  integrity sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==
+  dependencies:
+    boxen "^1.2.1"
+    chalk "^2.0.1"
+    configstore "^3.0.0"
+    import-lazy "^2.1.0"
+    is-ci "^1.0.10"
+    is-installed-globally "^0.1.0"
+    is-npm "^1.0.0"
+    latest-version "^3.0.0"
+    semver-diff "^2.0.0"
+    xdg-basedir "^3.0.0"
 
 upper-case-first@^2.0.2:
   version "2.0.2"
@@ -21141,6 +21554,13 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
+widest-line@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.1.tgz#7438764730ec7ef4381ce4df82fb98a53142a3fc"
+  integrity sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==
+  dependencies:
+    string-width "^2.1.1"
+
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
@@ -21194,7 +21614,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@^2.3.0:
+write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
   integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
@@ -21318,6 +21738,11 @@ xcode@^3.0.1:
   dependencies:
     simple-plist "^1.1.0"
     uuid "^7.0.3"
+
+xdg-basedir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
+  integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
 
 xhr-request-promise@^0.1.2:
   version "0.1.3"
@@ -21591,6 +22016,14 @@ yarn-logical-tree@^1.0.2:
   dependencies:
     npm-logical-tree "^1.2.1"
     semver "^5.5.0"
+
+yauzl@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Tried to add more meaningful names and comments to make the code more readable, but still there are lot's of improvements to be done.

- Allow wallet creation and restores only with mnemonic
- Removes the ability to watch or import using private key
- Enables backup and restore on iCloud
- Removes webcredentials and unused applinks
- Adds a initial doc diagram on how the initial nav wallet creation happens
- Adds react-devtools to use with flipper
- Fixes UI bugs, Restore disabled button misplaced, RestoreSheet not skipping line on smaller devices.
- Remove some android specifics since we have not way to make sure it keeps working and we need to redo anyway.

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2139)
- [x] Completes #(CS-1828)
- [x] Completes #(CS-1991) 

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

Video can be found [here](https://linear.app/cardstack/issue/CS-2139#comment-5075b902)
