### PR TITLE
[CS-2424]: Chop off cpxd token to get hist price

### DIFF
--- a/cardstack/src/services/historical-pricing-service.ts
+++ b/cardstack/src/services/historical-pricing-service.ts
@@ -1,8 +1,6 @@
 import { CRYPTOCOMPARE_API_KEY } from 'react-native-dotenv';
-import { getNativeBalanceFromOracle } from './exchange-rate-service';
 import logger from 'logger';
-import { toWei } from '@rainbow-me/handlers/web3';
-import { isCPXDToken } from '@cardstack/utils';
+import { removeCPXDTokenSuffix } from '@cardstack/utils';
 
 const getRoundedTimestamp = (timestamp: string | number) => {
   const date = new Date(Number(timestamp) * 1000);
@@ -18,24 +16,17 @@ export const fetchHistoricalPrice = async (
   nativeCurrency: string
 ) => {
   try {
-    if (isCPXDToken(symbol)) {
-      const priceFromOracle = await getNativeBalanceFromOracle({
-        symbol,
-        nativeCurrency,
-        balance: toWei('1'),
-      });
-
-      return priceFromOracle;
-    }
+    // For cpxd tokens we chop off .CPXD in order to get mainnet's historical price
+    const tokenSymbol = removeCPXDTokenSuffix(symbol);
 
     const roundedTimestamp = getRoundedTimestamp(timestamp);
 
     const response = await fetch(
-      `https://min-api.cryptocompare.com/data/pricehistorical?fsym=${symbol}&tsyms=${nativeCurrency}&ts=${roundedTimestamp}&api_key=${CRYPTOCOMPARE_API_KEY}`
+      `https://min-api.cryptocompare.com/data/pricehistorical?fsym=${tokenSymbol}&tsyms=${nativeCurrency}&ts=${roundedTimestamp}&api_key=${CRYPTOCOMPARE_API_KEY}`
     );
 
     const data = await response.json();
-    const price = data[symbol][nativeCurrency];
+    const price = data[tokenSymbol][nativeCurrency];
 
     return price;
   } catch (e) {

--- a/cardstack/src/utils/cardpay-utils.ts
+++ b/cardstack/src/utils/cardpay-utils.ts
@@ -20,7 +20,7 @@ const LAYER_1_NETWORKS = [Network.mainnet, Network.kovan];
 
 const LAYER_2_NETWORKS = [Network.xdai, Network.sokol];
 
-const CPXD_TOKEN_SUFFIX = 'CPXD';
+const CPXD_TOKEN_SUFFIX = '.CPXD';
 
 export const isNativeToken = (symbol: string, network: string) => {
   const nativeTokenSymbol = getConstantByNetwork('nativeTokenSymbol', network);
@@ -30,6 +30,9 @@ export const isNativeToken = (symbol: string, network: string) => {
 
 export const isCPXDToken = (symbol: string) =>
   symbol.includes(CPXD_TOKEN_SUFFIX);
+
+export const removeCPXDTokenSuffix = (symbol: string) =>
+  symbol.replace(CPXD_TOKEN_SUFFIX, '');
 
 export const isLayer1 = (network: Network) =>
   LAYER_1_NETWORKS.includes(network);


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
We don't track historical prices in the sdk, but since cpxd token are based on mainnet we can remove `.CPXD` and use the token symbol to get the historical price. Now we can see that for the same amount of CARD for example `0.10` we have a different conversion amount. 

<!-- Include a summary of the changes. -->

-  [x] Completes #(CS-2424)


### Screenshots

<!-- Screenshots or animated GIFs included here -->


<img width="500" alt="Screenshot" src="https://user-images.githubusercontent.com/20520102/140940150-e24ca9d8-fefd-4e3d-9792-834815a2a6f6.png"> 


