### PR TITLE
 [CS-2321]: Enable send token from merchant address

### DIFF
--- a/cardstack/src/screens/SendSheetDepot/useSendSheetDepotScreen.test.ts
+++ b/cardstack/src/screens/SendSheetDepot/useSendSheetDepotScreen.test.ts
@@ -5,6 +5,7 @@ import { useSendSheetDepotScreen } from './useSendSheetDepotScreen';
 import { useAccountAssets } from '@rainbow-me/hooks';
 import { getSafesInstance } from '@cardstack/models/safes-providers';
 import { getUsdConverter } from '@cardstack/services/exchange-rate-service';
+import { reshapeSingleDepotTokenToAsset } from '@cardstack/utils';
 
 jest.mock('@cardstack/utils/device', () => ({ Device: { isAndroid: false } }));
 jest.mock('@rainbow-me/navigation/Navigation', () => ({
@@ -71,14 +72,20 @@ describe('useSendSheetDepotScreen', () => {
     expect(result.current.selected).toBeUndefined();
   });
 
-  it('should return empty array if not depot is found without error', async () => {
+  it('should return the current reshaped token from params if no depot is found', async () => {
     (useAccountAssets as jest.Mock).mockImplementation(() => ({
       depots: [],
     }));
 
+    const expectedAssets = [
+      reshapeSingleDepotTokenToAsset(
+        updatedData.updatedDepots[0].tokens[0] as any
+      ),
+    ];
+
     const { result } = renderHook(() => useSendSheetDepotScreen());
 
-    expect(result.current.allAssets).toEqual([]);
+    expect(result.current.allAssets).toEqual(expectedAssets);
   });
 
   it('should update gas fee and usdConverter initial render', async () => {

--- a/src/components/expanded-state/AvailableBalancesExpandedState.tsx
+++ b/src/components/expanded-state/AvailableBalancesExpandedState.tsx
@@ -123,8 +123,6 @@ const TabHeader = ({ tab, selectedTab, setSelectedTab }: TabHeaderProps) => {
 };
 
 const Assets = (props: AvailableBalancesExpandedStateProps) => {
-  const { tokens } = props.asset;
-
   const [network, nativeCurrency, currencyConversionRates] = useRainbowSelector<
     [string, string, { [key: string]: number }]
   >(state => [
@@ -132,7 +130,7 @@ const Assets = (props: AvailableBalancesExpandedStateProps) => {
     state.settings.nativeCurrency,
     state.currencyConversion.rates,
   ]);
-  const balancesSection = useBalancesSection(tokens);
+  const balancesSection = useBalancesSection(props.asset);
   const orderedSections = [
     balancesSection,
     // ToDo: add more sections here later
@@ -163,10 +161,12 @@ const Assets = (props: AvailableBalancesExpandedStateProps) => {
 };
 
 const useBalancesSection = (
-  tokens: TokenType[]
+  asset: MerchantSafeType
 ): AssetListSectionItem<TokenBalanceProps> => {
   const [nativeCurrency] = useNativeCurrencyAndConversionRates();
   const { navigate } = useNavigation();
+
+  const { tokens, address: safeAddress } = asset;
 
   const assets = useMemo(
     () =>
@@ -176,13 +176,14 @@ const useBalancesSection = (
         nativeBalance: token.native.balance.display,
         onPress: () =>
           navigate(Routes.EXPANDED_ASSET_SHEET, {
+            safeAddress,
             asset: token,
             type: 'token',
           }),
         key: token.tokenAddress,
         tokenBalanceFontSize: 'largeBalance',
       })),
-    [navigate, tokens]
+    [navigate, tokens, safeAddress]
   );
 
   const totalDisplay = useMemo(

--- a/src/components/expanded-state/ChartExpandedState.js
+++ b/src/components/expanded-state/ChartExpandedState.js
@@ -125,6 +125,7 @@ export default function ChartExpandedState(props) {
           <SendActionButton
             asset={currentAsset}
             color={color}
+            safeAddress={props.safeAddress}
             small={showSwapButton} //reenable once swap functionality is fixed
           />
         </Container>

--- a/src/components/sheet/sheet-action-buttons/SendActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/SendActionButton.js
@@ -4,15 +4,15 @@ import { useExpandedStateNavigation } from '../../../hooks';
 import { Button } from '@cardstack/components';
 import Routes from '@rainbow-me/routes';
 
-export default function SendActionButton({ small, asset }) {
+export default function SendActionButton({ small, asset, safeAddress }) {
   const navigate = useExpandedStateNavigation();
 
   const handlePress = useCallback(() => {
     const isDepot = !!asset?.tokenAddress;
     const route = isDepot ? Routes.SEND_FLOW_DEPOT : Routes.SEND_FLOW;
 
-    navigate(route, params => ({ ...params, asset }));
-  }, [navigate, asset]);
+    navigate(route, params => ({ ...params, asset, safeAddress }));
+  }, [asset, safeAddress, navigate]);
 
   const variantProp = small ? { variant: 'small' } : {};
 

--- a/src/screens/ExpandedAssetSheet.js
+++ b/src/screens/ExpandedAssetSheet.js
@@ -64,6 +64,7 @@ export default function ExpandedAssetSheet(props) {
       {ios && <TouchableBackdrop onPress={goBack} />}
       {createElement(ScreenTypes[params.type], {
         asset: selectedAsset,
+        safeAddress: params.safeAddress,
         ...props,
       })}
     </Container>


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR passes the merchant safe address forward to the send flow so we can transfer tokens from a merchant safe, now that we have the ability to transfer from depot and from merchants, we should probably rename the whole flow to `SendSheetSafes`  or something, since we have some refactor to do across these flows we can do this later.

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2321)


### Screenshots

<!-- Screenshots or animated GIFs included here -->


Merchant safe address:
<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/20520102/139483933-f7f227e4-fb06-4d86-b705-ed1e15ad2676.png"> 

Blockscout Transfer: 
<img width="450" alt="Screenshot" src="https://user-images.githubusercontent.com/20520102/139483887-3b167102-bea6-445d-96ba-7f62f6f67876.png"> 

