### PR TITLE
[CS-2220][CS-2222]: Update PrepaidCards section on purchase

### DIFF
--- a/cardstack/src/hooks/prepaid-card/useBuyPrepaidCard.ts
+++ b/cardstack/src/hooks/prepaid-card/useBuyPrepaidCard.ts
@@ -101,7 +101,7 @@ export default function useBuyPrepaidCard() {
     goBack();
 
     InteractionManager.runAfterInteractions(() => {
-      navigate(Routes.WALLET_SCREEN);
+      navigate(Routes.WALLET_SCREEN, { scrollToPrepaidCardsSection: true });
     });
   }, [goBack, navigate]);
 
@@ -114,6 +114,8 @@ export default function useBuyPrepaidCard() {
         const prepaidCardAddress = orderData?.prepaidCardAddress;
 
         if (status === 'complete') {
+          clearInterval(orderStatusPolling);
+
           if (prepaidCardAddress) {
             await updatePrepaidCardsState(prepaidCardAddress);
           }
@@ -129,8 +131,6 @@ export default function useBuyPrepaidCard() {
             ],
             message: 'Prepaid card purchased successfully',
           });
-
-          clearInterval(orderStatusPolling);
         }
       }
     }, 2000);

--- a/cardstack/src/services/gnosis-service.ts
+++ b/cardstack/src/services/gnosis-service.ts
@@ -8,13 +8,13 @@ import {
 } from '@cardstack/cardpay-sdk';
 import Web3 from 'web3';
 import { captureException } from '@sentry/react-native';
+import { updatePrepaidCardWithCustomization } from './prepaid-card-service';
 import {
   saveDepots,
   saveMerchantSafes,
   savePrepaidCards,
 } from '@rainbow-me/handlers/localstorage/accountLocal';
 import { CurrencyConversionRates } from '@cardstack/types';
-import { fetchCardCustomizationFromDID } from '@cardstack/utils';
 import logger from 'logger';
 import Web3Instance from '@cardstack/models/web3-instance';
 import { Navigation } from '@rainbow-me/navigation';
