### PR TITLE
[Fix]: Show loading while refetchn safes w/ new acc

### DIFF
--- a/cardstack/src/components/AssetList/AssetList.tsx
+++ b/cardstack/src/components/AssetList/AssetList.tsx
@@ -114,6 +114,7 @@ export const AssetList = (props: AssetListProps) => {
     color,
     headerPaddingVertical,
     headerPaddingHorizontal,
+    isFetchingSafes,
   } = props;
 
   const networkName = getConstantByNetwork('name', network);
@@ -201,7 +202,12 @@ export const AssetList = (props: AssetListProps) => {
     }
   }, [isDamaged, network, navigate, accountAddress]);
 
-  if (loading) {
+  const isNotManualRefetch = useMemo(() => !refreshing && isFetchingSafes, [
+    isFetchingSafes,
+    refreshing,
+  ]);
+
+  if (loading || isNotManualRefetch) {
     return <AssetListLoading />;
   }
 


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

While switching account, or creating a new one, the isLoading flag from rtk query is not triggered, what is triggered is the isFetching flag, which is also triggered when we pull to refresh, so we need a condition to check if it's not manually triggered by the user and we isFetching, it means some args changed and the data will be different so we need to show the fullscreen loading.



### Screenshots

https://user-images.githubusercontent.com/20520102/143048879-7ed2855e-6fdd-40cf-8f98-aa1695f780cf.mp4



<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->
