### PR TITLE
[CS-1998]: Handle hub url prod - staging

### DIFF
--- a/cardstack/src/hooks/prepaid-card/useBuyPrepaidCard.ts
+++ b/cardstack/src/hooks/prepaid-card/useBuyPrepaidCard.ts
@@ -196,8 +196,10 @@ export default function useBuyPrepaidCard() {
   }, [authToken, currencyConversionRates, hubURL, nativeCurrency, network]);
 
   useEffect(() => {
-    getInventoryData();
-  }, [getInventoryData]);
+    if (authToken) {
+      getInventoryData();
+    }
+  }, [authToken, getInventoryData]);
 
   useEffect(() => {
     if (inventoryError) {
@@ -209,12 +211,14 @@ export default function useBuyPrepaidCard() {
   }, [inventoryError]);
 
   useEffect(() => {
-    const getCustodialWalletData = async () => {
-      const data = await getCustodialWallet(hubURL, authToken);
-      setCustodialWalletData(data);
-    };
+    if (authToken) {
+      const getCustodialWalletData = async () => {
+        const data = await getCustodialWallet(hubURL, authToken);
+        setCustodialWalletData(data);
+      };
 
-    getCustodialWalletData();
+      getCustodialWalletData();
+    }
   }, [authToken, hubURL]);
 
   const onSelectCard = useCallback(

--- a/cardstack/src/hooks/prepaid-card/useBuyPrepaidCard.ts
+++ b/cardstack/src/hooks/prepaid-card/useBuyPrepaidCard.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { getAddressByNetwork } from '@cardstack/cardpay-sdk';
 import { useDispatch } from 'react-redux';
 import { useNavigation } from '@react-navigation/core';
@@ -20,6 +20,7 @@ import { useAuthToken } from '@cardstack/hooks';
 import {
   CustodialWallet,
   getCustodialWallet,
+  getHubUrl,
   getInventories,
   getOrder,
   Inventory,
@@ -35,16 +36,9 @@ import {
 } from '@cardstack/utils';
 import { PrepaidCardCustomization } from '@cardstack/types';
 import { addNewPrepaidCard } from '@rainbow-me/redux/data';
-import { Network } from '@rainbow-me/helpers/networkTypes';
 import Routes from '@rainbow-me/navigation/routesNames';
 import { getPrepaidCardByAddress } from '@cardstack/services/prepaid-card-service';
 import { useLoadingOverlay } from '@cardstack/navigation';
-
-const HUB_URL_STAGING = 'https://hub-staging.stack.cards';
-const HUB_URL_PROD = 'https://hub.cardstack.com';
-
-const getHubUrl = (network: Network) =>
-  network === Network.xdai ? HUB_URL_PROD : HUB_URL_STAGING;
 
 interface CardAttrs extends InventoryAttrs {
   customizationDID?: PrepaidCardCustomization | null;
@@ -74,7 +68,7 @@ export default function useBuyPrepaidCard() {
   const { accountAddress, network } = useAccountSettings();
   const { showLoadingOverlay, dismissLoadingOverlay } = useLoadingOverlay();
 
-  const hubURL = getHubUrl(network);
+  const hubURL = useMemo(() => getHubUrl(network), [network]);
 
   const { authToken } = useAuthToken(hubURL);
 

--- a/cardstack/src/services/hub-service.ts
+++ b/cardstack/src/services/hub-service.ts
@@ -97,7 +97,10 @@ export const getInventories = async (
   issuerAddress: string
 ): Promise<Inventory[] | undefined> => {
   try {
-    const results = await axios.get('/api/inventories', axiosConfig(authToken));
+    const results = await axios.get(
+      `${hubURL}/api/inventories`,
+      axiosConfig(authToken)
+    );
 
     if (results?.data?.data) {
       const inventory = results?.data?.data;

--- a/cardstack/src/services/hub-service.ts
+++ b/cardstack/src/services/hub-service.ts
@@ -1,10 +1,17 @@
 import axios from 'axios';
 import { fromWei } from '@cardstack/cardpay-sdk';
 import logger from 'logger';
+import { Network } from '@rainbow-me/helpers/networkTypes';
+
+const HUB_URL_STAGING = 'https://hub-staging.stack.cards';
+const HUB_URL_PROD = 'https://hub.cardstack.com';
+
+export const getHubUrl = (network: Network) =>
+  network === Network.xdai ? HUB_URL_PROD : HUB_URL_STAGING;
 
 const axiosConfig = (authToken: string) => {
   return {
-    baseURL: 'https://hub-staging.stack.cards/',
+    baseURL: HUB_URL_PROD,
     headers: {
       'Content-Type': 'application/vnd.api+json',
       Authorization: `Bearer: ${authToken}`,


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Sets hub api url to production as default, handles needless calls without authToken and add hubUrl param to inventories call, which is quite weird eslint didn't complain about it.

PS: is not functional on xDai yet, because it's missing the issuer

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-1998)


