### PR TITLE
[CS-2491] Fix reading qrcode currency when use camera outside app

### DIFF
--- a/cardstack/src/redux/payment.ts
+++ b/cardstack/src/redux/payment.ts
@@ -1,5 +1,4 @@
 import { AnyAction } from 'redux';
-import { NativeCurrency } from '@cardstack/cardpay-sdk/sdk/currencies';
 import { getNativeCurrency } from '@rainbow-me/handlers/localstorage/globalSettings';
 import { AppDispatch } from '@rainbow-me/redux/store';
 import logger from 'logger';
@@ -37,7 +36,7 @@ export const paymentChangeCurrency = (currency: string) => async (
 
 // -- Reducer --------------------------------------------------------------- //
 export const INITIAL_STATE = {
-  currency: NativeCurrency.USD,
+  currency: null,
 };
 
 export default (state = INITIAL_STATE, action: AnyAction) => {

--- a/cardstack/src/screens/PayMerchant/usePayMerchant.ts
+++ b/cardstack/src/screens/PayMerchant/usePayMerchant.ts
@@ -87,10 +87,16 @@ export const usePayMerchant = () => {
 
   // Updating in case first render selected is undefined
   useEffect(() => {
-    if (!selectedPrepaidCard?.address) {
+    if (!selectedPrepaidCard?.address && prepaidCards.length > 0) {
       selectPrepaidCard(prepaidCards[0]);
     }
   }, [prepaidCards, selectedPrepaidCard]);
+
+  useEffect(() => {
+    if (hasMultipleCards) {
+      setPayStep(PAY_STEP.CHOOSE_PREPAID_CARD);
+    }
+  }, [hasMultipleCards]);
 
   // Updating amount when nav param change
   useEffect(() => {

--- a/src/redux/settings.js
+++ b/src/redux/settings.js
@@ -39,14 +39,17 @@ const SETTINGS_UPDATE_NETWORK_SUCCESS =
 const SETTINGS_UPDATE_SHOW_TESTNETS = 'settings/SETTINGS_UPDATE_SHOW_TESTNETS';
 
 // -- Actions --------------------------------------------------------------- //
-export const settingsLoadState = () => async dispatch => {
+export const settingsLoadState = () => async (dispatch, getState) => {
   try {
     const nativeCurrency = await getNativeCurrency();
+    const paymentCurrency = getState().payment.currency;
     dispatch({
       payload: nativeCurrency,
       type: SETTINGS_UPDATE_NATIVE_CURRENCY_SUCCESS,
     });
-    dispatch(paymentChangeCurrency(nativeCurrency));
+    if (!paymentCurrency) {
+      dispatch(paymentChangeCurrency(nativeCurrency));
+    }
   } catch (error) {
     logger.log('Error loading native currency', error);
   }


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Fixed payment currency overrides happened when opens cardwallet app after read qrcode using camera app

<!-- Include a summary of the changes. -->

- [x] Completes #CS-2491

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Nov-11-2021 14-06-22](https://user-images.githubusercontent.com/16714648/141246653-be65dc66-987b-49e5-8862-e106a9778dfd.gif)

