### PR TITLE
[CS-2552] Fix inputAmount not allowing decimals for SPD currency

### DIFF
--- a/cardstack/src/components/Input/InputAmount.tsx
+++ b/cardstack/src/components/Input/InputAmount.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, memo } from 'react';
+import React, { useCallback, memo, useEffect } from 'react';
 import { InteractionManager } from 'react-native';
 import {
   nativeCurrencies,
@@ -61,6 +61,13 @@ export const InputAmount = memo(
         })
       );
     }, [nativeCurrency, navigate]);
+
+    useEffect(() => {
+      if (nativeCurrency === NativeCurrency.SPD) {
+        setInputValue(formatNative(inputValue, nativeCurrency));
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [nativeCurrency, setInputValue]);
 
     const selectedCurrency = nativeCurrencies[nativeCurrency];
 

--- a/cardstack/src/screens/PaymentRequest/helper.tsx
+++ b/cardstack/src/screens/PaymentRequest/helper.tsx
@@ -103,7 +103,7 @@ export const useAmountConvertHelper = (
   const isSPDCurrency: boolean = inputNativeCurrency === NativeCurrency.SPD;
 
   const amountWithSymbol = isSPDCurrency
-    ? `§${formatNative(`${amountInNum}`)} SPD`
+    ? `§${formatNative(`${amountInNum}`, inputNativeCurrency)} SPD`
     : convertAmountToNativeDisplay(amountInNum, inputNativeCurrency);
 
   const amountInAnotherCurrency = isSPDCurrency

--- a/cardstack/src/utils/__tests__/currency-utils.test.ts
+++ b/cardstack/src/utils/__tests__/currency-utils.test.ts
@@ -37,7 +37,7 @@ describe('Currency utils', () => {
     it('should work for difference currencies', () => {
       const formattedValue = formatNative('12345.67890', 'SPD');
 
-      expect(formattedValue).toBe('12,345.67890');
+      expect(formattedValue).toBe('12,345');
     });
   });
 

--- a/cardstack/src/utils/currency-utils.ts
+++ b/cardstack/src/utils/currency-utils.ts
@@ -35,13 +35,10 @@ export function formatNative(value: string | undefined, currency = 'USD') {
     return '';
   }
 
-  const noDecimal = currency === NativeCurrency.SPD;
+  const decimalAllowed = currency !== NativeCurrency.SPD;
+  const isIncludeOneDot = (value.match(/\./g) || []).length === 1;
 
-  if (
-    !noDecimal &&
-    value.endsWith('.') &&
-    (value.match(/\./g) || []).length === 1
-  ) {
+  if (decimalAllowed && value.endsWith('.') && isIncludeOneDot) {
     return `${formattedCurrencyToAbsNum(value).toLocaleString('en-US', {
       currency,
       maximumFractionDigits: 20,
@@ -49,14 +46,14 @@ export function formatNative(value: string | undefined, currency = 'USD') {
     })}.`;
   }
 
-  if (!noDecimal && (value.match(/\./g) || []).length === 1) {
+  if (decimalAllowed && isIncludeOneDot) {
     const decimalStrings = value.split('.');
     return `${formattedCurrencyToAbsNum(decimalStrings[0]).toLocaleString(
       'en-US'
     )}.${decimalStrings[1].replace(/\D/g, '')}`;
   }
 
-  return `${formattedCurrencyToAbsNum(value, noDecimal).toLocaleString(
+  return `${formattedCurrencyToAbsNum(value, !decimalAllowed).toLocaleString(
     'en-US',
     {
       currency,

--- a/cardstack/src/utils/currency-utils.ts
+++ b/cardstack/src/utils/currency-utils.ts
@@ -4,10 +4,14 @@ import {
   formatCurrencyAmount,
   convertStringToNumber,
 } from '@cardstack/cardpay-sdk';
+import { NativeCurrency } from '@cardstack/cardpay-sdk/sdk/currencies';
 
 export const getDollarsFromDai = (dai: number) => dai / 100;
 
-export function formattedCurrencyToAbsNum(value?: string): number {
+export function formattedCurrencyToAbsNum(
+  value?: string,
+  noDecimal?: boolean
+): number {
   if (!value) {
     return 0;
   }
@@ -16,6 +20,10 @@ export function formattedCurrencyToAbsNum(value?: string): number {
 
   if (isNaN(result)) {
     return 0;
+  }
+
+  if (noDecimal) {
+    return Math.floor(result);
   }
 
   return result;
@@ -27,7 +35,13 @@ export function formatNative(value: string | undefined, currency = 'USD') {
     return '';
   }
 
-  if (value.endsWith('.') && (value.match(/\./g) || []).length === 1) {
+  const noDecimal = currency === NativeCurrency.SPD;
+
+  if (
+    !noDecimal &&
+    value.endsWith('.') &&
+    (value.match(/\./g) || []).length === 1
+  ) {
     return `${formattedCurrencyToAbsNum(value).toLocaleString('en-US', {
       currency,
       maximumFractionDigits: 20,
@@ -35,18 +49,21 @@ export function formatNative(value: string | undefined, currency = 'USD') {
     })}.`;
   }
 
-  if ((value.match(/\./g) || []).length === 1) {
+  if (!noDecimal && (value.match(/\./g) || []).length === 1) {
     const decimalStrings = value.split('.');
     return `${formattedCurrencyToAbsNum(decimalStrings[0]).toLocaleString(
       'en-US'
     )}.${decimalStrings[1].replace(/\D/g, '')}`;
   }
 
-  return `${formattedCurrencyToAbsNum(value).toLocaleString('en-US', {
-    currency,
-    maximumFractionDigits: 20,
-    maximumSignificantDigits: 20,
-  })}`;
+  return `${formattedCurrencyToAbsNum(value, noDecimal).toLocaleString(
+    'en-US',
+    {
+      currency,
+      maximumFractionDigits: 20,
+      maximumSignificantDigits: 20,
+    }
+  )}`;
 }
 
 export const nativeCurrencyToAmountInSpend = (


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

<!-- Include a summary of the changes. -->

Fixed inputAmount and currency util functions to don't allow decimals for SPD. note: there's still more work to do for improving inputAmount behavior for cs-2477, yet to be decided how gonna handle it.

- [x] Completes #CS-2552

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Nov-17-2021 17-46-52](https://user-images.githubusercontent.com/16714648/142190089-1e56d78f-143b-4155-b016-9dafbe2c348b.gif)

