### PR TITLE
[CS-2655]: Keep local cache for safes in case of error

### DIFF
--- a/cardstack/src/components/AssetList/AssetList.tsx
+++ b/cardstack/src/components/AssetList/AssetList.tsx
@@ -25,7 +25,7 @@ import {
   Icon,
   Text,
 } from '@cardstack/components';
-import { isLayer1, Device } from '@cardstack/utils';
+import { isLayer1, Device, dateFormatter } from '@cardstack/utils';
 import {
   PinnedHiddenSectionOption,
   useAccountProfile,
@@ -60,6 +60,7 @@ export type AssetListSectionItem<ComponentProps> = {
   ) => JSX.Element | null;
   header: HeaderItem;
   data: ComponentProps[];
+  timestamp?: string;
 };
 
 interface AssetListProps
@@ -91,6 +92,16 @@ interface RouteType {
 // We need to pass this prop if the section to scrollTo is not on viewport
 const onScrollToIndexFailed = () => {
   logger.log('onScrollToIndexFailed');
+};
+
+const strings = {
+  lastUpdatedAt: (timestamp: string) =>
+    `Last updated at: ${dateFormatter(
+      parseFloat(timestamp),
+      'MM/dd/yy',
+      'h:mm a',
+      ', '
+    )}`,
 };
 
 export const AssetList = (props: AssetListProps) => {
@@ -207,6 +218,22 @@ export const AssetList = (props: AssetListProps) => {
     refreshing,
   ]);
 
+  const renderSectionFooter = useCallback(
+    ({ section: { timestamp } }) =>
+      timestamp ? (
+        <Container
+          paddingHorizontal={4}
+          alignItems="flex-end"
+          justifyContent="center"
+        >
+          <Text color="white" size="xs">
+            {strings.lastUpdatedAt(timestamp)}
+          </Text>
+        </Container>
+      ) : null,
+    []
+  );
+
   if (loading || isNotManualRefetch) {
     return <AssetListLoading />;
   }
@@ -237,6 +264,7 @@ export const AssetList = (props: AssetListProps) => {
             currencyConversionRates={currencyConversionRates}
           />
         )}
