### PR TITLE
[CS-2076] - Use loadingOverlay on card purchase, handle no orderData

### DIFF
--- a/cardstack/src/hooks/merchant/usePaymentMerchantUniversalLink.ts
+++ b/cardstack/src/hooks/merchant/usePaymentMerchantUniversalLink.ts
@@ -94,10 +94,7 @@ export const usePaymentMerchantUniversalLink = () => {
         network: networkName,
       });
 
-      showLoadingOverlay({
-        title: 'Processing Transaction',
-        subTitle: `This will take approximately\n10-15 seconds`,
-      });
+      showLoadingOverlay();
 
       const prepaidCardInstance: PrepaidCard = await getSDK(
         'PrepaidCard',

--- a/cardstack/src/navigation/hooks.tsx
+++ b/cardstack/src/navigation/hooks.tsx
@@ -28,11 +28,16 @@ export const useCardstackMainScreens = (Stack: any) =>
 export const useCardstackGlobalScreens = (Stack: any) =>
   getScreens(GlobalRoutes, GlobalScreens, Stack);
 
+const defaulLoadingtMessage = {
+  title: 'Processing Transaction',
+  subTitle: `This will take approximately\n10-15 seconds`,
+};
+
 export const useLoadingOverlay = () => {
   const { navigate, goBack } = useNavigation();
 
   const showLoadingOverlay = useCallback(
-    ({ title, subTitle }) => {
+    ({ title, subTitle } = defaulLoadingtMessage) => {
       navigate(MainRoutes.LOADING_OVERLAY, {
         title,
         subTitle,

--- a/cardstack/src/screens/BuyPrepaidCard/BuyPrepaidCard.tsx
+++ b/cardstack/src/screens/BuyPrepaidCard/BuyPrepaidCard.tsx
@@ -18,7 +18,6 @@ import ApplePayButton from '@rainbow-me/components/add-cash/ApplePayButton';
 import { SlackSheet } from '@rainbow-me/components/sheet';
 import { Inventory } from '@cardstack/services';
 import { useBuyPrepaidCard } from '@rainbow-me/hooks';
-import { LoadingOverlay } from '@rainbow-me/components/modal';
 import MediumPrepaidCard from '@cardstack/components/PrepaidCard/MediumPrepaidCard';
 import Routes from '@rainbow-me/routes';
 
@@ -34,7 +33,6 @@ const DEFAULT_CARD_CONFIG = {
 const BuyPrepaidCard = () => {
   const {
     onSelectCard,
-    isLoading,
     card,
     handlePurchase,
     isInventoryLoading,
@@ -69,11 +67,6 @@ const BuyPrepaidCard = () => {
 
   return (
     <Container backgroundColor="backgroundBlue" flex={1}>
-      {isLoading ? (
-        <LoadingOverlay
-          title={`Processing Transaction \nThis will take approximately \n10-15 seconds`}
-        />
-      ) : null}
       <SlackSheet
         backgroundColor="transparent"
         renderHeader={() => (


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

- Add default message to useLoadingOverlay
- Add loadingOverlay to prepaidcard purchase
- Handles error, case orderData is empty
- Reduces poller time to see if tx happens faster

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2076)

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size


<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

https://user-images.githubusercontent.com/20520102/138499455-f328972f-e522-4d58-b51a-fb1adae0f889.mov
