### PR TITLE
[CS-2682]: Fix not showing alert when payment link diff net

### DIFF
--- a/cardstack/src/hooks/merchant/usePaymentMerchantUniversalLink.ts
+++ b/cardstack/src/hooks/merchant/usePaymentMerchantUniversalLink.ts
@@ -49,30 +49,29 @@ export const usePaymentMerchantUniversalLink = () => {
     nativeCurrency,
   } = useAccountSettings();
 
-  const { isLoadingCards = true, prepaidCards } = useGetSafesDataQuery(
+  const { isLoading = true, prepaidCards } = useGetSafesDataQuery(
     { address: accountAddress, nativeCurrency },
     {
       refetchOnMountOrArgChange: 60,
       skip: isLayer1(accountNetwork) || !accountAddress || !walletReady,
-      selectFromResult: ({ data, isLoading, isUninitialized }) => ({
+      selectFromResult: ({
+        data,
+        isLoading: isLoadingCards,
+        isUninitialized,
+      }) => ({
         prepaidCards: data?.prepaidCards || [],
-        isLoadingCards: isLoading || isUninitialized,
+        isLoading: isLoadingCards || isUninitialized,
       }),
     }
   );
 
-  const {
-    isLoading: isLoadingMerchantInfo,
-    callback: getMerchantSafeData,
-  } = useWorker(async () => {
+  const { callback: getMerchantSafeData } = useWorker(async () => {
     const { infoDID: did } = (await getSafeData(
       merchantAddress
     )) as MerchantSafe;
 
     setInfoDID(did);
   }, [merchantAddress]);
-
-  const isLoading = !infoDID || isLoadingMerchantInfo || isLoadingCards;
 
   useEffect(() => {
     getMerchantSafeData();
@@ -96,7 +95,7 @@ export const usePaymentMerchantUniversalLink = () => {
     if (qrCodeNetwork && accountNetwork && qrCodeNetwork !== accountNetwork) {
       InteractionManager.runAfterInteractions(() => {
         handleAlertError(
-          `This is a ${networkInfo[qrCodeNetwork].name} QR Code, please confirm your device is on ${networkInfo[qrCodeNetwork].name}.`,
+          `This is a ${networkInfo[qrCodeNetwork].name} request, please confirm your device is on ${networkInfo[qrCodeNetwork].name}.`,
           'Oops!',
           [
             {
@@ -109,7 +108,7 @@ export const usePaymentMerchantUniversalLink = () => {
 
       return;
     }
-  }, [accountNetwork, qrCodeNetwork, goBack, isLoading, isLoadingCards]);
+  }, [accountNetwork, qrCodeNetwork, goBack, isLoading]);
 
   const data: PayMerchantDecodedData & { qrCodeNetwork: string } = useMemo(
     () => ({

--- a/cardstack/src/screens/PayMerchant/PayMerchant.tsx
+++ b/cardstack/src/screens/PayMerchant/PayMerchant.tsx
@@ -41,6 +41,7 @@ const PayMerchant = memo(() => {
     setInputValue,
     onAmountNext,
     onCancelConfirmation,
+    isLoadingMerchantInfo,
   } = usePayMerchant();
 
   if (isLoading) {
@@ -59,7 +60,7 @@ const PayMerchant = memo(() => {
         onNextPress={onAmountNext}
         inputValue={inputValue}
         setInputValue={setInputValue}
-        isLoading={isLoading}
+        isLoading={isLoadingMerchantInfo}
         nativeCurrency={nativeCurrency || 'SPD'}
       />
     );
@@ -68,7 +69,7 @@ const PayMerchant = memo(() => {
   if (payStep === PAY_STEP.CONFIRMATION) {
     return (
       <TransactionConfirmationSheet
-        loading={isLoading}
+        loading={isLoadingMerchantInfo}
         onConfirmLoading={onConfirmLoading}
         data={txSheetData}
         onCancel={onCancelConfirmation}

--- a/cardstack/src/screens/PayMerchant/usePayMerchant.ts
+++ b/cardstack/src/screens/PayMerchant/usePayMerchant.ts
@@ -202,7 +202,10 @@ export const usePayMerchant = () => {
 
   const [payStep, setPayStep] = useState<Step>(initialStep);
 
-  const { merchantInfoDID } = useMerchantInfoFromDID(infoDID);
+  const {
+    merchantInfoDID,
+    isLoading: isLoadingMerchantInfo,
+  } = useMerchantInfoFromDID(infoDID);
 
   const [
     accountCurrency,
@@ -313,5 +316,6 @@ export const usePayMerchant = () => {
     setInputValue,
     onCancelConfirmation,
     onAmountNext,
+    isLoadingMerchantInfo,
   };
 };


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

When we are at a diff network from the one from the payment request we won't be able to retrieve the merchant info, so it doesn't make sense to wait for it to show the alert and handle the other steps since we can have separated loadings for merchantInfo only.
 

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

Video was added to the ticket, since it's too big for github