+        renderSectionFooter={renderSectionFooter}
         renderSectionHeader={({ section }) => {
           const {
             header: { type, title, count, showContextMenu, total },

--- a/cardstack/src/components/Depot/Depot.tsx
+++ b/cardstack/src/components/Depot/Depot.tsx
@@ -24,7 +24,7 @@ export const Depot = (depot: DepotProps) => {
   const onPress = () => navigate(Routes.DEPOT_SCREEN, { depot });
 
   return (
-    <Container width="100%" paddingHorizontal={4}>
+    <Container width="100%" paddingHorizontal={4} marginBottom={4}>
       <Touchable width="100%" testID="inventory-card" onPress={onPress}>
         <Container
           backgroundColor="white"

--- a/src/handlers/localstorage/accountLocal.js
+++ b/src/handlers/localstorage/accountLocal.js
@@ -3,9 +3,9 @@ import { NATIVE_TOKEN_SYMBOLS } from '@cardstack/utils';
 
 const assetPricesFromUniswapVersion = '0.1.0';
 const assetsVersion = '0.2.1';
-const prepaidCardsVersion = '0.1.0';
-const depotVersion = '0.1.0';
-const merchantSafeVersion = '0.1.0';
+const prepaidCardsVersion = '0.2.0';
+const depotVersion = '0.2.0';
+const merchantSafeVersion = '0.2.0';
 const purchaseTransactionsVersion = '0.1.0';
 const savingsVersion = '0.2.0';
 const transactionsVersion = '0.2.6';
@@ -44,6 +44,9 @@ export const accountLocalKeys = [
   COLLECTIBLES,
   PINNED_COINS,
   HIDDEN_COINS,
+  DEPOTS,
+  MERCHANT_SAFES,
+  PREPAID_CARDS,
 ];
 
 /**
@@ -116,14 +119,14 @@ export const saveAssets = (assets, accountAddress, network) =>
  * @desc get prepaid cards
  * @param  {String}   [address]
  * @param  {String}   [network]
- * @return {Object}
+ * @return {{prepaidCards: Array, timestamp: String}}
  */
 export const getPrepaidCards = (accountAddress, network) =>
   getAccountLocal(
     PREPAID_CARDS,
     accountAddress,
     network,
-    [],
+    { prepaidCards: [], timestamp: '' },
     prepaidCardsVersion
   );
 
@@ -133,10 +136,15 @@ export const getPrepaidCards = (accountAddress, network) =>
  * @param  {String}   [address]
  * @param  {String}   [network]
  */
-export const savePrepaidCards = (prepaidCards, accountAddress, network) =>
+export const savePrepaidCards = (
+  prepaidCards,
+  accountAddress,
+  network,
+  timestamp
+) =>
   saveAccountLocal(
     PREPAID_CARDS,
-    prepaidCards,
+    { prepaidCards, timestamp },
     accountAddress,
     network,
     prepaidCardsVersion
@@ -146,10 +154,16 @@ export const savePrepaidCards = (prepaidCards, accountAddress, network) =>
  * @desc get depots
  * @param  {String}   [address]
  * @param  {String}   [network]
- * @return {Object}
+ * @return {{depots: Array, timestamp: String}}
  */
 export const getDepots = (accountAddress, network) =>
-  getAccountLocal(DEPOTS, accountAddress, network, [], depotVersion);
+  getAccountLocal(
+    DEPOTS,
+    accountAddress,
+    network,
+    { depots: [], timestamp: '' },
+    depotVersion
+  );
 
 /**
  * @desc save depots
@@ -157,21 +171,27 @@ export const getDepots = (accountAddress, network) =>
  * @param  {String}   [address]
  * @param  {String}   [network]
  */
-export const saveDepots = (depots, accountAddress, network) =>
-  saveAccountLocal(DEPOTS, depots, accountAddress, network, depotVersion);
+export const saveDepots = (depots, accountAddress, network, timestamp) =>
+  saveAccountLocal(
+    DEPOTS,
+    { depots, timestamp },
+    accountAddress,
+    network,
+    depotVersion
+  );
 
 /**
  * @desc get merchant safes
  * @param  {String}   [address]
  * @param  {String}   [network]
- * @return {Object}
+ * @return {{merchantSafes: Array, timestamp: String}}
  */
 export const getMerchantSafes = (accountAddress, network) =>
   getAccountLocal(
     MERCHANT_SAFES,
     accountAddress,
     network,
-    [],
+    { merchantSafes: [], timestamp: '' },
     merchantSafeVersion
   );
 
@@ -181,10 +201,15 @@ export const getMerchantSafes = (accountAddress, network) =>
  * @param  {String}   [address]
  * @param  {String}   [network]
  */
-export const saveMerchantSafes = (merchantSafes, accountAddress, network) =>
+export const saveMerchantSafes = (
+  merchantSafes,
+  accountAddress,
+  network,
+  timestamp
+) =>
   saveAccountLocal(
     MERCHANT_SAFES,
-    merchantSafes,
+    { merchantSafes, timestamp },
     accountAddress,
     network,
     merchantSafeVersion

--- a/src/hooks/useAssetListData.tsx
+++ b/src/hooks/useAssetListData.tsx
@@ -31,7 +31,8 @@ import {
 } from '@rainbow-me/redux/hooks';
 
 const usePrepaidCardSection = (
-  prepaidCards: PrepaidCardType[]
+  prepaidCards: PrepaidCardType[],
+  timestamp: string
 ): AssetListSectionItem<PrepaidCardType> => {
   const { hidden, pinned } = usePinnedAndHiddenItemOptions();
   const count = prepaidCards.filter(pc => !hidden.includes(pc.address)).length;
@@ -54,28 +55,33 @@ const usePrepaidCardSection = (
       showContextMenu: true,
     },
     data: prepaidCards,
+    timestamp,
     Component: PrepaidCard,
   };
 };
 
 const useDepotSection = (
-  depots: DepotType[]
+  depots: DepotType[],
+  timestamp: string
 ): AssetListSectionItem<DepotType> => ({
   header: {
     title: 'Depot',
   },
   data: depots,
+  timestamp,
   Component: Depot,
 });
 
 const useMerchantSafeSection = (
-  merchantSafes: MerchantSafeType[]
+  merchantSafes: MerchantSafeType[],
+  timestamp: string
 ): AssetListSectionItem<MerchantSafeType> => ({
   header: {
     title: 'Accounts',
     count: merchantSafes?.length,
   },
   data: merchantSafes,
+  timestamp,
   Component: MerchantSafe,
 });
 
@@ -158,6 +164,7 @@ const safesInitialState = {
   prepaidCards: [],
   depots: [],
   merchantSafes: [],
+  timestamp: '',
 };
 
 export const useAssetListData = () => {
@@ -178,11 +185,11 @@ export const useAssetListData = () => {
     }
   );
 
-  const { prepaidCards, depots, merchantSafes } = data;
+  const { prepaidCards, depots, merchantSafes, timestamp } = data;
 
-  const prepaidCardSection = usePrepaidCardSection(prepaidCards);
-  const depotSection = useDepotSection(depots);
-  const merchantSafesSection = useMerchantSafeSection(merchantSafes);
+  const prepaidCardSection = usePrepaidCardSection(prepaidCards, timestamp);
+  const depotSection = useDepotSection(depots, timestamp);
+  const merchantSafesSection = useMerchantSafeSection(merchantSafes, timestamp);
   const otherTokensSection = useOtherTokensSection();
   const collectiblesSection = useCollectiblesSection();
 

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -114,7 +114,12 @@ export const dataLoadState = () => async (dispatch, getState) => {
   } catch (error) {}
   try {
     dispatch({ type: DATA_LOAD_ASSETS_REQUEST });
-    const [assets, prepaidCards, depots, merchantSafes] = await Promise.all([
+    const [
+      assets,
+      { prepaidCards },
+      { depots },
+      { merchantSafes },
+    ] = await Promise.all([
       getAssets(accountAddress, network),
       getPrepaidCards(accountAddress, network),
       getDepots(accountAddress, network),


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

In case of an error while fetching safes we fallback to local cache if it exists and store/show a timestamp so we can let the user know the data might be stale

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2655)

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->
- First fetch 9:48AM 
- Pull to refresh at 9:49AM, forced an error, kept stale data from 9:48AM
- 9:49AM refreshed without error, updated data at 9:49AM

![Nov-30-2021 09-58-05](https://user-images.githubusercontent.com/20520102/144051783-ce99c08e-4712-4d3d-a37d-cd6511bebddf.gif)


