### PR TITLE
[CS-2120][CS-2119] Hide split prepaid card view in prepaid, update transfer transaction

### DIFF
--- a/cardstack/src/components/Button/Button.tsx
+++ b/cardstack/src/components/Button/Button.tsx
@@ -120,7 +120,7 @@ export const Button = ({
           </Container>
         )}
       </AnimatedButton>
-      {disabled && (
+      {disabled ? (
         <Container
           backgroundColor="black"
           top={0}
@@ -133,7 +133,7 @@ export const Button = ({
           width="100%"
           testID="disabledOverlay"
         />
-      )}
+      ) : null}
     </ButtonContentWrapper>
   );
 };

--- a/cardstack/src/components/Transactions/PrepaidCard/PrepaidCardTransferTransaction.tsx
+++ b/cardstack/src/components/Transactions/PrepaidCard/PrepaidCardTransferTransaction.tsx
@@ -28,7 +28,7 @@ export const PrepaidCardTransferTransaction = ({
         />
       }
       statusIconName="arrow-up"
-      statusText="Transferred"
+      statusText={item.statusText}
       topText="Face value"
       primaryText={item.spendBalanceDisplay}
       subText={item.nativeBalanceDisplay}

--- a/cardstack/src/graphql/fragments.graphql
+++ b/cardstack/src/graphql/fragments.graphql
@@ -124,6 +124,23 @@ fragment PrepaidCardTransfer on PrepaidCardTransfer {
   }
 }
 
+fragment PrepaidCardInventoryEvent on PrepaidCardInventoryEvent {
+  inventoryProvisioned {
+    timestamp
+    inventory {
+      sku {
+        issuer {
+          id
+        }
+        issuingToken {
+          symbol
+        }
+        faceValue
+      }
+    }
+  }
+}
+
 fragment MerchantClaim on MerchantClaim {
   id
   timestamp
@@ -200,6 +217,9 @@ fragment Transaction on Transaction {
   }
   prepaidCardPayments {
     ...PrepaidCardPayment
+  }
+  prepaidCardInventoryEvents {
+    ...PrepaidCardInventoryEvent
   }
   spendAccumulations {
     id

--- a/cardstack/src/graphql/graphql-codegen.ts
+++ b/cardstack/src/graphql/graphql-codegen.ts
@@ -6961,6 +6961,28 @@ export type PrepaidCardTransferFragment = (
   ) }
 );
 
