### PR TITLE
[Feat]: Add query to fetch safes by prepaidcard type

### DIFF
--- a/cardstack/src/services/prepaid-cards/prepaid-card-api.ts
+++ b/cardstack/src/services/prepaid-cards/prepaid-card-api.ts
@@ -1,10 +1,30 @@
 import { getSDK } from '@cardstack/cardpay-sdk';
 import { CacheTags, safesApi } from '../safes-api';
+import { queryPromiseWrapper } from '../utils';
+import {
+  PrepaidCardSafeQueryParams,
+  PrepaidCardsQueryResult,
+} from './prepaid-card-types';
+import { fetchPrepaidCards } from './prepaid-card-service';
 import HDProvider from '@cardstack/models/hd-provider';
 import Web3Instance from '@cardstack/models/web3-instance';
 
 const prepaidCardApi = safesApi.injectEndpoints({
   endpoints: builder => ({
+    getPrepaidCards: builder.query<
+      PrepaidCardsQueryResult,
+      PrepaidCardSafeQueryParams
+    >({
+      async queryFn(params) {
+        return queryPromiseWrapper<
+          PrepaidCardsQueryResult,
+          PrepaidCardSafeQueryParams
+        >(fetchPrepaidCards, params, {
+          errorLogMessage: 'Error fetching prepaidCards',
+        });
+      },
+      providesTags: [CacheTags.PREPAID_CARDS],
+    }),
     // TODO: Add right types, and extract to prepaid-card-service service
     payMerchant: builder.mutation<any, any>({
       async queryFn({
@@ -45,4 +65,7 @@ const prepaidCardApi = safesApi.injectEndpoints({
   }),
 });
 
-export const { usePayMerchantMutation } = prepaidCardApi;
+export const {
+  usePayMerchantMutation,
+  useGetPrepaidCardsQuery,
+} = prepaidCardApi;

--- a/cardstack/src/services/prepaid-cards/prepaid-card-service.ts
+++ b/cardstack/src/services/prepaid-cards/prepaid-card-service.ts
@@ -1,11 +1,13 @@
 import { PrepaidCardSafe } from '@cardstack/cardpay-sdk';
+import { updateSafeWithTokenPrices } from '../gnosis-service';
+import { PrepaidCardSafeQueryParams } from './prepaid-card-types';
 import { getSafeData } from '@cardstack/services';
 import logger from 'logger';
 import { fetchCardCustomizationFromDID } from '@cardstack/utils';
+import { getSafesInstance } from '@cardstack/models';
+import { PrepaidCardType } from '@cardstack/types';
 
-export const updatePrepaidCardWithCustomization = async (
-  card: PrepaidCardSafe
-) => {
+export const addPrepaidCardCustomization = async (card: PrepaidCardSafe) => {
   try {
     const cardCustomization = await fetchCardCustomizationFromDID(
       card.customizationDID
@@ -31,9 +33,7 @@ export const getPrepaidCardByAddress = async (
       | undefined;
 
     if (prepaidCard) {
-      const updatedPrepaidCard = updatePrepaidCardWithCustomization(
-        prepaidCard
-      );
+      const updatedPrepaidCard = addPrepaidCardCustomization(prepaidCard);
 
       return updatedPrepaidCard;
     }

--- a/cardstack/src/services/prepaid-cards/prepaid-card-types.ts
+++ b/cardstack/src/services/prepaid-cards/prepaid-card-types.ts
@@ -1,0 +1,11 @@
+import { NativeCurrency } from '@cardstack/cardpay-sdk';
+import { PrepaidCardType } from '@cardstack/types';
+
+export interface PrepaidCardsQueryResult {
+  prepaidCards: PrepaidCardType[];
+}
+
+export interface PrepaidCardSafeQueryParams {
+  accountAddress: string;
+  nativeCurrency: NativeCurrency;
+}

--- a/cardstack/src/services/safes-api.ts
+++ b/cardstack/src/services/safes-api.ts
@@ -4,12 +4,13 @@ import { fetchSafes } from './gnosis-service';
 
 export enum CacheTags {
   SAFES = 'SAFES',
+  PREPAID_CARDS = 'PREPAID_CARDS',
 }
 
 export const safesApi = createApi({
   reducerPath: 'safesApi',
   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
-  tagTypes: [CacheTags.SAFES],
+  tagTypes: [...Object.values(CacheTags)],
   endpoints: builder => ({
     // TODO: Add right return type
     getSafesData: builder.query<

--- a/cardstack/src/services/utils/__tests__/services-utils.test.ts
+++ b/cardstack/src/services/utils/__tests__/services-utils.test.ts
@@ -1,0 +1,79 @@
+import * as sentry from '@sentry/minimal';
+import { queryPromiseWrapper } from '../index';
+import logger from 'logger';
+
+describe('service utils', () => {
+  describe('queryPromiseWrapper', () => {
+    const captureExceptionSpy = jest.spyOn(sentry, 'captureException');
+
+    beforeAll(() => {
+      logger.sentry = jest.fn();
+    });
+
+    it('it should call a given promise with its params', async () => {
+      const anyPromise = jest
+        .fn()
+        .mockImplementation((params: string) => Promise.resolve(params));
+
+      await queryPromiseWrapper(anyPromise, 'foo');
+
+      expect(anyPromise).toBeCalledWith('foo');
+    });
+
+    it('it should return a strutured data object given a successful promise', async () => {
+      const successPromiseResult = { foo: 'bar' };
+
+      const anyPromise = () => Promise.resolve(successPromiseResult);
+
+      const queryWrapperResult = await queryPromiseWrapper(
+        anyPromise,
+        undefined
+      );
+
+      expect(queryWrapperResult).toStrictEqual({ data: successPromiseResult });
+    });
+
+    it('it should return a strutured error object given a failed promise', async () => {
+      const anyPromise = () => Promise.reject('Error');
+
+      const queryWrapperResult = await queryPromiseWrapper(
+        anyPromise,
+        undefined
+      );
+
+      expect(logger.sentry).toBeCalledWith(
+        'Error on queryPromiseWrapper',
+        'Error'
+      );
+
+      expect(captureExceptionSpy).toBeCalledWith('Error');
+
+      expect(queryWrapperResult).toStrictEqual({
+        error: {
+          status: 418,
+          data: 'Error',
+        },
+      });
+    });
+
+    it('it should return a strutured custom error object given a failed promise and status error', async () => {
+      const anyPromise = () => Promise.reject('Error');
+
+      const queryWrapperResult = await queryPromiseWrapper(
+        anyPromise,
+        undefined,
+        { errorStatus: 400, errorLogMessage: 'Error on anyPromise' }
+      );
+
+      expect(logger.sentry).toBeCalledWith('Error on anyPromise', 'Error');
+      expect(captureExceptionSpy).toBeCalledWith('Error');
+
+      expect(queryWrapperResult).toStrictEqual({
+        error: {
+          status: 400,
+          data: 'Error',
+        },
+      });
+    });
+  });
+});

--- a/cardstack/src/services/utils/index.ts
+++ b/cardstack/src/services/utils/index.ts
@@ -1,0 +1,44 @@
+import { captureException } from '@sentry/minimal';
+import logger from 'logger';
+
+type QueryError = {
+  error: {
+    status: number;
+    data: any;
+  };
+  data?: undefined;
+};
+
+type QuerySuccess<TResult> = {
+  data: TResult;
+  error?: undefined;
+};
+
+interface Options {
+  errorStatus?: number;
+  errorLogMessage?: string;
+}
+
+export const queryPromiseWrapper = async <TResult, TArgs>(
+  promise: (args: TArgs) => Promise<TResult>,
+  args: TArgs,
+  options?: Options
+): Promise<QuerySuccess<TResult> | QueryError> => {
+  try {
+    const result = await promise(args);
+
+    return { data: result };
+  } catch (error) {
+    const message = options?.errorLogMessage || 'Error on queryPromiseWrapper';
+
+    logger.sentry(message, error);
+    captureException(error);
+
+    return {
+      error: {
+        status: options?.errorStatus || 418,
+        data: error,
+      },
+    };
+  }
+};

--- a/cardstack/src/types/TokenType.ts
+++ b/cardstack/src/types/TokenType.ts
@@ -5,8 +5,8 @@ import { BalanceType } from '.';
 // Balance info added with redux
 export interface TokenType extends Omit<TokenInfo, 'balance'> {
   native: {
-    balance: BalanceType;
-    price: AssetWithNativeType['price'];
+    balance: { amount: number; display: string };
+    price?: AssetWithNativeType['price'];
   };
   balance: BalanceType;
 }

--- a/src/components/expanded-state/UnclaimedRevenueExpandedState.tsx
+++ b/src/components/expanded-state/UnclaimedRevenueExpandedState.tsx
@@ -39,7 +39,7 @@ export default function UnclaimedRevenueExpandedState({
   const { revenueBalances } = merchantSafe;
 
   const nativeAmount = revenueBalances[0].native.balance.amount;
-  const isDust = parseFloat(nativeAmount) < 0.01;
+  const isDust = nativeAmount < 0.01;
 
   return useMemo(
     () => (


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds the query to fetch PrepaidCards safes only, it is still not in use, bc we need to create for each safe type bf migrating, but I wanted to merge because it also creates a `queryPromiseWrapper` helper so we can use across all ours `queryFn` that automatically handles success/error cases and we can start to migrate the mutations too.

