### PR TITLE
[Feat]: Move promo banner to asset list scroll

### DIFF
--- a/cardstack/src/components/AssetList/AssetList.tsx
+++ b/cardstack/src/components/AssetList/AssetList.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useCallback, useEffect, createRef } from 'react';
+import React, {
+  useState,
+  useCallback,
+  useEffect,
+  createRef,
+  useMemo,
+} from 'react';
 import { LayoutAnimation, RefreshControl, SectionList } from 'react-native';
 import { BackgroundColorProps, ColorProps } from '@shopify/restyle';
 import { getConstantByNetwork } from '@cardstack/cardpay-sdk';
@@ -8,6 +14,10 @@ import ButtonPressAnimation from '../../../../src/components/animations/ButtonPr
 import { Theme } from '../../theme';
 import { AssetFooter } from './AssetFooter';
 import { AssetListLoading } from './AssetListLoading';
+import {
+  DiscordPromoBanner,
+  useDiscordPromoBanner,
+} from '@cardstack/components/DiscordPromoBanner';
 import {
   Button,
   Container,
@@ -116,6 +126,19 @@ export const AssetList = (props: AssetListProps) => {
     type && toggle(type);
   }
 
+  const {
+    showPromoBanner,
+    onPress: onDiscordPromoPress,
+  } = useDiscordPromoBanner();
+
+  const renderPromoBanner = useMemo(
+    () =>
+      showPromoBanner ? (
+        <DiscordPromoBanner onPress={onDiscordPromoPress} />
+      ) : null,
+    [onDiscordPromoPress, showPromoBanner]
+  );
+
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
     await refresh();
@@ -184,6 +207,7 @@ export const AssetList = (props: AssetListProps) => {
   return (
     <>
       <SectionList
+        ListHeaderComponent={renderPromoBanner}
         onScrollToIndexFailed={onScrollToIndexFailed}
         ref={sectionListRef}
         refreshControl={

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -29,10 +29,6 @@ import {
 } from '../hooks';
 import { useCoinListEditedValue } from '../hooks/useCoinListEdited';
 import { Container, SystemNotification, Text } from '@cardstack/components';
-import {
-  DiscordPromoBanner,
-  useDiscordPromoBanner,
-} from '@cardstack/components/DiscordPromoBanner';
 import { colors } from '@cardstack/theme';
 import { isLayer2, NOTIFICATION_KEY } from '@cardstack/utils';
 import { useNavigation } from '@rainbow-me/navigation';
@@ -66,11 +62,6 @@ export default function WalletScreen() {
 
   const navigation = useNavigation();
   const { editing, toggle } = usePinnedAndHiddenItemOptions();
-
-  const {
-    showPromoBanner,
-    onPress: onDiscordPromoPress,
-  } = useDiscordPromoBanner();
 
   const setNotifications = async () => {
     try {
@@ -170,9 +161,6 @@ export default function WalletScreen() {
             <SystemNotification type="info" {...notificationProps} />
           )}
         </HeaderOpacityToggler>
-        {showPromoBanner && (
-          <DiscordPromoBanner onPress={onDiscordPromoPress} />
-        )}
         <AssetListWrapper />
       </FabWrapper>
     </WalletPage>


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

To improve smaller devices usability we are moving the promo banner to assets section so it can be scrolled.
<!-- Include a summary of the changes. -->


### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

https://user-images.githubusercontent.com/20520102/142903625-7e9aa94a-a82d-4a05-a328-99923ffe4022.mp4


