### PR TITLE
[CS-2377] Update transaction processing behaviors, refetch assets after success

### DIFF
--- a/cardstack/src/components/AssetList/AssetList.tsx
+++ b/cardstack/src/components/AssetList/AssetList.tsx
@@ -70,6 +70,7 @@ interface AssetListProps
 interface RouteType {
   params: {
     scrollToPrepaidCardsSection?: boolean;
+    forceRefreshOnce?: boolean;
   };
   key: string;
   name: string;
@@ -115,6 +116,20 @@ export const AssetList = (props: AssetListProps) => {
     type && toggle(type);
   }
 
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await refresh();
+    setRefreshing(false);
+  }, [refresh, setRefreshing]);
+
+  useEffect(() => {
+    if (params?.forceRefreshOnce) {
+      // Set to false so it won't update on assetsRefresh
+      onRefresh();
+      setParams({ forceRefreshOnce: false });
+    }
+  }, [onRefresh, params, sectionListRef, sections, setParams]);
+
   useEffect(() => {
     if (params?.scrollToPrepaidCardsSection) {
       const prepaidCardSectionIndex = sections.findIndex(
@@ -134,12 +149,6 @@ export const AssetList = (props: AssetListProps) => {
       }, 2500);
     }
   }, [params, sectionListRef, sections, setParams]);
