### PR TITLE
[CS-2247]: Add loading per inventory item

### DIFF
--- a/cardstack/src/components/Button/Button.tsx
+++ b/cardstack/src/components/Button/Button.tsx
@@ -35,6 +35,7 @@ interface ButtonProps extends RestyleProps {
   onPress?: () => void;
   loading?: boolean;
   wrapper?: ButtonWrappper;
+  disablePress?: boolean;
 }
 
 type IconPosition = 'left' | 'right';
@@ -64,8 +65,9 @@ const ButtonContentWrapper = ({
  */
 export const Button = ({
   children,
-  disabled,
   iconProps,
+  disabled,
+  disablePress = false,
   iconPosition = 'left',
   wrapper = 'container',
   loading,
@@ -91,7 +93,7 @@ export const Button = ({
       <AnimatedButton
         {...props}
         alignItems="center"
-        disabled={disabled}
+        disabled={disabled || disablePress}
         onPress={onPress}
       >
         {loading ? (

--- a/cardstack/src/hooks/prepaid-card/useBuyPrepaidCard.ts
+++ b/cardstack/src/hooks/prepaid-card/useBuyPrepaidCard.ts
@@ -56,6 +56,16 @@ export interface Card {
   attributes: CardAttrs;
 }
 
+const emptyInventory = {
+  id: '',
+  type: '',
+  isSelected: false,
+  amount: 0,
+  attributes: undefined,
+};
+
+const inventoryInitialState = Array(4).fill(emptyInventory);
+
 export default function useBuyPrepaidCard() {
   const { goBack, navigate } = useNavigation();
   const dispatch = useDispatch();
@@ -74,7 +84,11 @@ export default function useBuyPrepaidCard() {
 
   const [order, setOrder] = useState<string>('');
   const [card, setCard] = useState<CardAttrs>();
-  const [inventoryData, setInventoryData] = useState<Inventory[]>();
+
+  const [inventoryData, setInventoryData] = useState<Inventory[] | undefined>(
+    inventoryInitialState
+  );
+
   const [sku, setSku] = useState<string>('');
   const [wyreOrderId, setWyreOrderId] = useState<string>('');
 
@@ -170,7 +184,10 @@ export default function useBuyPrepaidCard() {
   } = useWorker(async () => {
     const issuerAddress = getAddressByNetwork('wyreIssuer', network);
     const data = await getInventories(hubURL, authToken, issuerAddress);
-    setInventoryData(data);
+
+    if (data) {
+      setInventoryData(data);
+    }
   }, [authToken, currencyConversionRates, hubURL, nativeCurrency, network]);
 
   useEffect(() => {

--- a/cardstack/src/screens/BuyPrepaidCard/BuyPrepaidCard.tsx
+++ b/cardstack/src/screens/BuyPrepaidCard/BuyPrepaidCard.tsx
@@ -3,7 +3,7 @@ import { FlatList } from 'react-native';
 import { useNavigation } from '@react-navigation/core';
 import {
   CardContent,
-  InventorySection,
+  CardLoaderSkeleton,
   Subtitle,
   TopContent,
 } from './Components';
@@ -45,16 +45,19 @@ const BuyPrepaidCard = () => {
   const { navigate } = useNavigation();
 
   const renderItem = useCallback(
-    ({ item, index }: { item: Inventory; index: number }) => (
-      <CardContent
-        onPress={() => onSelectCard(item, index)}
-        isSelected={item?.isSelected}
-        amount={item?.amount}
-        faceValue={item?.attributes['face-value']}
-        quantity={item.attributes?.quantity}
-      />
-    ),
-    [onSelectCard]
+    ({ item, index }: { item: Inventory; index: number }) =>
+      isInventoryLoading || !item.attributes ? (
+        <CardLoaderSkeleton />
+      ) : (
+        <CardContent
+          onPress={() => onSelectCard(item, index)}
+          isSelected={item?.isSelected}
+          amount={item?.amount}
+          faceValue={item?.attributes?.['face-value']}
+          quantity={item.attributes?.quantity}
+        />
+      ),
+    [isInventoryLoading, onSelectCard]
   );
 
   const onPressSupport = useCallback(
@@ -111,15 +114,11 @@ const BuyPrepaidCard = () => {
         <Container backgroundColor="backgroundBlue" height="100%" flex={1}>
           <Container backgroundColor="backgroundBlue" width="100%" padding={4}>
             <Subtitle text="CHOOSE AMOUNT" />
-            {!isInventoryLoading ? (
-              <FlatList
-                data={inventoryData}
-                renderItem={renderItem}
-                numColumns={2}
-              />
-            ) : (
-              <InventorySection />
-            )}
+            <FlatList
+              data={inventoryData}
+              renderItem={renderItem}
+              numColumns={2}
+            />
           </Container>
           {card ? (
             <Container marginBottom={16} padding={4}>

--- a/cardstack/src/screens/BuyPrepaidCard/Components.tsx
+++ b/cardstack/src/screens/BuyPrepaidCard/Components.tsx
@@ -1,17 +1,6 @@
 import React from 'react';
-import {
-  Button,
-  Container,
-  ContainerProps,
-  Skeleton,
-  Text,
-} from '@cardstack/components';
-
-export const InventorySection = (props: ContainerProps) => (
-  <Container {...props}>
-    <Skeleton height={200} width="100%" marginTop={3} />
-  </Container>
-);
+import { StyleSheet } from 'react-native';
+import { Button, Container, Skeleton, Text } from '@cardstack/components';
 
 export const TopContent = () => {
   return (
@@ -26,6 +15,19 @@ export const TopContent = () => {
     </Container>
   );
 };
+
+const styles = StyleSheet.create({
+  cardContainer: {
+    flex: 1,
+    margin: 2,
+  },
+});
+
+export const CardLoaderSkeleton = () => (
+  <Container {...styles.cardContainer}>
+    <Skeleton height={100} />
+  </Container>
+);
 
 export const CardContent = ({
   onPress,
@@ -53,9 +55,9 @@ export const CardContent = ({
       borderColor={isSoldOut ? 'buttonDisabledBackground' : borderColor}
       variant={isSoldOut ? 'squareDisabled' : variant}
       onPress={onPress}
-      flex={1}
-      margin={2}
       wrapper="fragment"
+      disablePress={isSoldOut}
+      {...styles.cardContainer}
     >
       <Text
         color={isSoldOut ? 'blueText' : titleColor}


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
It's defined that we are only going to show 4 inventory options, so we can safely add the loading per item, this PR adds the loading skeleton for each inventory item and also disables the press if item is SoldOut

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2247)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Simulator Screen Recording - iPhone 11 - 2021-10-27 at 10 52 33](https://user-images.githubusercontent.com/20520102/139079658-d4f386bd-161b-4472-b826-a250dfa6b90c.gif)

