### PR TITLE
[CS-2428]: Fix eoa currency price conversion

### DIFF
--- a/cardstack/test/helpers/fallbackExplorerHelper.test.ts
+++ b/cardstack/test/helpers/fallbackExplorerHelper.test.ts
@@ -7,7 +7,11 @@ import {
 import { Network } from '@rainbow-me/helpers/networkTypes';
 
 jest.mock('@cardstack/services', () => ({
-  getNativeBalanceFromOracle: jest.fn().mockResolvedValue(4.5),
+  getNativeBalanceFromOracle: jest.fn().mockImplementation(({ balance }) => {
+    const fromWei = require('@cardstack/cardpay-sdk').fromWei;
+    const balanceNumber = parseFloat(fromWei(balance));
+    return balanceNumber > 0 ? balanceNumber * 4.5 : balanceNumber;
+  }),
 }));
 
 describe('Fallback Explorer Helpers', () => {

--- a/cardstack/test/helpers/mocks/dataMocks.ts
+++ b/cardstack/test/helpers/mocks/dataMocks.ts
@@ -286,7 +286,7 @@ const chartData = {
 
 const balances = {
   '0x0000000000000000000000000000000000000000': '499703144000000000',
-  '0x6B78C121bBd10D8ef0dd3623CC1abB077b186F65': '0',
+  '0x6B78C121bBd10D8ef0dd3623CC1abB077b186F65': '1000000000000000000',
   '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1': '57823293170000000002',
   '0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee': '0',
 };
@@ -344,12 +344,12 @@ const updatedAssets = [
       price: {
         changed_at: null,
         relative_change_24h: 0,
-        value: 0,
+        value: 4.5,
       },
       symbol: 'DOM',
       chartPrices: null,
     },
-    quantity: '0',
+    quantity: '1000000000000000000',
   },
   {
     asset: {


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

We were only adding the native balance and not the price, so this PR adds the price to cpxd tokens, we still need to check if there's no `coingekoId` because, for example, `CARD` wont' have a `coingekoId ` but it doesn't have the `.CPXD` suffix, so if we don't check that we can't  get CARD's prices from oracle.

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2428)


### Screenshots

![Simulator Screen Recording - iPhone 11 - 2021-11-05 at 16 41 04](https://user-images.githubusercontent.com/20520102/140569222-3b870668-e5ff-48a5-aa70-db3eaf6abe84.gif)




<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->
