### PR TITLE
[CS-2312]: Fix race condition on PayMerchant

### DIFF
--- a/cardstack/src/hooks/merchant/usePaymentMerchantUniversalLink.ts
+++ b/cardstack/src/hooks/merchant/usePaymentMerchantUniversalLink.ts
@@ -94,12 +94,12 @@ export const usePaymentMerchantUniversalLink = () => {
       prepaidCardAddress: string,
       onSuccess: (receipt: TransactionReceipt) => void
     ) => {
+      showLoadingOverlay();
+
       const web3 = await Web3Instance.get({
         selectedWallet,
         network: networkName,
       });
-
-      showLoadingOverlay();
 
       const prepaidCardInstance: PrepaidCard = await getSDK(
         'PrepaidCard',
@@ -114,16 +114,16 @@ export const usePaymentMerchantUniversalLink = () => {
         { from: accountAddress }
       );
 
-      onSuccess(receipt);
-
-      // resets signed provider and web3 instance to kill poller
-      await HDProvider.reset();
-
       // update prepaidcard facevalue almost instantly
       await syncPrepaidCardFaceValue(prepaidCardAddress);
 
       // refetch all assets to sync
       await fetchAssetsBalancesAndPrices();
+
+      // resets signed provider and web3 instance to kill poller
+      await HDProvider.reset();
+
+      onSuccess(receipt);
     },
     [
       merchantAddress,

--- a/cardstack/src/models/web3-instance.ts
+++ b/cardstack/src/models/web3-instance.ts
@@ -19,12 +19,13 @@ const Web3Instance = {
       ?.connected;
 
     try {
-      if (web3Instance.currentProvider === null || isProviderDisconnected) {
-        web3Instance.setProvider(await Web3WsProvider.get());
-      }
-
       if (signedProviderParams) {
         web3Instance.setProvider(await HDProvider.get(signedProviderParams));
+      } else if (
+        web3Instance.currentProvider === null ||
+        isProviderDisconnected
+      ) {
+        web3Instance.setProvider(await Web3WsProvider.get());
       }
     } catch (e) {
       logger.log('Failed while getting web3Instance', e);


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
We were calling the onSuccess function before handling all the updates on PayMerchantConfirm, and reseting the provider was triggering an error while trying to fetch the receipt block, so it reorganizes the order of the requests, also adds preference to set the provider to a signed one.

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2312)

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->
![Simulator Screen Recording - iPhone 11 - 2021-10-28 at 15 00 22](https://user-images.githubusercontent.com/20520102/139312501-08d1a760-cc0c-4141-8593-2a4db90a85e5.gif)