+export type PrepaidCardInventoryEventFragment = (
+  { __typename?: 'PrepaidCardInventoryEvent' }
+  & { inventoryProvisioned?: Maybe<(
+    { __typename?: 'PrepaidCardProvisionedEvent' }
+    & Pick<PrepaidCardProvisionedEvent, 'timestamp'>
+    & { inventory: (
+      { __typename?: 'SKUInventory' }
+      & { sku: (
+        { __typename?: 'SKU' }
+        & Pick<Sku, 'faceValue'>
+        & { issuer: (
+          { __typename?: 'Account' }
+          & Pick<Account, 'id'>
+        ), issuingToken: (
+          { __typename?: 'Token' }
+          & Pick<Token, 'symbol'>
+        ) }
+      ) }
+    ) }
+  )> }
+);
+
 export type MerchantClaimFragment = (
   { __typename?: 'MerchantClaim' }
   & Pick<MerchantClaim, 'id' | 'timestamp' | 'amount'>
@@ -7035,6 +7057,9 @@ export type TransactionFragment = (
   )>>, prepaidCardPayments: Array<Maybe<(
     { __typename?: 'PrepaidCardPayment' }
     & PrepaidCardPaymentFragment
+  )>>, prepaidCardInventoryEvents: Array<Maybe<(
+    { __typename?: 'PrepaidCardInventoryEvent' }
+    & PrepaidCardInventoryEventFragment
   )>>, spendAccumulations: Array<Maybe<(
     { __typename?: 'SpendAccumulation' }
     & Pick<SpendAccumulation, 'id'>
@@ -7148,12 +7173,6 @@ export type GetPrepaidCardHistoryDataQuery = (
       { __typename?: 'PrepaidCard' }
       & { payments: Array<Maybe<(
         { __typename?: 'PrepaidCardPayment' }
-        & { transaction: (
-          { __typename?: 'Transaction' }
-          & TransactionFragment
-        ) }
-      )>>, splits: Array<Maybe<(
-        { __typename?: 'PrepaidCardSplit' }
         & { transaction: (
           { __typename?: 'Transaction' }
           & TransactionFragment
@@ -7374,6 +7393,24 @@ export const MerchantCreationFragmentDoc = gql`
   }
 }
     `;
+export const PrepaidCardInventoryEventFragmentDoc = gql`
+    fragment PrepaidCardInventoryEvent on PrepaidCardInventoryEvent {
+  inventoryProvisioned {
+    timestamp
+    inventory {
+      sku {
+        issuer {
+          id
+        }
+        issuingToken {
+          symbol
+        }
+        faceValue
+      }
+    }
+  }
+}
+    `;
 export const TransactionFragmentDoc = gql`
     fragment Transaction on Transaction {
   id
@@ -7408,6 +7445,9 @@ export const TransactionFragmentDoc = gql`
   prepaidCardPayments {
     ...PrepaidCardPayment
   }
+  prepaidCardInventoryEvents {
+    ...PrepaidCardInventoryEvent
+  }
   spendAccumulations {
     id
   }
@@ -7429,6 +7469,7 @@ ${PrepaidCardSplitFragmentDoc}
 ${TokenTransferFragmentDoc}
 ${MerchantCreationFragmentDoc}
 ${PrepaidCardPaymentFragmentDoc}
+${PrepaidCardInventoryEventFragmentDoc}
 ${MerchantClaimFragmentDoc}`;
 export const GetMerchantSafeDocument = gql`
     query GetMerchantSafe($address: ID!) {
@@ -7595,11 +7636,6 @@ export const GetPrepaidCardHistoryDataDocument = gql`
   safe(id: $address) {
     prepaidCard {
       payments {
-        transaction {
-          ...Transaction
-        }
-      }
-      splits {
         transaction {
           ...Transaction
         }

--- a/cardstack/src/graphql/queries.graphql
+++ b/cardstack/src/graphql/queries.graphql
@@ -38,11 +38,6 @@ query GetPrepaidCardHistoryData($address: ID!) {
           ...Transaction
         }
       }
-      splits {
-        transaction {
-          ...Transaction
-        }
-      }
       transfers {
         transaction {
           ...Transaction

--- a/cardstack/src/hooks/transactions/use-prepaid-card-transactions.tsx
+++ b/cardstack/src/hooks/transactions/use-prepaid-card-transactions.tsx
@@ -4,7 +4,6 @@ import logger from 'logger';
 import { useGetPrepaidCardHistoryDataQuery } from '@cardstack/graphql';
 import { PrepaidCardCreationStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/prepaid-card-creation-strategy';
 import { PrepaidCardPaymentStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/prepaid-card-payment-strategy';
-import { PrepaidCardSplitStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/prepaid-card-split-strategy';
 import { PrepaidCardTransferStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/prepaid-card-transfer-strategy';
 
 export const usePrepaidCardTransactions = (prepaidCardAddress: string) => {
@@ -27,9 +26,9 @@ export const usePrepaidCardTransactions = (prepaidCardAddress: string) => {
   const prepaidCard = data?.safe?.prepaidCard;
 
   if (prepaidCard) {
-    const { splits, transfers, payments, creation } = prepaidCard;
+    const { transfers, payments, creation } = prepaidCard;
 
-    transactions = [...splits, ...transfers, ...payments, creation];
+    transactions = [...transfers, ...payments, creation];
   }
 
   if (error) {
@@ -43,7 +42,6 @@ export const usePrepaidCardTransactions = (prepaidCardAddress: string) => {
     networkStatus,
     fetchMore,
     transactionStrategies: [
-      PrepaidCardSplitStrategy,
       PrepaidCardCreationStrategy,
       PrepaidCardPaymentStrategy,
       PrepaidCardTransferStrategy,

--- a/cardstack/src/types/transaction-types.ts
+++ b/cardstack/src/types/transaction-types.ts
@@ -209,6 +209,7 @@ export interface PrepaidCardTransferTransactionType {
   spendBalanceDisplay: string;
   nativeBalanceDisplay: string;
   transactionHash: string;
+  statusText: string;
   type: TransactionTypes.PREPAID_CARD_TRANSFER;
 }
 

--- a/cardstack/src/utils/__mocks__/merchant-strategies.ts
+++ b/cardstack/src/utils/__mocks__/merchant-strategies.ts
@@ -249,3 +249,172 @@ export const PREPAID_CARD_PAYMENT_MOCK = {
     },
   ],
 };
+
+export const PREPAID_CARD_TRANSFER_MOCK = {
+  __typename: 'Transaction',
+  bridgeToLayer1Events: [],
+  bridgeToLayer2Events: [],
+  id: '0x96390cbf6fcd88e2e54bed81a88fe41d5dce29e14b36537a730dfefd300d1e1a',
+  merchantClaims: [],
+  merchantCreations: [],
+  merchantFeePayments: [],
+  merchantRegistrationPayments: [],
+  prepaidCardCreations: [],
+  prepaidCardInventoryEvents: [],
+  prepaidCardPayments: [],
+  prepaidCardSplits: [],
+  prepaidCardTransfers: [
+    {
+      __typename: 'PrepaidCardTransfer',
+      from: {
+        __typename: 'Account',
+        id: '0x41149498EAc53F8C15Fe848bC5f010039A130963',
+      },
+      id: '0x96390cbf6fcd88e2e54bed81a88fe41d5dce29e14b36537a730dfefd300d1e1a',
+      prepaidCard: {
+        __typename: 'PrepaidCard',
+        creation: {
+          __typename: 'PrepaidCardCreation',
+          spendAmount: '111',
+        },
+        customizationDID: 'abcdefg',
+        faceValue: '11',
+        id: '0xcC91634e10345125E0234EF88cf422381D9E7483',
+      },
+      timestamp: '1634832515',
+      to: {
+        __typename: 'Account',
+        id: '0x8e9E9bB54BE3D6aa9756E254a0c93c851Cabd2B9',
+      },
+    },
+  ],
+  spendAccumulations: [],
+  supplierInfoDIDUpdates: [],
+  timestamp: '1634832515',
+  tokenSwaps: [],
+  tokenTransfers: [
+    {
+      __typename: 'TokenTransfer',
+      amount: '0',
+      from: '0xcC91634e10345125E0234EF88cf422381D9E7483',
+      id:
+        '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1-0x96390cbf6fcd88e2e54bed81a88fe41d5dce29e14b36537a730dfefd300d1e1a-7',
+      timestamp: '1634832515',
+      to: '0xaE5AC3685630b33Ed2677438EEaAe0aD5372c795',
+      token: {
+        __typename: 'Token',
+        id: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+        name: 'Dai Stablecoin.CPXD',
+        symbol: 'DAI',
+      },
+    },
+    {
+      __typename: 'TokenTransfer',
+      amount: '0',
+      from: '0xaE5AC3685630b33Ed2677438EEaAe0aD5372c795',
+      id:
+        '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1-0x96390cbf6fcd88e2e54bed81a88fe41d5dce29e14b36537a730dfefd300d1e1a-9',
+      timestamp: '1634832515',
+      to: '0x311529D6DB926441c352725448eeF4A64f71438e',
+      token: {
+        __typename: 'Token',
+        id: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+        name: 'Dai Stablecoin.CPXD',
+        symbol: 'DAI',
+      },
+    },
+  ],
+};
+
+export const PREPAID_CARD_PURCHASED_MOCK = {
+  __typename: 'Transaction',
+  bridgeToLayer1Events: [],
+  bridgeToLayer2Events: [],
+  id: '0x96390cbf6fcd88e2e54bed81a88fe41d5dce29e14b36537a730dfefd300d1e1a',
+  merchantClaims: [],
+  merchantCreations: [],
+  merchantFeePayments: [],
+  merchantRegistrationPayments: [],
+  prepaidCardCreations: [],
+  prepaidCardPayments: [],
+  prepaidCardSplits: [],
+  prepaidCardTransfers: [
+    {
+      __typename: 'PrepaidCardTransfer',
+      from: {
+        __typename: 'Account',
+        id: '0x41149498EAc53F8C15Fe848bC5f010039A130963',
+      },
+      id: '0x96390cbf6fcd88e2e54bed81a88fe41d5dce29e14b36537a730dfefd300d1e1a',
+      prepaidCard: {
+        __typename: 'PrepaidCard',
+        creation: {
+          __typename: 'PrepaidCardCreation',
+          spendAmount: '111',
+        },
+        customizationDID: 'abcdefg',
+        faceValue: '11',
+        id: '0xcC91634e10345125E0234EF88cf422381D9E7483',
+      },
+      timestamp: '1634832515',
+      to: {
+        __typename: 'Account',
+        id: '0x8e9E9bB54BE3D6aa9756E254a0c93c851Cabd2B9',
+      },
+    },
+  ],
+  prepaidCardInventoryEvents: [
+    {
+      inventoryProvisioned: {
+        inventory: {
+          sku: {
+            faceValue: '2500',
+            issuer: {
+              id: '0xEdEeb0Ec367CF65Be7efA8340be05170028679aA',
+            },
+            issuingToken: {
+              symbol: 'DAI',
+            },
+          },
+        },
+        timestamp: '1634604805',
+      },
+    },
+  ],
+  spendAccumulations: [],
+  supplierInfoDIDUpdates: [],
+  timestamp: '1634832515',
+  tokenSwaps: [],
+  tokenTransfers: [
+    {
+      __typename: 'TokenTransfer',
+      amount: '0',
+      from: '0xcC91634e10345125E0234EF88cf422381D9E7483',
+      id:
+        '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1-0x96390cbf6fcd88e2e54bed81a88fe41d5dce29e14b36537a730dfefd300d1e1a-7',
+      timestamp: '1634832515',
+      to: '0xaE5AC3685630b33Ed2677438EEaAe0aD5372c795',
+      token: {
+        __typename: 'Token',
+        id: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+        name: 'Dai Stablecoin.CPXD',
+        symbol: 'DAI',
+      },
+    },
+    {
+      __typename: 'TokenTransfer',
+      amount: '0',
+      from: '0xaE5AC3685630b33Ed2677438EEaAe0aD5372c795',
+      id:
+        '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1-0x96390cbf6fcd88e2e54bed81a88fe41d5dce29e14b36537a730dfefd300d1e1a-9',
+      timestamp: '1634832515',
+      to: '0x311529D6DB926441c352725448eeF4A64f71438e',
+      token: {
+        __typename: 'Token',
+        id: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+        name: 'Dai Stablecoin.CPXD',
+        symbol: 'DAI',
+      },
+    },
+  ],
+};

--- a/cardstack/test/strategies/prepaid-card-transfer-strategy.test.ts
+++ b/cardstack/test/strategies/prepaid-card-transfer-strategy.test.ts
@@ -1,0 +1,152 @@
+import {
+  PREPAID_CARD_TRANSFER_MOCK,
+  PREPAID_CARD_PURCHASED_MOCK,
+  PREPAID_CARD_PAYMENT_MOCK,
+} from '@cardstack/utils/__mocks__/merchant-strategies';
+import { PrepaidCardTransferStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/prepaid-card-transfer-strategy';
+
+jest.mock('../../../src/utils', () => ({ deviceUtils: { isIOS14: false } }));
+
+jest.mock('@rainbow-me/references', () => ({
+  shitcoins: 'JSON-MOCK-RETURN',
+}));
+
+jest.mock('@cardstack/utils', () => ({
+  convertSpendForBalanceDisplay: jest.fn().mockReturnValue({
+    nativeBalanceDisplay: '$1.00 USD',
+    tokenBalanceDisplay: '§100 SPEND',
+  }),
+  fetchCardCustomizationFromDID: jest.fn().mockReturnValue({
+    background: '#C3FC33',
+    issuerName: 'Test Card',
+    patternColor: 'white',
+    patternUrl:
+      'https://app.cardstack.com/images/prepaid-card-customizations/pattern-1.svg',
+    textColor: 'black',
+  }),
+}));
+
+const result = {
+  address: '0xcC91634e10345125E0234EF88cf422381D9E7483',
+  cardCustomization: {
+    background: '#C3FC33',
+    issuerName: 'Test Card',
+    patternColor: 'white',
+    patternUrl:
+      'https://app.cardstack.com/images/prepaid-card-customizations/pattern-1.svg',
+    textColor: 'black',
+  },
+  nativeBalanceDisplay: '$1.00 USD',
+  spendBalanceDisplay: '§100 SPEND',
+  statusText: 'Transferred',
+  timestamp: '1634832515',
+  transactionHash:
+    '0x96390cbf6fcd88e2e54bed81a88fe41d5dce29e14b36537a730dfefd300d1e1a',
+  type: 'prepaidCardTransfer',
+};
+
+const purchasedResult = {
+  address: '0xEdEeb0Ec367CF65Be7efA8340be05170028679aA',
+  cardCustomization: {
+    background: '#C3FC33',
+    issuerName: 'Test Card',
+    patternColor: 'white',
+    patternUrl:
+      'https://app.cardstack.com/images/prepaid-card-customizations/pattern-1.svg',
+    textColor: 'black',
+  },
+  nativeBalanceDisplay: '$1.00 USD',
+  spendBalanceDisplay: '§100 SPEND',
+  statusText: 'Purchased',
+  timestamp: '1634604805',
+  transactionHash:
+    '0x96390cbf6fcd88e2e54bed81a88fe41d5dce29e14b36537a730dfefd300d1e1a',
+  type: 'prepaidCardTransfer',
+};
+
+describe('PrepaidCardTransferStrategy', () => {
+  const contructorParams = {
+    accountAddress: '0x64Fbf34FaC77696112F1Abaa69D28211214d76c7',
+    currencyConversionRates: {
+      AUD: 1.362445,
+      CAD: 1.262345,
+      CNY: 6.432498,
+      EUR: 0.846102,
+      GBP: 0.72197,
+      INR: 73.445498,
+      JPY: 109.350353,
+      KRW: 1166.819664,
+      NZD: 1.402265,
+      RUB: 72.280298,
+      TRY: 8.429594,
+      USD: 1,
+      ZAR: 14.41804,
+    },
+    depotAddress: '0xF48c7B663DFCa76E1954bC44f7Fc006e2e04b09C',
+    merchantSafeAddresses: [
+      '0x51217e4769DFD61a42f8A509d4DCcC5683BFCB21',
+      '0xb891ad9b23826e61F010D5cd90d6a24Ea55010Bd',
+      '0x1D2BCdFb26319d1F5919aa66b105AE972946b9fE',
+      '0x6A4946bF21df59C58d4129802e0a37Ac649e6ae7',
+      '0x8de5D051565dF590A92f00a57B6d24609a17BC01',
+      '0x372582b0290cab3fcEb009A0F3869D50a00276D2',
+      '0x9Ed84407e5ed5B7c0323E5653A06F4528357e3B5',
+      '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
+    ],
+    nativeCurrency: 'USD',
+    prepaidCardAddresses: ['0x35Ae15dCEB6930756A59EfcC2169d2b834CdD371'],
+    transaction: PREPAID_CARD_TRANSFER_MOCK,
+  };
+
+  it('returns the proper object', async () => {
+    const PrepaidCardTransfer = new PrepaidCardTransferStrategy(
+      contructorParams as any
+    );
+
+    const value = await PrepaidCardTransfer.mapTransaction();
+    expect(value).toEqual(result);
+  });
+
+  it('returns the null object for other transaction', async () => {
+    const PrepaidCardTransferOtherTransaction = new PrepaidCardTransferStrategy(
+      {
+        ...contructorParams,
+        transaction: PREPAID_CARD_PAYMENT_MOCK as any,
+      }
+    );
+
+    const value = await PrepaidCardTransferOtherTransaction.mapTransaction();
+    expect(value).toEqual(null);
+  });
+
+  it('returns the purchased object', async () => {
+    const PrepaidCardTransfer = new PrepaidCardTransferStrategy({
+      ...contructorParams,
+      transaction: PREPAID_CARD_PURCHASED_MOCK as any,
+    });
+
+    const value = await PrepaidCardTransfer.mapTransaction();
+    expect(value).toEqual(purchasedResult);
+  });
+
+  it('returns true with proper constructors', () => {
+    const PrepaidCardTransfer = new PrepaidCardTransferStrategy(
+      contructorParams as any
+    );
+
+    expect(PrepaidCardTransfer.handlesTransaction()).toBeTruthy();
+  });
+
+  it('returns false with empty prepaidCardPayments', () => {
+    const newParams = {
+      ...contructorParams,
+      transaction: { prepaidCardTransfers: [] },
+    };
+
+    expect(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      new PrepaidCardTransferStrategy(newParams).handlesTransaction()
+    ).toBeFalsy();
+  });
+});


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

- Hide split transaction in prepaidcard activities
- Update transfer transaction status as Purchased when there's inventoryProvisioned data as Hasan provided
- Fix a button issue
<!-- Include a summary of the changes. -->

- [x] Completes #CS-2120
- [x] Completes #CS-2119

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size -->

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/16714648/138820944-372f51ac-755b-4f8c-8606-813f07f46a9a.png">