-
-  async function onRefresh() {
-    setRefreshing(true);
-    await refresh();
-    setRefreshing(false);
-  }
 
   const goToBuyPrepaidCard = useCallback(() => {
     if (isDamaged) {

--- a/cardstack/src/constants.ts
+++ b/cardstack/src/constants.ts
@@ -1,3 +1,5 @@
 export const ENABLE_PAYMENTS = true;
 export const TRANSACTION_PAGE_SIZE = 100; // Temp increase the page size
 export const SUPPORT_EMAIL_ADDRESS = 'appfeedback@cardstack.com';
+export const SEND_TRANSACTION_ERROR_MESSAGE =
+  'An error has occurred, could not send. If this persists, please contact support@cardstack.com';

--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -4,6 +4,7 @@ export const MainRoutes = {
   PREPAID_CARD_MODAL: 'PrepaidCardModal',
   BUY_PREPAID_CARD: 'BuyPrepaidCard',
   SEND_FLOW_DEPOT: 'SendFlowDepot',
+  SEND_FLOW_EOA: 'SendFlowEOA',
   PAY_MERCHANT: 'PayMerchant',
   ERROR_FALLBACK_SCREEN: 'ErrorFallbackScreen',
   LOADING_OVERLAY: 'LoadingOverlay',

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -18,6 +18,7 @@ import {
 import { expandedPreset, sheetPreset } from '@rainbow-me/navigation/effects';
 import { nativeStackModalConfig } from '@rainbow-me/navigation/config';
 import RainbowRoutes from '@rainbow-me/navigation/routesNames';
+import SendSheetEOA from '@rainbow-me/screens/SendSheetEOA';
 
 interface ScreenNavigation {
   component: React.ComponentType<any>;
@@ -37,6 +38,10 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
   BUY_PREPAID_CARD: { component: BuyPrepaidCard },
   SEND_FLOW_DEPOT: {
     component: SendSheetDepot,
+    options: sheetPreset as StackNavigationOptions,
+  },
+  SEND_FLOW_EOA: {
+    component: SendSheetEOA,
     options: sheetPreset as StackNavigationOptions,
   },
   PAY_MERCHANT: {

--- a/cardstack/src/screens/SendSheetDepot/useSendSheetDepotScreen.ts
+++ b/cardstack/src/screens/SendSheetDepot/useSendSheetDepotScreen.ts
@@ -25,6 +25,7 @@ import {
 import Routes from '@rainbow-me/routes';
 import logger from 'logger';
 import { DepotAsset, TokenType } from '@cardstack/types';
+import { SEND_TRANSACTION_ERROR_MESSAGE } from '@cardstack/constants';
 import { getUsdConverter } from '@cardstack/services/exchange-rate-service';
 import HDProvider from '@cardstack/models/hd-provider';
 import { useWorker } from '@cardstack/utils/hooks-utilities';
@@ -313,13 +314,10 @@ export const useSendSheetDepotScreen = () => {
       if (errorMessage) {
         Alert({
           message: errorMessage,
-          title:
-            'An error has occurred, could not send. If this persists, please contact support@cardstack.com',
+          title: SEND_TRANSACTION_ERROR_MESSAGE,
         });
       } else {
-        Alert(
-          'An error has occurred, could not send. If this persists, please contact support@cardstack.com'
-        );
+        Alert({ title: SEND_TRANSACTION_ERROR_MESSAGE });
       }
 
       logger.sentry('TX Details', error);

--- a/src/components/sheet/sheet-action-buttons/SendActionButton.js
+++ b/src/components/sheet/sheet-action-buttons/SendActionButton.js
@@ -9,7 +9,7 @@ export default function SendActionButton({ small, asset, safeAddress }) {
 
   const handlePress = useCallback(() => {
     const isDepot = !!asset?.tokenAddress;
-    const route = isDepot ? Routes.SEND_FLOW_DEPOT : Routes.SEND_FLOW;
+    const route = isDepot ? Routes.SEND_FLOW_DEPOT : Routes.SEND_FLOW_EOA;
 
     navigate(route, params => ({ ...params, asset, safeAddress }));
   }, [asset, safeAddress, navigate]);

--- a/src/screens/SendSheetEOA.js
+++ b/src/screens/SendSheetEOA.js
@@ -19,8 +19,10 @@ import { createSignableTransaction, estimateGasLimit } from '../handlers/web3';
 import AssetTypes from '../helpers/assetTypes';
 import { sendTransaction } from '../model/wallet';
 import { useNavigation } from '../navigation/Navigation';
+import { SEND_TRANSACTION_ERROR_MESSAGE } from '@cardstack/constants';
 import { useLoadingOverlay } from '@cardstack/navigation';
 import { isNativeToken } from '@cardstack/utils';
+import { Alert } from '@rainbow-me/components/alerts';
 import {
   useAccountAssets,
   useAccountSettings,
@@ -364,6 +366,7 @@ const useSendSheetScreen = () => {
       }
     } catch (error) {
       setIsAuthorizing(false);
+      Alert({ title: SEND_TRANSACTION_ERROR_MESSAGE });
       dismissLoadingOverlay();
     }
   }, [

--- a/src/screens/SendSheetEOA.js
+++ b/src/screens/SendSheetEOA.js
@@ -19,6 +19,7 @@ import { createSignableTransaction, estimateGasLimit } from '../handlers/web3';
 import AssetTypes from '../helpers/assetTypes';
 import { sendTransaction } from '../model/wallet';
 import { useNavigation } from '../navigation/Navigation';
+import { useLoadingOverlay } from '@cardstack/navigation';
 import { isNativeToken } from '@cardstack/utils';
 import {
   useAccountAssets,
@@ -36,7 +37,6 @@ import {
 } from '@rainbow-me/hooks';
 import { ETH_ADDRESS_SYMBOL } from '@rainbow-me/references/addresses';
 import Routes from '@rainbow-me/routes';
-
 import { gasUtils } from '@rainbow-me/utils';
 import logger from 'logger';
 
@@ -64,6 +64,7 @@ const useSendSheetScreen = () => {
   const isDismissing = useRef(false);
 
   const recipientFieldRef = useRef();
+  const { showLoadingOverlay, dismissLoadingOverlay } = useLoadingOverlay();
 
   useEffect(() => {
     if (ios) {
@@ -355,15 +356,23 @@ const useSendSheetScreen = () => {
     }
 
     try {
+      showLoadingOverlay({ title: 'Sending...' });
       const submitSuccessful = await onSubmit();
 
       if (submitSuccessful) {
-        navigate(Routes.PROFILE_SCREEN);
+        navigate(Routes.WALLET_SCREEN, { forceRefreshOnce: true });
       }
     } catch (error) {
       setIsAuthorizing(false);
+      dismissLoadingOverlay();
     }
-  }, [amountDetails.assetAmount, navigate, onSubmit]);
+  }, [
+    amountDetails.assetAmount,
+    dismissLoadingOverlay,
+    navigate,
+    onSubmit,
+    showLoadingOverlay,
+  ]);
 
   const onPressTransactionSpeed = useCallback(
     onSuccess => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,8 @@
       "@rainbow-me/references": ["src/references"],
       "@rainbow-me/references/*": ["src/references/*"],
       "@rainbow-me/routes": ["src/navigation/routesNames"],
+      "@rainbow-me/screens": ["src/screens"],
+      "@rainbow-me/screens/*": ["src/screens/*"],
       "@rainbow-me/styles": ["src/styles"],
       "@rainbow-me/styles/*": ["src/styles/*"],
       "@rainbow-me/utilities": ["src/helpers/utilities"],


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

- Added overlay loading for sending transactions from depot and from EOA
- Moved SendSheetEOA screen route to cardstack routes to show send screen below of overlay loading
- Redirected to wallet screen and refetched assets to reflect balance changes(it redirected to profile screen before but weirdly transactions are never updated even after refetched until assets are refetched.. need to investigate why)

<!-- Include a summary of the changes. -->

- [x] Completes #CS-2377

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/16714648/140418480-aad09a09-f6e2-45da-9052-ae29aa1b4648.gif">
<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/16714648/140418489-7340fc34-8965-45b3-8236-5a350e712ef0.gif">
