### PR TITLE
[CS-2311]: Revert to show only local time on payment confirmation

### DIFF
--- a/cardstack/src/utils/date-utils.ts
+++ b/cardstack/src/utils/date-utils.ts
@@ -1,4 +1,4 @@
-import { format, subMinutes } from 'date-fns';
+import { format } from 'date-fns';
 
 export type Units = 'days' | 'hours';
 
@@ -116,18 +116,11 @@ export const groupAccumulations = (
 
 export const dateFormatter = (
   ts: number,
-  isLocalTime = false,
   dateTimeFormat = 'MMM-dd-yyyy',
   timeFormat = 'h:mm:ss a',
   delimitation = '\n'
 ) => {
-  let timestamp = new Date(ts * 1000);
-
-  if (isLocalTime) {
-    // get local time based on timezone offset
-    const offsetInMinites = new Date().getTimezoneOffset();
-    timestamp = subMinutes(timestamp, offsetInMinites);
-  }
+  const timestamp = new Date(ts * 1000);
 
   return `${format(timestamp, dateTimeFormat)}${delimitation}${format(
     timestamp,

--- a/src/components/expanded-state/PaymentConfirmationExpandedState.tsx
+++ b/src/components/expanded-state/PaymentConfirmationExpandedState.tsx
@@ -45,7 +45,6 @@ const PaymentDetailsItem = ({
   info,
   infoColor = 'blueText',
   isTimestamp = false,
-  isLocalTime = false,
 }: {
   title: string;
   color?: string;
@@ -54,7 +53,6 @@ const PaymentDetailsItem = ({
   infoColor?: ResponsiveValue<keyof Theme['colors'], Theme>;
   name?: string;
   isTimestamp?: boolean;
-  isLocalTime?: boolean;
 }) => {
   return (
     <Container marginBottom={6} paddingHorizontal={6}>
@@ -90,7 +88,7 @@ const PaymentDetailsItem = ({
         <Container flex={2} />
         <Container flex={8}>
           <Text color={infoColor} size="small">
-            {isTimestamp ? dateFormatter(info, isLocalTime) : info}
+            {isTimestamp ? dateFormatter(info) : info}
           </Text>
         </Container>
       </Container>
@@ -136,7 +134,7 @@ export default function PaymentConfirmationExpandedState(
 
               {timestamp ? (
                 <Text color="black" marginTop={4} size="medium" weight="bold">
-                  {dateFormatter(timestamp, true, 'MMM dd', 'h:mm a', ', ')}
+                  {dateFormatter(timestamp, 'MMM dd', 'h:mm a', ', ')}
                 </Text>
               ) : null}
             </Container>
@@ -161,15 +159,8 @@ export default function PaymentConfirmationExpandedState(
             <PaymentDetailsItem
               info={timestamp}
               infoColor="black"
-              isLocalTime
               isTimestamp
               title="LOCAL TIME"
-            />
-            <PaymentDetailsItem
-              info={timestamp}
-              infoColor="black"
-              isTimestamp
-              title="UTC TIME"
             />
           </Container>
           <BlockscoutButton


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2311)

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

<img width="467" alt="Screen Shot 2021-10-28 at 16 30 05" src="https://user-images.githubusercontent.com/20520102/139323154-9852c1a0-b98e-4803-a148-54a1f729c4e5.png">

