### PR TITLE
[CS-2509] - Apple Pay button should not be clickable if no card is selected

### DIFF
--- a/cardstack/src/screens/BuyPrepaidCard/BuyPrepaidCard.tsx
+++ b/cardstack/src/screens/BuyPrepaidCard/BuyPrepaidCard.tsx
@@ -68,6 +68,11 @@ const BuyPrepaidCard = () => {
     [navigate]
   );
 
+  const isDisabled =
+    card?.quantity === 0 ||
+    inventoryData?.length === 0 ||
+    inventoryData?.filter(item => item?.isSelected).length === 0;
+
   return (
     <Container backgroundColor="backgroundBlue" flex={1}>
       <SlackSheet
@@ -89,11 +94,13 @@ const BuyPrepaidCard = () => {
             backgroundColor="backgroundBlue"
             justifyContent="center"
           >
-            <ApplePayButton
-              disabled={card?.quantity === 0}
-              onSubmit={handlePurchase}
-              onDisabledPress={() => console.log('onDisablePress')}
-            />
+            {isDisabled ? null : (
+              <ApplePayButton
+                disabled={isDisabled}
+                onSubmit={handlePurchase}
+                onDisabledPress={() => console.log('onDisablePress')}
+              />
+            )}
             <Touchable width="100%" onPress={onPressSupport}>
               <Container
                 alignItems="center"


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Disabling Apple Button if no card is selected or Inventory data is empty

<!-- Include a summary of the changes. -->

- [X] Completes #2509

### Checklist

- [X] All UI changes have been tested on a small device

### Screenshots

![Nov-15-2021 11-42-00](https://user-images.githubusercontent.com/8547776/141800921-b5192421-797b-4d5c-9e14-86019a1367d1.gif)

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size


<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->
