### PR TITLE
[CS-2450] - Fix no fiat balance crashes

### DIFF
--- a/cardstack/src/components/BalanceCoinRow/BalanceCoinRow.tsx
+++ b/cardstack/src/components/BalanceCoinRow/BalanceCoinRow.tsx
@@ -30,6 +30,11 @@ export const BalanceCoinRow = ({
   pinned = false,
   hidden = false,
 }: BalanceCoinRowProps) => {
+  // Without price there's no way to get currency conversion
+  const hasPriceUnit = !!item.native?.price?.amount;
+
+  const nativeBalance = hasPriceUnit ? item.native?.balance?.display : '';
+
   return (
     <Touchable onPress={onPress}>
       <Container
@@ -57,7 +62,7 @@ export const BalanceCoinRow = ({
             address={item.address}
             tokenSymbol={item.symbol}
             tokenBalance={item.balance?.display}
-            nativeBalance={item.native?.balance?.display}
+            nativeBalance={nativeBalance}
           />
         </Container>
         <HiddenOverlay isEditing={isEditing} hidden={hidden} />

--- a/src/components/coin-row/SendCoinRow.js
+++ b/src/components/coin-row/SendCoinRow.js
@@ -14,14 +14,18 @@ import { CenteredContainer } from '@cardstack/components';
 const isTinyPhone = deviceUtils.dimensions.height <= 568;
 const selectedHeight = isTinyPhone ? 62 : 78;
 
-const BottomRow = ({ balance, native, nativeCurrencySymbol }) => {
+const BottomRow = ({ balance, native }) => {
   const { colors } = useTheme();
-  const fiatValue =
-    get(native, 'balance.display') || `${nativeCurrencySymbol}0.00`;
+
+  const hasNativeBalance = !!parseFloat(native?.balance?.amount);
+
+  const fiatValue = hasNativeBalance
+    ? `≈ ${get(native, 'balance.display')}`
+    : '';
 
   return (
     <Text color={colors.alpha(colors.blueGreyDark, 0.5)} size="smedium">
-      {get(balance, 'display')} ≈ {fiatValue}
+      {get(balance, 'display')} {fiatValue}
     </Text>
   );
 };

--- a/src/components/expanded-state/ChartExpandedState.js
+++ b/src/components/expanded-state/ChartExpandedState.js
@@ -74,6 +74,8 @@ export default function ChartExpandedState(props) {
   const ChartExpandedStateSheetHeight =
     ios || showChart ? heightWithChart : heightWithoutChart;
 
+  const hasNativeBalance = !!parseFloat(asset?.native?.balance?.amount);
+
   return (
     <SlackSheet
       additionalTopPadding={android}
@@ -100,7 +102,7 @@ export default function ChartExpandedState(props) {
           <TokenInfoItem asset={asset} title="Balance">
             <TokenInfoBalanceValue />
           </TokenInfoItem>
-          {asset?.native?.price?.display && (
+          {hasNativeBalance && (
             <TokenInfoItem align="right" title="Value" weight="bold">
               {`${asset?.native?.balance.display}`}
             </TokenInfoItem>

--- a/src/components/send/SendAssetFormToken.js
+++ b/src/components/send/SendAssetFormToken.js
@@ -32,6 +32,7 @@ export default function SendAssetFormToken({
   selected,
   sendMaxBalance,
   txSpeedRenderer,
+  showNativeCurrencyField = true,
   ...props
 }) {
   const { isSmallPhone, height: deviceHeight } = useDimensions();
@@ -53,17 +54,19 @@ export default function SendAssetFormToken({
           testID="selected-asset-field"
           value={assetAmount}
         />
-        <SendAssetFormField
-          autoFocus
-          label={nativeCurrency}
-          mask={nativeMask}
-          onChange={onChangeNativeAmount}
-          onFocus={onFocus}
-          onPressButton={sendMaxBalance}
-          placeholder={nativePlaceholder}
-          testID="selected-asset-quantity-field"
-          value={nativeAmount}
-        />
+        {showNativeCurrencyField && (
+          <SendAssetFormField
+            autoFocus
+            label={nativeCurrency}
+            mask={nativeMask}
+            onChange={onChangeNativeAmount}
+            onFocus={onFocus}
+            onPressButton={sendMaxBalance}
+            placeholder={nativePlaceholder}
+            testID="selected-asset-quantity-field"
+            value={nativeAmount}
+          />
+        )}
       </FormContainer>
       <FooterContainer deviceHeight={deviceHeight}>
         {buttonRenderer}

--- a/src/components/send/SendSheet.js
+++ b/src/components/send/SendSheet.js
@@ -96,6 +96,7 @@ export default function SendSheet({
   selectedGasPrice,
   fetchData = undefined,
   onPressTransactionSpeed = undefined,
+  showNativeCurrencyField = true,
 }) {
   const [currentInput, setCurrentInput] = useState('');
 
@@ -177,6 +178,7 @@ export default function SendSheet({
             onResetAssetSelection={onResetAssetSelection}
             selected={selected}
             sendMaxBalance={onMaxBalancePress}
+            showNativeCurrencyField={showNativeCurrencyField}
             txSpeedRenderer={
               isIphoneX() && (
                 <SendTransactionSpeed

--- a/src/screens/SendSheetEOA.js
+++ b/src/screens/SendSheetEOA.js
@@ -490,6 +490,8 @@ const useSendSheetScreen = () => {
     onMaxBalancePress,
     selectedGasPrice,
     onPressTransactionSpeed,
+    // without price, hide fiat field, since there's no way to calculate it
+    showNativeCurrencyField: Boolean(selected?.price?.value),
   };
 };
 


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Sometimes we may get a Timeout or in any other case may not be able to  retrieve the prices from SDK, so the fiat balance will be zero, if we don't get the price we can't calculate the balance amount. This PR checks wether we have prices and balance amount in order to hide or show the information.

PS: Maybe the layout on send flow can be improve to keep the input field fixed on top, we can discuss it later, just didn't think it was worth right now.

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2450)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Simulator Screen Recording - iPhone 11 - 2021-11-08 at 16 35 59](https://user-images.githubusercontent.com/20520102/140807157-a08d08d2-77b3-4707-bff9-b7252723526f.gif)
