### PR TITLE
[CS-2585] Refactor transactions to use correct historyPrices in native currency conversion

### DIFF
--- a/cardstack/src/services/historical-pricing-service.ts
+++ b/cardstack/src/services/historical-pricing-service.ts
@@ -2,14 +2,6 @@ import { CRYPTOCOMPARE_API_KEY } from 'react-native-dotenv';
 import logger from 'logger';
 import { removeCPXDTokenSuffix } from '@cardstack/utils';
 
-const getRoundedTimestamp = (timestamp: string | number) => {
-  const date = new Date(Number(timestamp) * 1000);
-
-  date.setHours(0, 0, 0, 0);
-
-  return date.getTime();
-};
-
 export const fetchHistoricalPrice = async (
   symbol: string,
   timestamp: string | number,
@@ -19,10 +11,31 @@ export const fetchHistoricalPrice = async (
     // For cpxd tokens we chop off .CPXD in order to get mainnet's historical price
     const tokenSymbol = removeCPXDTokenSuffix(symbol);
 
-    const roundedTimestamp = getRoundedTimestamp(timestamp);
+    // cryptocompare does not support CARD price history correctly,
+    // so uses kucoin exchange to get CARD price in USDT(kucoin supports only USDT) and convert it to native currency
+    if (tokenSymbol === 'CARD') {
+      const usdtPriceData = await (
+        await fetch(
+          `https://min-api.cryptocompare.com/data/pricehistorical?fsym=${tokenSymbol}&tsyms=USDT&ts=${timestamp}&e=kucoin&api_key=${CRYPTOCOMPARE_API_KEY}`
+        )
+      ).json();
+
+      const usdtPrice = usdtPriceData.CARD.USDT;
+
+      const nativeCurrencyDataForUSDT = await (
+        await fetch(
+          `https://min-api.cryptocompare.com/data/pricehistorical?fsym=USDT&tsyms=${nativeCurrency}&ts=${timestamp}&api_key=${CRYPTOCOMPARE_API_KEY}`
+        )
+      ).json();
+
+      const nativeCurrencyPriceForUSDT =
+        nativeCurrencyDataForUSDT.USDT[nativeCurrency];
+
+      return usdtPrice * nativeCurrencyPriceForUSDT;
+    }
 
     const response = await fetch(
-      `https://min-api.cryptocompare.com/data/pricehistorical?fsym=${tokenSymbol}&tsyms=${nativeCurrency}&ts=${roundedTimestamp}&api_key=${CRYPTOCOMPARE_API_KEY}`
+      `https://min-api.cryptocompare.com/data/pricehistorical?fsym=${tokenSymbol}&tsyms=${nativeCurrency}&ts=${timestamp}&api_key=${CRYPTOCOMPARE_API_KEY}`
     );
 
     const data = await response.json();

--- a/cardstack/src/services/historical-pricing-service.ts
+++ b/cardstack/src/services/historical-pricing-service.ts
@@ -3,11 +3,13 @@ import { CRYPTOCOMPARE_API_KEY } from 'react-native-dotenv';
 import logger from 'logger';
 import { removeCPXDTokenSuffix } from '@cardstack/utils';
 
+const CryptoCompareAPIBaseURL = `https://min-api.cryptocompare.com/data/pricehistorical?&api_key=${CRYPTOCOMPARE_API_KEY}`;
+
 export const fetchHistoricalPrice = async (
   symbol: string,
   timestamp: string | number,
   nativeCurrency: string
-) => {
+): Promise<number> => {
   try {
     if (!symbol) {
       return 0;
@@ -21,26 +23,23 @@ export const fetchHistoricalPrice = async (
     if (tokenSymbol === cryptoCurrencies.CARD.currency) {
       const usdtPriceData = await (
         await fetch(
-          `https://min-api.cryptocompare.com/data/pricehistorical?fsym=${tokenSymbol}&tsyms=USDT&ts=${timestamp}&e=kucoin&api_key=${CRYPTOCOMPARE_API_KEY}`
+          `${CryptoCompareAPIBaseURL}&fsym=${tokenSymbol}&tsyms=USDT&ts=${timestamp}&e=kucoin`
         )
       ).json();
 
       const usdtPrice = usdtPriceData.CARD.USDT;
 
-      const nativeCurrencyDataForUSDT = await (
-        await fetch(
-          `https://min-api.cryptocompare.com/data/pricehistorical?fsym=USDT&tsyms=${nativeCurrency}&ts=${timestamp}&api_key=${CRYPTOCOMPARE_API_KEY}`
-        )
-      ).json();
-
-      const nativeCurrencyPriceForUSDT =
-        nativeCurrencyDataForUSDT.USDT[nativeCurrency];
+      const nativeCurrencyPriceForUSDT = await fetchHistoricalPrice(
+        'USDT',
+        timestamp,
+        nativeCurrency
+      );
 
       return usdtPrice * nativeCurrencyPriceForUSDT;
     }
 
     const response = await fetch(
-      `https://min-api.cryptocompare.com/data/pricehistorical?fsym=${tokenSymbol}&tsyms=${nativeCurrency}&ts=${timestamp}&api_key=${CRYPTOCOMPARE_API_KEY}`
+      `${CryptoCompareAPIBaseURL}&fsym=${tokenSymbol}&tsyms=${nativeCurrency}&ts=${timestamp}`
     );
 
     const data = await response.json();

--- a/cardstack/src/services/historical-pricing-service.ts
+++ b/cardstack/src/services/historical-pricing-service.ts
@@ -1,3 +1,4 @@
+import { cryptoCurrencies } from '@cardstack/cardpay-sdk';
 import { CRYPTOCOMPARE_API_KEY } from 'react-native-dotenv';
 import logger from 'logger';
 import { removeCPXDTokenSuffix } from '@cardstack/utils';
@@ -8,12 +9,16 @@ export const fetchHistoricalPrice = async (
   nativeCurrency: string
 ) => {
   try {
+    if (!symbol) {
+      return 0;
+    }
+
     // For cpxd tokens we chop off .CPXD in order to get mainnet's historical price
     const tokenSymbol = removeCPXDTokenSuffix(symbol);
 
     // cryptocompare does not support CARD price history correctly,
     // so uses kucoin exchange to get CARD price in USDT(kucoin supports only USDT) and convert it to native currency
-    if (tokenSymbol === 'CARD') {
+    if (tokenSymbol === cryptoCurrencies.CARD.currency) {
       const usdtPriceData = await (
         await fetch(
           `https://min-api.cryptocompare.com/data/pricehistorical?fsym=${tokenSymbol}&tsyms=USDT&ts=${timestamp}&e=kucoin&api_key=${CRYPTOCOMPARE_API_KEY}`

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/erc20-token-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/erc20-token-strategy.ts
@@ -47,17 +47,13 @@ export class ERC20TokenStrategy extends BaseStrategy {
       this.isDepotTransaction ? this.depotAddress : this.accountAddress
     );
 
-    let price = 0;
-
     const symbol = userTransaction.token.symbol || '';
 
-    if (symbol) {
-      price = await fetchHistoricalPrice(
-        symbol,
-        userTransaction.timestamp,
-        this.nativeCurrency
-      );
-    }
+    const price = await fetchHistoricalPrice(
+      symbol,
+      userTransaction.timestamp,
+      this.nativeCurrency
+    );
 
     return {
       from: userTransaction.from || 'Unknown',

--- a/cardstack/src/types/react-coin-icon.d.ts
+++ b/cardstack/src/types/react-coin-icon.d.ts
@@ -1,6 +1,5 @@
 declare module 'react-coin-icon' {
   const value: any;
-  const FallbackIcon: any;
   export default value;
   export const FallbackIcon;
 }


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

`CARD` token is not supported correctly in cryptocompare api so used kucoin exchange to get CARD price in USDT(kucoin does not supports nativecurrencies, support USDT) and then convert it to native currency by calling cryptocompare again. Also found many transactions used sdk to get native currency balance but it's not history price so updated them to use history price properly at that transaction's timestamp.

<!-- Include a summary of the changes. -->

- [x] Completes #CS-2585

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->
<img width="300" alt="Screen Shot 2021-11-29 at 10 11 51 PM" src="https://user-images.githubusercontent.com/16714648/143883252-76d146a6-99ee-405d-96ef-2eee27b0cf1f.png">

