### PR TITLE
[Fix]: Preserve promise order on fallbackExplorer

### DIFF
--- a/src/redux/fallbackExplorer.js
+++ b/src/redux/fallbackExplorer.js
@@ -455,8 +455,14 @@ export const fetchAssetsBalancesAndPrices = async () => {
       formattedNativeCurrency
     );
 
+    const {
+      depots,
+      prepaidCards,
+      merchantSafes,
+    } = await fetchGnosisSafesAndAddCoingeckoId();
+
     // needs to be fetched after safes, because of contract signing
-    const fetchBalances = fetchAssetBalances(
+    const balances = await fetchAssetBalances(
       assets.map(({ asset: { asset_code, symbol } }) =>
         isNativeToken(symbol, network) ? ETH_ADDRESS : asset_code
       ),
@@ -464,16 +470,9 @@ export const fetchAssetsBalancesAndPrices = async () => {
       network
     );
 
-    const [
-      prices,
-      chartData,
-      { depots, prepaidCards, merchantSafes },
-      balances,
-    ] = await Promise.all([
+    const [prices, chartData] = await Promise.all([
       fetchPrices,
       fetchChartData,
-      fetchGnosisSafesAndAddCoingeckoId(),
-      fetchBalances,
     ]);
 
     const reduceAssets = reduceAssetsWithPriceChartAndBalances({


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Not sure why, probably some web3 confusion, but if we try to fetch the balances, before getting the safes, we get an error, so we can't really use promise.all with balances and safes since we need to preserve the order, that's why I'm reverting the change