@@ -70,24 +70,7 @@ export const fetchGnosisSafes = async (address: string) => {
     );
 
     const extendedPrepaidCards = await Promise.all(
-      prepaidCards.map(async (prepaidCard: PrepaidCardSafe) => {
-        try {
-          const cardCustomization = await fetchCardCustomizationFromDID(
-            prepaidCard.customizationDID
-          );
-
-          return { ...prepaidCard, cardCustomization };
-        } catch (e) {
-          logger.sentry(
-            'Fetch DID failed:',
-            e,
-            'DID =',
-            prepaidCard.customizationDID
-          );
-
-          return prepaidCard;
-        }
-      })
+      prepaidCards.map(updatePrepaidCardWithCustomization)
     );
 
     return {

--- a/cardstack/src/services/hub-service.ts
+++ b/cardstack/src/services/hub-service.ts
@@ -70,6 +70,7 @@ export interface OrderData {
   id: string;
   type: string;
   attributes: OrderAttrs;
+  prepaidCardAddress?: string;
 }
 
 export const getCustodialWallet = async (
@@ -192,9 +193,10 @@ export const getOrder = async (
       axiosConfig(authToken)
     );
 
-    if (results.data?.data) {
-      return await results.data?.data;
-    }
+    const prepaidCardAddress =
+      results?.data?.included?.[0].attributes?.['prepaid-card-address'] || null;
+
+    return { ...results?.data?.data, prepaidCardAddress };
   } catch (e) {
     logger.sentry('Error getting order details', e);
   }

--- a/cardstack/src/services/prepaid-card-service.ts
+++ b/cardstack/src/services/prepaid-card-service.ts
@@ -1,0 +1,45 @@
+import { PrepaidCardSafe } from '@cardstack/cardpay-sdk';
+import { getSafeData } from '@cardstack/services';
+import logger from 'logger';
+import { fetchCardCustomizationFromDID } from '@cardstack/utils';
+
+export const updatePrepaidCardWithCustomization = async (
+  card: PrepaidCardSafe
+) => {
+  try {
+    const cardCustomization = await fetchCardCustomizationFromDID(
+      card.customizationDID
+    );
+
+    return {
+      ...card,
+      cardCustomization,
+    };
+  } catch (e) {
+    logger.sentry('Error getting cardCustomization', e);
+  }
+
+  return card;
+};
+
+export const getPrepaidCardByAddress = async (
+  address: string
+): Promise<PrepaidCardSafe | undefined> => {
+  try {
+    const prepaidCard = (await getSafeData(address)) as
+      | PrepaidCardSafe
+      | undefined;
+
+    if (prepaidCard) {
+      const updatedPrepaidCard = updatePrepaidCardWithCustomization(
+        prepaidCard
+      );
+
+      return updatedPrepaidCard;
+    }
+
+    return prepaidCard;
+  } catch (e) {
+    logger.sentry('Error getPrepaidCardByAddress', e);
+  }
+};

--- a/src/components/secret-display/SecretDisplaySection.js
+++ b/src/components/secret-display/SecretDisplaySection.js
@@ -108,7 +108,6 @@ export default function SecretDisplaySection({
             iconProps={{ name: 'face-id' }}
             onPress={loadSeed}
             variant="white"
-            width="100%"
           >
             Show Secret Recovery Phrase
           </Button>

--- a/src/hooks/useRefreshAccountData.js
+++ b/src/hooks/useRefreshAccountData.js
@@ -1,13 +1,9 @@
 import { captureException } from '@sentry/react-native';
-import delay from 'delay';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { uniqueTokensRefreshState } from '../redux/uniqueTokens';
 import { fetchWalletNames } from '../redux/wallets';
-import {
-  fallbackExplorerClearState,
-  fallbackExplorerInit,
-} from '@rainbow-me/redux/fallbackExplorer';
+import { fetchAssetsBalancesAndPrices } from '@rainbow-me/redux/fallbackExplorer';
 import logger from 'logger';
 
 export default function useRefreshAccountData() {
@@ -15,18 +11,13 @@ export default function useRefreshAccountData() {
 
   const refreshAccountData = useCallback(async () => {
     try {
-      await dispatch(fallbackExplorerClearState());
       const getWalletNames = dispatch(fetchWalletNames());
       const getUniqueTokens = dispatch(uniqueTokensRefreshState());
-      const explorer = dispatch(fallbackExplorerInit());
 
       return Promise.all([
-        explorer,
         getWalletNames,
         getUniqueTokens,
-        // We will remove this and track the loading based on fallbackExplorer
-        // This is a workaround to have the animation while updating the assets
-        delay(12000), // minimum duration we want the "Pull to Refresh" animation to last
+        fetchAssetsBalancesAndPrices(),
       ]);
     } catch (error) {
       logger.log('Error refreshing data', error);

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -663,6 +663,16 @@ export const updateRefetchSavings = fetch => dispatch =>
     type: DATA_UPDATE_REFETCH_SAVINGS,
   });
 
+export const addNewPrepaidCard = newPrepaidCard => (dispatch, getState) => {
+  const { prepaidCards } = getState().data;
+  const updatedCards = [newPrepaidCard, ...prepaidCards];
+
+  dispatch({
+    payload: { prepaidCards: updatedCards },
+    type: DATA_UPDATE_PREPAIDCARDS,
+  });
+};
+
 // -- Reducer ----------------------------------------- //
 const INITIAL_STATE = {
   assetPricesFromUniswap: {},


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This updates the prepaidcards section with the new purchase one, once the tx is done successfully we navigate the user to the wallet screen and auto scroll to the PrepaidCard section so the user can see it's new card. 
Fixes `Show Secret Recovery Phrase`  button UI.
Fixes refresh, the previous implementation was just dispatching an action to redux, without waiting the promise to be resolved, we don't actually need to call fallbackExplorerInit when we want to update just the assets, so now we are calling `fetchAssetsBalancesAndPrices` directly which is enough to wait for the updated items.

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2222)
- [x] Completes #(CS-2220)


### Screenshots

<!-- Screenshots or animated GIFs included here -->


https://user-images.githubusercontent.com/20520102/138346545-642599c6-48ec-4f56-b164-4c1ee6d9f35e.mov


