### PR TITLE
[CS-2414] Implement activities reload in main transaction screen

### DIFF
--- a/cardstack/src/components/TransactionList/TransactionList.tsx
+++ b/cardstack/src/components/TransactionList/TransactionList.tsx
@@ -63,7 +63,6 @@ export const TransactionList = memo(
     useEffect(() => {
       if (isFocused) {
         onRefresh();
-        console.log('TransactionList refetch..');
       }
     }, [isFocused, onRefresh]);
 

--- a/cardstack/src/components/TransactionList/TransactionList.tsx
+++ b/cardstack/src/components/TransactionList/TransactionList.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useEffect } from 'react';
 import {
   RefreshControl,
   SectionList,
@@ -28,6 +28,23 @@ const styles = StyleSheet.create({
   background: { backgroundColor: colors.backgroundBlue },
 });
 
+const renderSectionHeader = ({
+  section: { title },
+}: {
+  section: { title: string };
+}) => (
+  <Container
+    paddingVertical={2}
+    paddingHorizontal={5}
+    width="100%"
+    backgroundColor="backgroundBlue"
+  >
+    <Text size="medium" color="white">
+      {title}
+    </Text>
+  </Container>
+);
+
 export const TransactionList = memo(
   ({ Header, isFocused }: TransactionListProps) => {
     const {
@@ -43,21 +60,12 @@ export const TransactionList = memo(
       refetch && refetch();
     }, [refetch]);
 
-    const renderSectionHeader = useCallback(
-      ({ section: { title } }) => (
-        <Container
-          paddingVertical={2}
-          paddingHorizontal={5}
-          width="100%"
-          backgroundColor="backgroundBlue"
-        >
-          <Text size="medium" color="white">
-            {title}
-          </Text>
-        </Container>
-      ),
-      []
-    );
+    useEffect(() => {
+      if (isFocused) {
+        onRefresh();
+        console.log('TransactionList refetch..');
+      }
+    }, [isFocused, onRefresh]);
 
     if (isLoadingTransactions) {
       return (

--- a/cardstack/src/constants.ts
+++ b/cardstack/src/constants.ts
@@ -5,4 +5,3 @@ export const SEND_TRANSACTION_ERROR_MESSAGE =
   'An error has occurred, could not send. If this persists, please contact support@cardstack.com';
 export const UPDATE_BALANCE_AND_PRICE_FREQUENCY = 10000;
 export const DISCOVER_NEW_ASSETS_FREQUENCY = 13000;
-export const FETCHING_TRANSACTIONS_FREQUENCY = 15000;

--- a/cardstack/src/constants.ts
+++ b/cardstack/src/constants.ts
@@ -3,3 +3,6 @@ export const TRANSACTION_PAGE_SIZE = 100; // Temp increase the page size
 export const SUPPORT_EMAIL_ADDRESS = 'appfeedback@cardstack.com';
 export const SEND_TRANSACTION_ERROR_MESSAGE =
   'An error has occurred, could not send. If this persists, please contact support@cardstack.com';
+export const UPDATE_BALANCE_AND_PRICE_FREQUENCY = 10000;
+export const DISCOVER_NEW_ASSETS_FREQUENCY = 13000;
+export const FETCHING_TRANSACTIONS_FREQUENCY = 15000;

--- a/cardstack/src/hooks/transactions/use-transaction-sections.tsx
+++ b/cardstack/src/hooks/transactions/use-transaction-sections.tsx
@@ -71,7 +71,7 @@ export const useTransactionSections = ({
     prevLastestTx === currentLastestTx && currentTxLength > prevTxLength;
 
   const isNewtx =
-    prevLastestTx !== currentLastestTx && prevTxLength === currentTxLength;
+    prevLastestTx !== currentLastestTx && prevTxLength !== currentTxLength;
 
   const isInitialTx = !prevLastestTx;
 

--- a/cardstack/src/screens/SendSheetDepot/useSendSheetDepotScreen.ts
+++ b/cardstack/src/screens/SendSheetDepot/useSendSheetDepotScreen.ts
@@ -322,11 +322,7 @@ export const useSendSheetDepotScreen = () => {
       // resets signed provider and web3 instance to kill poller
       await HDProvider.reset();
 
-      navigate(
-        Routes.WALLET_SCREEN,
-        { forceRefreshOnce: true, initialized: false },
-        true
-      );
+      navigate(Routes.WALLET_SCREEN, { forceRefreshOnce: true });
     } catch (error) {
       dismissLoadingOverlay();
       const errorMessage = (error as any).toString();

--- a/cardstack/src/screens/SendSheetDepot/useSendSheetDepotScreen.ts
+++ b/cardstack/src/screens/SendSheetDepot/useSendSheetDepotScreen.ts
@@ -128,10 +128,26 @@ export const useSendSheetDepotScreen = () => {
       const maxBalanceEth = Web3.utils.fromWei(maxBalanceWei, 'ether');
 
       updateMaxInputBalance(maxBalanceEth);
+
+      const isSufficientBalance =
+        Number(amountDetails.assetAmount) <= Number(maxBalanceEth);
+
+      if (isSufficientBalance !== amountDetails.isSufficientBalance) {
+        setAmountDetails(oldAmountDetails => ({
+          ...oldAmountDetails,
+          isSufficientBalance,
+        }));
+      }
     } catch (e) {
       logger.error('Error getting gasPriceEstimate or maxBalance', e);
     }
-  }, [amountDetails.assetAmount, recipient, safeAddress, selected]);
+  }, [
+    amountDetails.assetAmount,
+    amountDetails.isSufficientBalance,
+    recipient,
+    safeAddress,
+    selected,
+  ]);
 
   // Update gasFee initial render and when asset changes
   useEffect(() => {
@@ -306,7 +322,11 @@ export const useSendSheetDepotScreen = () => {
       // resets signed provider and web3 instance to kill poller
       await HDProvider.reset();
 
-      navigate(Routes.WALLET_SCREEN, { forceRefreshOnce: true });
+      navigate(
+        Routes.WALLET_SCREEN,
+        { forceRefreshOnce: true, initialized: false },
+        true
+      );
     } catch (error) {
       dismissLoadingOverlay();
       const errorMessage = (error as any).toString();

--- a/src/redux/fallbackExplorer.js
+++ b/src/redux/fallbackExplorer.js
@@ -13,6 +13,10 @@ import { setCurrencyConversionRates } from './currencyConversion';
 import { addressAssetsReceived } from './data';
 import store from './store';
 import {
+  DISCOVER_NEW_ASSETS_FREQUENCY,
+  UPDATE_BALANCE_AND_PRICE_FREQUENCY,
+} from '@cardstack/constants';
+import {
   reduceAssetsWithPriceChartAndBalances,
   reduceDepotsWithPricesAndChart,
 } from '@cardstack/helpers/fallbackExplorerHelper';
@@ -35,8 +39,6 @@ const FALLBACK_EXPLORER_SET_LATEST_TX_BLOCK_NUMBER =
   'explorer/FALLBACK_EXPLORER_SET_LATEST_TX_BLOCK_NUMBER';
 
 const HONEYSWAP_ENDPOINT = 'https://tokens.honeyswap.org';
-const UPDATE_BALANCE_AND_PRICE_FREQUENCY = 10000;
-const DISCOVER_NEW_ASSETS_FREQUENCY = 13000;
 
 // Some contracts like SNX / SUSD use an ERC20 proxy
 // some of those tokens have been migrated to a new address


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Implemented transaction activities reload when re-focus on transactions list screen and fixed an issue in use-transaction-sections. Also I've tried to fix an issue with input amount in depo send screen, which is button was keep disabled even after gas price calc is finished.

<!-- Include a summary of the changes. -->

- [x] Completes #CS-2414

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->
![Nov-09-2021 16-05-45](https://user-images.githubusercontent.com/16714648/140914070-aae021ee-421a-4131-b719-020369d76df8.gif)


