### PR TITLE
[Fix]: Handle test warnings 

### DIFF
--- a/cardstack/src/hooks/merchant/__tests__/useMerchantInfoFromDID.test.ts
+++ b/cardstack/src/hooks/merchant/__tests__/useMerchantInfoFromDID.test.ts
@@ -1,6 +1,9 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react-native';
 import { useMerchantInfoFromDID } from '../useMerchantInfoFromDID';
 import * as MerchantUtils from '@cardstack/utils/merchant-utils';
+
+jest.mock('logger');
 
 describe('useMerchantInfoFromDID', () => {
   afterEach(() => {
@@ -21,14 +24,11 @@ describe('useMerchantInfoFromDID', () => {
       .spyOn(MerchantUtils, 'fetchMerchantInfoFromDID')
       .mockResolvedValueOnce(mockedDID);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useMerchantInfoFromDID('foo')
-    );
+    const { result } = renderHook(() => useMerchantInfoFromDID('foo'));
 
-    await waitForNextUpdate();
+    await waitFor(() => expect(spyFetchDID).toBeCalledTimes(1));
 
     expect(spyFetchDID).toBeCalledWith('foo');
-    expect(spyFetchDID).toBeCalledTimes(1);
     expect(result.current.merchantInfoDID).toStrictEqual(mockedDID);
   });
 
@@ -41,8 +41,9 @@ describe('useMerchantInfoFromDID', () => {
       useMerchantInfoFromDID('did does not exist')
     );
 
+    await waitFor(() => expect(spyFetchDID).toBeCalledTimes(1));
+
     expect(spyFetchDID).toBeCalledWith('did does not exist');
-    expect(spyFetchDID).toBeCalledTimes(1);
     expect(result.current.merchantInfoDID).toStrictEqual(undefined);
   });
 

--- a/cardstack/src/screens/SendSheetDepot/__tests__/useSendSheetDepotScreen.test.ts
+++ b/cardstack/src/screens/SendSheetDepot/__tests__/useSendSheetDepotScreen.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useRoute } from '@react-navigation/native';
+import { waitFor } from '@testing-library/react-native';
 import { updatedData } from '../../../helpers/__mocks__/dataMocks';
 import { useSendSheetDepotScreen } from '../useSendSheetDepotScreen';
 import { useAccountAssets } from '@rainbow-me/hooks';
@@ -92,7 +93,9 @@ describe('useSendSheetDepotScreen', () => {
 
     const { result } = renderHook(() => useSendSheetDepotScreen());
 
-    expect(result.current.allAssets).toEqual(expectedAssets);
+    await waitFor(() =>
+      expect(result.current.allAssets).toEqual(expectedAssets)
+    );
   });
 
   it('should update gas fee and usdConverter initial render', async () => {
@@ -111,11 +114,11 @@ describe('useSendSheetDepotScreen', () => {
 
     (getUsdConverter as jest.Mock).mockResolvedValue(mockConverter);
 
-    const { waitForNextUpdate, result } = renderHook(() =>
-      useSendSheetDepotScreen()
-    );
+    const { result } = renderHook(() => useSendSheetDepotScreen());
 
-    await waitForNextUpdate();
+    await waitFor(() =>
+      expect(result.current.selectedGasPrice).toEqual(usdGasEstimate)
+    );
 
     expect(mockSendTokensGasEstimate).toBeCalledWith(
       '0x107c1F2e2cE594cCb60629eaf33cF703419E01fb',
@@ -126,7 +129,6 @@ describe('useSendSheetDepotScreen', () => {
 
     expect(mockConverter).toBeCalledWith(weiGasEstimate);
     expect(getUsdConverter).toBeCalledWith('CARD');
-    expect(result.current.selectedGasPrice).toEqual(usdGasEstimate);
   });
 
   it('should update estimated gas fee with native currency amount', async () => {
@@ -153,12 +155,10 @@ describe('useSendSheetDepotScreen', () => {
 
     (getUsdConverter as jest.Mock).mockResolvedValue(mockConverter);
 
-    const { waitForNextUpdate, result } = renderHook(() =>
-      useSendSheetDepotScreen()
+    const { result } = renderHook(() => useSendSheetDepotScreen());
+
+    await waitFor(() =>
+      expect(result.current.selectedGasPrice).toEqual(eurGasEstimate)
     );
-
-    await waitForNextUpdate();
-
-    expect(result.current.selectedGasPrice).toEqual(eurGasEstimate);
   });
 });

--- a/cardstack/src/test-utils/jest-setup.js
+++ b/cardstack/src/test-utils/jest-setup.js
@@ -292,6 +292,12 @@ jest.mock('@cardstack/navigation/screens', () => ({
   default: jest.fn(),
 }));
 
+// Mock to avoid not checksum address console.warn
+jest.mock('@uniswap/sdk', () => ({
+  ...jest.requireActual('@uniswap/sdk'),
+  Token: jest.fn(),
+}));
+
 jest.mock('@cardstack/navigation', () => ({
   useLoadingOverlay: () => ({
     showLoadingOverlay: jest.fn(),


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

There were multiple act errors on the test, because sometimes while calling a async function and not waiting properly the component was updating after the test had run, so instead of waiting for the next update, we actually need to wait for the promise to resolve, for more information about this type of issue, there's a great Kent's doc [here](https://kentcdodds.com/blog/fix-the-not-wrapped-in-act-warning). There was also some annoying  console.warn happening because an unmocked package, so that's fixed too. Now we can read the test results better, without garbage.
