### PR TITLE
[CS-2482][CS-2506] - Earnings history sticky sheet / Blockscout Link

### DIFF
--- a/src/components/expanded-state/LifetimeEarningsExpandedState.tsx
+++ b/src/components/expanded-state/LifetimeEarningsExpandedState.tsx
@@ -18,15 +18,15 @@ import {
 } from '@cardstack/hooks';
 import { palette } from '@cardstack/theme';
 import { MerchantSafeType } from '@cardstack/types';
-import { convertSpendForBalanceDisplay } from '@cardstack/utils';
+import { convertSpendForBalanceDisplay, screenHeight } from '@cardstack/utils';
 import { sectionStyle } from '@cardstack/utils/layouts';
 import { ChartPath } from '@rainbow-me/animated-charts';
 import { useDimensions } from '@rainbow-me/hooks';
 import { useNavigation } from '@rainbow-me/navigation';
 import { useRainbowSelector } from '@rainbow-me/redux/hooks';
 
-const CHART_HEIGHT = 200;
-const HEIGHT = CHART_HEIGHT + 400;
+const CHART_HEIGHT = screenHeight * 0.25;
+const HEIGHT = screenHeight * 0.85;
 
 const useMerchantSafe = (address: string) => {
   const merchantSafes = useRainbowSelector(state => state.data.merchantSafes);

--- a/src/components/expanded-state/RecentActivityExpandedState.tsx
+++ b/src/components/expanded-state/RecentActivityExpandedState.tsx
@@ -14,7 +14,7 @@ import { screenHeight } from '@cardstack/utils';
 import { sectionStyle } from '@cardstack/utils/layouts';
 import { useNavigation } from '@rainbow-me/navigation';
 
-const CHART_HEIGHT = screenHeight * 0.75;
+const HEIGHT = screenHeight * 0.85;
 
 export default function RecentActivityExpandedState(props: {
   asset: MerchantSafeType;
@@ -23,7 +23,7 @@ export default function RecentActivityExpandedState(props: {
 
   useEffect(() => {
     setOptions({
-      longFormHeight: CHART_HEIGHT,
+      longFormHeight: HEIGHT,
     });
   }, [setOptions]);
   return useMemo(

--- a/src/components/list/ListItem.js
+++ b/src/components/list/ListItem.js
@@ -51,7 +51,7 @@ const ListItem = ({
       >
         <RowWithMargins
           align="center"
-          flex={1}
+          flex={2}
           justify={justify}
           margin={iconMargin}
         >

--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -1,3 +1,4 @@
+import { getConstantByNetwork } from '@cardstack/cardpay-sdk';
 import AsyncStorage from '@react-native-community/async-storage';
 import React, { useCallback, useMemo } from 'react';
 import { Linking, NativeModules, ScrollView, Share } from 'react-native';
@@ -82,7 +83,7 @@ export default function SettingsSection({
   onPressShowSecret,
 }) {
   const { wallets } = useWallets();
-  const { nativeCurrency, network } = useAccountSettings();
+  const { nativeCurrency, network, accountAddress } = useAccountSettings();
   const { isTinyPhone } = useDimensions();
 
   const { colors } = useTheme();
@@ -126,6 +127,11 @@ export default function SettingsSection({
         : Linking.openURL(SettingsExternalURLs.twitterWebUrl)
     );
   }, []);
+
+  const onPressBlockscout = useCallback(() => {
+    const blockExplorer = getConstantByNetwork('blockExplorer', network);
+    Linking.openURL(`${blockExplorer}/address/${accountAddress}`);
+  }, [accountAddress, network]);
 
   const { areBackedUp, canBeBackedUp } = useMemo(
     () => checkAllWallets(wallets),
@@ -175,6 +181,12 @@ export default function SettingsSection({
             {networkInfo?.[network]?.name}
           </ListItemArrowGroup>
         </ListItem>
+        <ListItem
+          icon={<Icon color="settingsTeal" name="eye" />}
+          label="View on Blockscout"
+          onPress={onPressBlockscout}
+          testID="blockscout-section"
+        />
       </ColumnWithDividers>
       <ListFooter />
       <ColumnWithDividers dividerRenderer={ListItemDivider}>


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

- Share sheet with sticky experience. We set height to 0.85 as initial HEIGHT for both Transactions / Lifetime Earnings, that makes it easier for the user to snap it to the top, specially in larger devices (Kiel tested it) 

- User setting with link to Blockscout wallet address

<!-- Include a summary of the changes. -->

- [X] Completes #(Linear ticket)

### Checklist

- [X] All UI changes have been tested on a small device

### Screenshots

![image](https://user-images.githubusercontent.com/8547776/141316625-797c611a-fd7b-4101-bcc9-9e285883b7ee.png)

<!-- Screenshots or animated GIFs included here -->

https://user-images.githubusercontent.com/8547776/141212994-3915ea10-b395-4d46-a92a-8b9b8f3179ad.mp4

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->
