### PR TITLE
[CS-2686]- Improve safes loading/fetching UI 

### DIFF
--- a/src/redux/settings.js
+++ b/src/redux/settings.js
@@ -140,7 +140,7 @@ export const toggleShowTestnets = () => (dispatch, getState) => {
 // -- Reducer --------------------------------------------------------------- //
 export const INITIAL_STATE = {
   accountAddress: '',
-  chainId: 1,
+  chainId: 100,
   language: 'en',
   nativeCurrency: 'USD',
   network: networkTypes.xdai,


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
Previously we were having a cache issue with safes while switching accounts, and `isNotManualRefetch` was implemented, but since safes and balances comes from different places we were having a hard time to keep the loading synced and showing the skeleton felt like a bug, so this new approach tracks if the account has been switched, and if it is and we are fetching safes we do show the skeleton, in any other safes fetching we show a loading indicator in the same place as the last updated at text when we are updating the data. Also updates the default chainID to be 100 which is the xdai one, since the default network is xdai.

### Screenshots

https://user-images.githubusercontent.com/20520102/144304456-736e1b8b-ec02-4b49-884c-74be0252c6e2.mp4

https://user-images.githubusercontent.com/20520102/144305481-cd757deb-74c9-4907-bddc-8d413f270244.mp4


