### PR TITLE
[CS-2239]: Handle websocket disconnections

### DIFF
--- a/cardstack/src/hooks/prepaid-card/useAuthToken.ts
+++ b/cardstack/src/hooks/prepaid-card/useAuthToken.ts
@@ -7,6 +7,7 @@ import { Network } from '@rainbow-me/networkTypes';
 import { useWorker } from '@cardstack/utils';
 import logger from 'logger';
 import { useAccountSettings } from '@rainbow-me/hooks';
+import HDProvider from '@cardstack/models/hd-provider';
 
 export const useAuthToken = (hubURL: string) => {
   const [authToken, setAuthToken] = useState<string>('');
@@ -21,6 +22,9 @@ export const useAuthToken = (hubURL: string) => {
     const web3 = await Web3Instance.get({ selectedWallet, network });
     const authAPI = await getSDK('HubAuth', web3, hubURL);
     setAuthToken(await authAPI.authenticate({ from: accountAddress }));
+
+    // resets signed provider and web3 instance to kill poller
+    await HDProvider.reset();
   }, [hubURL, accountAddress, network]);
 
   useEffect(() => {

--- a/cardstack/src/models/safes-providers.ts
+++ b/cardstack/src/models/safes-providers.ts
@@ -1,7 +1,10 @@
 import { getSDK } from '@cardstack/cardpay-sdk';
+import { captureException } from '@sentry/minimal';
 import { SignedProviderParams } from './hd-provider';
 import Web3Instance from './web3-instance';
 import logger from 'logger';
+import { MainRoutes } from '@cardstack/navigation';
+import { Navigation } from '@rainbow-me/navigation';
 
 export const getSafesInstance = async (
   signedProviderParams?: SignedProviderParams
@@ -12,6 +15,8 @@ export const getSafesInstance = async (
 
     return safes;
   } catch (e) {
-    logger.error('Unable to get safeInstance', e);
+    Navigation.handleAction(MainRoutes.ERROR_FALLBACK_SCREEN, {}, true);
+    captureException(e);
+    logger.sentry('Unable to get safeInstance', e);
   }
 };

--- a/cardstack/src/models/web3-instance.ts
+++ b/cardstack/src/models/web3-instance.ts
@@ -7,6 +7,13 @@ import logger from 'logger';
 const web3Instance: Web3 = new Web3();
 
 const Web3Instance = {
+  /**
+   * Return web3Instance either with a signed provider or not.
+   * @param signedProviderParams - info to sign the provider
+   *
+   * WARNING: After using a signed provider,
+   * it's recommended to reset it with `HDProvider.reset()`
+   */
   get: async (signedProviderParams?: SignedProviderParams) => {
     const isProviderDisconnected = !(web3Instance.currentProvider as WebsocketProvider)
       ?.connected;

--- a/cardstack/src/models/web3-instance.ts
+++ b/cardstack/src/models/web3-instance.ts
@@ -1,4 +1,5 @@
 import Web3 from 'web3';
+import { WebsocketProvider } from 'web3-core';
 import HDProvider, { SignedProviderParams } from './hd-provider';
 import Web3WsProvider from './web3-provider';
 import logger from 'logger';
@@ -7,8 +8,11 @@ const web3Instance: Web3 = new Web3();
 
 const Web3Instance = {
   get: async (signedProviderParams?: SignedProviderParams) => {
+    const isProviderDisconnected = !(web3Instance.currentProvider as WebsocketProvider)
+      ?.connected;
+
     try {
-      if (web3Instance.currentProvider === null) {
+      if (web3Instance.currentProvider === null || isProviderDisconnected) {
         web3Instance.setProvider(await Web3WsProvider.get());
       }
 

--- a/cardstack/src/models/web3-provider.ts
+++ b/cardstack/src/models/web3-provider.ts
@@ -25,8 +25,8 @@ const Web3WsProvider = {
         clientConfig: {
           keepalive: true,
           keepaliveInterval: 60000,
-          maxReceivedFrameSize: 200000000, // 2MiB
-          maxReceivedMessageSize: 100000000, // 10MiB
+          maxReceivedFrameSize: 100000000,
+          maxReceivedMessageSize: 100000000,
         },
       });
 

--- a/cardstack/src/models/web3-provider.ts
+++ b/cardstack/src/models/web3-provider.ts
@@ -5,18 +5,8 @@ import { WebsocketProvider } from 'web3-core';
 import { getNetwork } from '@rainbow-me/handlers/localstorage/globalSettings';
 import { Network } from '@rainbow-me/helpers/networkTypes';
 import logger from 'logger';
-import { Navigation } from '@rainbow-me/navigation';
-import { MainRoutes } from '@cardstack/navigation/routes';
 
 let provider: WebsocketProvider | null = null;
-
-const handleError = () => {
-  Navigation.handleAction(
-    MainRoutes.ERROR_FALLBACK_SCREEN,
-    { message: 'the web3 socket disconnected' },
-    true
-  );
-};
 
 const Web3WsProvider = {
   get: async (network?: Network) => {
@@ -29,32 +19,29 @@ const Web3WsProvider = {
         reconnect: {
           auto: true,
           delay: 1000,
+          onTimeout: true,
           maxAttempts: 10,
         },
         clientConfig: {
           keepalive: true,
           keepaliveInterval: 60000,
+          maxReceivedFrameSize: 200000000, // 2MiB
+          maxReceivedMessageSize: 100000000, // 10MiB
         },
       });
 
       //@ts-ignore it's wrongly typed bc it says it doesn't have param, but it does
       provider?.on('error', e => {
         logger.sentry('WS socket error', e);
-
-        // Navigate to error screen to force restart
-        handleError();
       });
 
       //@ts-ignore
       provider?.on('end', e => {
-        provider?.reconnect();
         logger.sentry('WS socket ended', e);
       });
 
       //@ts-ignore
       provider?.on('close', e => {
-        // Navigate to error screen to force restart
-        handleError();
         logger.sentry('WS socket close', e);
       });
     }


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Attempt to reduce the web3 ws disconnects, we will let the error go silent and will check if it's connected when we need a web3Instance, if not, we set a new provider.
Resets the HDProvider after getting the auth token to avoid the PollingTracker crash, also added documentation  on `WebInstance` usage to prevent forgetting this in the future.

PS: Still testing some edge cases to feel comfortable merging it, if you could test too, it would be great

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2239)

