### PR TITLE
Be resilient to wallet-connect peerMeta with no icons

### DIFF
--- a/src/hooks/useWalletConnectConnections.js
+++ b/src/hooks/useWalletConnectConnections.js
@@ -11,7 +11,7 @@ import {
 const formatDappData = connections =>
   values(
     mapValues(connections, connection => ({
-      dappIcon: connection?.[0].peerMeta.icons[0],
+      dappIcon: connection?.[0].peerMeta.icons?.[0],
       dappName: connection?.[0].peerMeta.name,
       dappUrl: connection?.[0].peerMeta.url,
     }))


### PR DESCRIPTION
A peerMeta with no icons can occur when connecting to the dapp running on localhost in development mode
