### PR TITLE
[CS-2519] - Add warning to users about not sending non .CPXD tokens to safe addresses

### DIFF
--- a/cardstack/src/components/Checkbox/Checkbox.tsx
+++ b/cardstack/src/components/Checkbox/Checkbox.tsx
@@ -4,7 +4,7 @@ import { IconProps } from '../Icon';
 
 interface CheckboxProps {
   onPress?: () => void;
-  label: string;
+  label?: string;
   isDisabled?: boolean;
   iconProps?: IconProps;
   isSelected?: boolean;

--- a/cardstack/src/screens/CopyAddressSheet.tsx
+++ b/cardstack/src/screens/CopyAddressSheet.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useRoute } from '@react-navigation/core';
+import { TouchableOpacity } from 'react-native';
 import {
   ToastPositionContainerHeight,
   CopyToast,
@@ -10,6 +11,7 @@ import {
   SheetHandle,
   NetworkBadge,
   Button,
+  Checkbox,
 } from '@cardstack/components';
 import { useClipboard } from '@rainbow-me/hooks';
 import { abbreviations } from '@rainbow-me/utils';
@@ -22,12 +24,17 @@ const CopyAddressSheet = () => {
   const { setClipboard } = useClipboard();
   const [copiedText, setCopiedText] = useState(undefined);
   const [copyCount, setCopyCount] = useState(0);
+  const [checked, setChecked] = useState(false);
 
   const handleCopiedText = () => {
     setClipboard(address);
     setCopiedText(abbreviations.formatAddressForDisplay(address));
     setCopyCount(count => count + 1);
   };
+
+  const toogleCheckbox = useCallback(() => {
+    setChecked(!checked);
+  }, [checked]);
 
   return (
     <>
@@ -47,6 +54,25 @@ const CopyAddressSheet = () => {
             alignItems="center"
             width="100%"
           >
+            {!disableCopying ? (
+              <Container flexDirection="row" marginBottom={6}>
+                <Container flex={1} justifyContent="center">
+                  <Checkbox isSelected={checked} onPress={toogleCheckbox} />
+                </Container>
+                <Container flex={4}>
+                  <TouchableOpacity onPress={toogleCheckbox}>
+                    <Text
+                      fontFamily="OpenSans-Regular"
+                      fontSize={14}
+                      color="red"
+                    >
+                      I acknowledge that I can only send DAI.CPXD and CARD.CPXD
+                      to this address. All other funds may be lost.
+                    </Text>
+                  </TouchableOpacity>
+                </Container>
+              </Container>
+            ) : null}
             <Container maxWidth={230}>
               <Text
                 fontFamily="RobotoMono-Regular"
@@ -72,8 +98,10 @@ const CopyAddressSheet = () => {
                 paddingHorizontal={5}
               >
                 <Button
+                  disablePress={!checked}
                   iconProps={{ name: 'copy' }}
                   marginTop={4}
+                  variant={checked ? undefined : 'disabled'}
                   wrapper="fragment"
                   width="80%"
                   onPress={handleCopiedText}


### PR DESCRIPTION
…o safe addresses

<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description


Add red warning label to address copy section for Depots/Merchants

Copy:

"I acknowledge that I can only send 

DAI.CPXD and CARD.CPXD to this address.

All other funds may be lost."



<!-- Include a summary of the changes. -->

- [X] Completes #2519

### Checklist

- [X] All UI changes have been tested on a small device

### Screenshots

![image](https://user-images.githubusercontent.com/8547776/142485991-f2c0d810-b8e5-4514-a901-c0dc7e5485fc.png)
![image](https://user-images.githubusercontent.com/8547776/142486007-d2eb4f1a-d1a6-4ffb-a69c-0abf264a6289.png)


<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->
