### PR TITLE
[CS-2687]: Use SDK to get token balances instead of eo contract

### DIFF
--- a/cardstack/src/helpers/__mocks__/dataMocks.ts
+++ b/cardstack/src/helpers/__mocks__/dataMocks.ts
@@ -3,7 +3,7 @@ const assets = [
   {
     asset: {
       asset_code: 'spoa',
-      coingecko_id: 'dai',
+      coingecko_id: 'spoa',
       decimals: 18,
       icon_url: 'https://s3.amazonaws.com/icons.assets/ETH.png',
       name: 'Spoa',
@@ -55,13 +55,13 @@ const assets = [
         amount: '',
         display: '',
       },
-      symbol: 'DAI',
+      symbol: 'DAI.CPXD',
     },
   },
   {
     asset: {
       asset_code: '0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee',
-      coingecko_id: 'cardstack',
+      coingecko_id: null,
       decimals: 18,
       icon_url:
         'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x954b890704693af242613edEf1B603825afcD708/logo.png',
@@ -71,7 +71,7 @@ const assets = [
         relative_change_24h: 0,
         value: 0,
       },
-      symbol: 'CARD',
+      symbol: 'CARD.CPXD',
       balance: {
         amount: '',
         display: '',
@@ -269,64 +269,47 @@ const prepaidCards = [
 ];
 
 const prices = {
-  dai: {
-    usd: 1,
-    usd_24h_change: 0.5608860044696169,
-    last_updated_at: 1629399932,
-  },
-  cardstack: {
-    usd: 0.00889263,
+  spoa: {
+    usd: 0.2,
     usd_24h_change: 22.304616235477624,
     last_updated_at: 1629399408,
   },
 };
 
 const chartData = {
-  dai: [
+  spoa: [
     [1629316840055, 0.9992493517535592],
     [1629317140870, 0.9983760748596904],
     [1629320428398, 0.9988230904876851],
     [1629320760703, 1.0006668259255413],
   ],
-  cardstack: [
-    [1629314735879, 0.0072259548640652245],
-    [1629315032452, 0.007219093412036481],
-    [1629315351742, 0.007221452392607805],
-    [1629315563048, 0.007215497853372955],
-  ],
-};
-
-const balances = {
-  '0x0000000000000000000000000000000000000000': '499703144000000000',
-  '0x6B78C121bBd10D8ef0dd3623CC1abB077b186F65': '1000000000000000000',
-  '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1': '57823293170000000002',
-  '0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee': '0',
 };
 
 const updatedAssets = [
   {
     asset: {
       asset_code: 'spoa',
-      coingecko_id: 'dai',
+      coingecko_id: 'spoa',
       decimals: 18,
       icon_url: 'https://s3.amazonaws.com/icons.assets/ETH.png',
       name: 'Spoa',
       native: {
         balance: {
-          amount: '0',
-          display: '$0.00 USD',
+          amount: '0.00098',
+          display: '$0.00098 USD',
         },
         price: {
-          amount: 1,
-          display: '$1.00 USD',
+          amount: 0.2,
+          display: '$0.20 USD',
         },
       },
       price: {
-        changed_at: 1629399932,
-        relative_change_24h: 0.5608860044696169,
-        value: 1,
+        changed_at: 1629399408,
+        relative_change_24h: 22.304616235477624,
+        value: 0.2,
       },
       symbol: 'SPOA',
+      balance: { amount: '0.0049', display: '0.0049 SPOA' },
       chartPrices: [
         [1629316840055, 0.9992493517535592],
         [1629317140870, 0.9983760748596904],
@@ -334,7 +317,6 @@ const updatedAssets = [
         [1629320760703, 1.0006668259255413],
       ],
     },
-    quantity: '499703144000000000',
   },
   {
     asset: {
@@ -345,12 +327,12 @@ const updatedAssets = [
       name: 'Dominic',
       native: {
         balance: {
-          amount: '4.5',
-          display: '$4.50 USD',
+          amount: '9',
+          display: '$9.00 USD',
         },
         price: {
-          amount: 0,
-          display: '$0.00 USD',
+          amount: 4.5,
+          display: '$4.50 USD',
         },
       },
       price: {
@@ -359,9 +341,9 @@ const updatedAssets = [
         value: 4.5,
       },
       symbol: 'DOM',
+      balance: { amount: '2', display: '2 DOM' },
       chartPrices: null,
     },
-    quantity: '1000000000000000000',
   },
   {
     asset: {
@@ -373,8 +355,8 @@ const updatedAssets = [
       name: 'DAI.CPXD',
       native: {
         balance: {
-          amount: '0',
-          display: '$0.00 USD',
+          amount: '57',
+          display: '$57.00 USD',
         },
         price: {
           amount: 1,
@@ -382,32 +364,27 @@ const updatedAssets = [
         },
       },
       price: {
-        changed_at: 1629399932,
-        relative_change_24h: 0.5608860044696169,
+        changed_at: null,
+        relative_change_24h: 0,
         value: 1,
       },
-      symbol: 'DAI',
-      chartPrices: [
-        [1629316840055, 0.9992493517535592],
-        [1629317140870, 0.9983760748596904],
-        [1629320428398, 0.9988230904876851],
-        [1629320760703, 1.0006668259255413],
-      ],
+      symbol: 'DAI.CPXD',
+      balance: { amount: '57', display: '57 DAI.CPXD' },
+      chartPrices: null,
     },
-    quantity: '57823293170000000002',
   },
   {
     asset: {
       asset_code: '0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee',
-      coingecko_id: 'cardstack',
+      coingecko_id: null,
       decimals: 18,
       icon_url:
         'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x954b890704693af242613edEf1B603825afcD708/logo.png',
       name: 'CARD.CPXD',
       native: {
         balance: {
-          amount: '0',
-          display: '$0.00 USD',
+          amount: '0.00889263',
+          display: '$0.00889 USD',
         },
         price: {
           amount: 0.00889263,
@@ -415,19 +392,14 @@ const updatedAssets = [
         },
       },
       price: {
-        changed_at: 1629399408,
-        relative_change_24h: 22.304616235477624,
+        changed_at: null,
+        relative_change_24h: 0,
         value: 0.00889263,
       },
-      symbol: 'CARD',
-      chartPrices: [
-        [1629314735879, 0.0072259548640652245],
-        [1629315032452, 0.007219093412036481],
-        [1629315351742, 0.007221452392607805],
-        [1629315563048, 0.007215497853372955],
-      ],
+      symbol: 'CARD.CPXD',
+      balance: { amount: '1', display: '1 CARD.CPXD' },
+      chartPrices: null,
     },
-    quantity: '0',
   },
 ];
 
@@ -769,7 +741,6 @@ export const inputData = {
 export const fetchedData = {
   prices,
   chartData,
-  balances,
 };
 
 export const updatedData = {

--- a/cardstack/src/helpers/__mocks__/dataMocks.ts
+++ b/cardstack/src/helpers/__mocks__/dataMocks.ts
@@ -13,8 +13,11 @@ const assets = [
         value: 259.2,
       },
       symbol: 'SPOA',
+      balance: {
+        amount: '',
+        display: '',
+      },
     },
-    quantity: '0',
   },
   {
     asset: {
@@ -28,9 +31,12 @@ const assets = [
         relative_change_24h: 0,
         value: 0,
       },
+      balance: {
+        amount: '',
+        display: '',
+      },
       symbol: 'DOM',
     },
-    quantity: '0',
   },
   {
     asset: {
@@ -45,9 +51,12 @@ const assets = [
         relative_change_24h: 0,
         value: 0,
       },
+      balance: {
+        amount: '',
+        display: '',
+      },
       symbol: 'DAI',
     },
-    quantity: '0',
   },
   {
     asset: {
@@ -63,8 +72,11 @@ const assets = [
         value: 0,
       },
       symbol: 'CARD',
+      balance: {
+        amount: '',
+        display: '',
+      },
     },
-    quantity: '0',
   },
 ];
 

--- a/cardstack/src/helpers/__tests__/fallbackExplorerHelper.test.ts
+++ b/cardstack/src/helpers/__tests__/fallbackExplorerHelper.test.ts
@@ -1,8 +1,5 @@
 import { fetchedData, inputData, updatedData } from '../__mocks__/dataMocks';
-import {
-  reduceAssetsWithPriceChartAndBalances,
-  reduceDepotsWithPricesAndChart,
-} from '@cardstack/helpers/fallbackExplorerHelper';
+import { reduceAssetsWithPriceChartAndBalances } from '@cardstack/helpers/fallbackExplorerHelper';
 
 import { Network } from '@rainbow-me/helpers/networkTypes';
 
@@ -17,48 +14,18 @@ jest.mock('@cardstack/services', () => ({
 describe('Fallback Explorer Helpers', () => {
   it(`should return updated assets with prices, chartData and balances`, async () => {
     const { assets } = inputData;
-    const { prices, balances, chartData } = fetchedData;
+    const { prices, chartData } = fetchedData;
 
     const updatedAssets = await reduceAssetsWithPriceChartAndBalances({
       assets,
       prices,
-      balances,
       chartData,
       formattedNativeCurrency: 'usd',
       network: Network.sokol,
       nativeCurrency: 'USD',
+      accountAddress: '0x000000',
     });
 
     expect(updatedAssets).toEqual(updatedData.updatedAssets);
-  });
-
-  it(`should return updated depots safes with prices, chartData and native price`, async () => {
-    const { depots } = inputData;
-    const { prices, chartData } = fetchedData;
-
-    const updatedDepots = await reduceDepotsWithPricesAndChart({
-      depots: depots as any, // need to figure right types
-      prices,
-      chartData,
-      formattedNativeCurrency: 'usd',
-      nativeCurrency: 'USD',
-    });
-
-    expect(updatedDepots).toEqual(updatedData.updatedDepots);
-  });
-
-  it(`should return updated prepaid cards safes with prices, chartData and native price`, async () => {
-    const { prepaidCards } = inputData;
-    const { prices, chartData } = fetchedData;
-
-    const updatedPrepaidCards = await reduceDepotsWithPricesAndChart({
-      depots: prepaidCards as any, // need to figure right types
-      prices,
-      chartData,
-      formattedNativeCurrency: 'usd',
-      nativeCurrency: 'USD',
-    });
-
-    expect(updatedPrepaidCards).toEqual(updatedData.updatedPrepaidCards);
   });
 });

--- a/cardstack/src/helpers/__tests__/fallbackExplorerHelper.test.ts
+++ b/cardstack/src/helpers/__tests__/fallbackExplorerHelper.test.ts
@@ -3,12 +3,42 @@ import { reduceAssetsWithPriceChartAndBalances } from '@cardstack/helpers/fallba
 
 import { Network } from '@rainbow-me/helpers/networkTypes';
 
+const pricesOracle = {
+  DOM: 4.5,
+  'CARD.CPXD': 0.00889263,
+  'DAI.CPXD': 1,
+} as any;
+
 jest.mock('@cardstack/services', () => ({
-  getNativeBalanceFromOracle: jest.fn().mockImplementation(({ balance }) => {
-    const fromWei = require('@cardstack/cardpay-sdk').fromWei;
-    const balanceNumber = parseFloat(fromWei(balance));
-    return balanceNumber > 0 ? balanceNumber * 4.5 : balanceNumber;
-  }),
+  getNativeBalanceFromOracle: jest
+    .fn()
+    .mockImplementation(({ balance, symbol }) => {
+      const fromWei = require('@cardstack/cardpay-sdk').fromWei;
+      const balanceNumber = parseFloat(fromWei(balance));
+
+      return balanceNumber * pricesOracle[symbol];
+    }),
+}));
+
+const balances = {
+  spoa: '4900000000000000',
+  '0x6B78C121bBd10D8ef0dd3623CC1abB077b186F65': '2000000000000000000',
+  '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1': '57000000000000000000',
+  '0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee': '1000000000000000000',
+} as any;
+
+jest.mock('@cardstack/services/assets', () => ({
+  getOnChainAssetBalance: jest
+    .fn()
+    .mockImplementation(({ asset: { address, symbol } }) => {
+      const fromWei = require('@cardstack/cardpay-sdk').fromWei;
+      const amount = fromWei(balances[address]);
+
+      return {
+        amount,
+        display: `${amount} ${symbol}`,
+      };
+    }),
 }));
 
 describe('Fallback Explorer Helpers', () => {

--- a/cardstack/src/helpers/fallbackExplorerHelper.ts
+++ b/cardstack/src/helpers/fallbackExplorerHelper.ts
@@ -8,7 +8,7 @@ import { AssetType, AssetWithNativeType, BalanceType } from '@cardstack/types';
 import { Network } from '@rainbow-me/helpers/networkTypes';
 import { getNativeBalanceFromOracle } from '@cardstack/services';
 import { toWei } from '@rainbow-me/handlers/web3';
-import { getOnchainAssetBalance } from '@rainbow-me/handlers/assets';
+import { getOnChainAssetBalance } from '@cardstack/services/assets';
 
 interface Prices {
   [key: string]: {
@@ -143,11 +143,11 @@ export const reduceAssetsWithPriceChartAndBalances = async ({
   assets.reduce(async (updatedAssets, { asset }) => {
     const coingeckoId = asset.coingecko_id || '';
 
-    const balance = await getOnchainAssetBalance(
-      { address: asset.asset_code || '', ...asset },
+    const balance = await getOnChainAssetBalance({
+      asset: { address: asset.asset_code || '', ...asset },
       accountAddress,
-      network
-    );
+      network,
+    });
 
     const { price, native } = await addPriceByCoingeckoIdOrOracle({
       coingeckoId,

--- a/cardstack/src/services/exchange-rate-service.ts
+++ b/cardstack/src/services/exchange-rate-service.ts
@@ -47,7 +47,7 @@ export const getCurrencyConversionsRates = async () => {
 
 // Token price to native currency
 export const getNativeBalanceFromOracle = async (props: {
-  symbol: string | null | undefined;
+  symbol?: string;
   balance: string;
   nativeCurrency: string;
 }): Promise<number> => {

--- a/cardstack/src/test-utils/jest-setup.js
+++ b/cardstack/src/test-utils/jest-setup.js
@@ -3,6 +3,8 @@ import '@testing-library/jest-native/extend-expect';
 
 // GLOBAL LIBS MOCKS
 
+jest.mock('react-native-flipper');
+
 jest.mock('react-native-background-timer', () => ({
   start: jest.fn(),
   stop: jest.fn(),

--- a/cardstack/src/utils/merchant-utils.ts
+++ b/cardstack/src/utils/merchant-utils.ts
@@ -157,7 +157,7 @@ export async function getMerchantClaimTransactionDetails(
   const gasRawAmount = gasData?.amount || '0';
 
   const gasBalance = await getNativeBalanceFromOracle({
-    symbol: merchantClaimTransaction.token.symbol,
+    symbol: merchantClaimTransaction.token.symbol || '',
     balance: gasRawAmount,
     nativeCurrency,
   });

--- a/src/handlers/assets.js
+++ b/src/handlers/assets.js
@@ -6,6 +6,7 @@ import {
 
 import Web3Instance from '@cardstack/models/web3-instance';
 import { isNativeToken } from '@cardstack/utils';
+import logger from 'logger';
 
 export async function getOnchainAssetBalance(
   { address, decimals, symbol },
@@ -45,7 +46,8 @@ async function getOnchainTokenBalance(
       display: displayBalance,
     };
   } catch (e) {
-    return null;
+    logger.sentry('Error getOnchainTokenBalance', e);
+    return { amount: '0', display: '' };
   }
 }
 
@@ -73,6 +75,7 @@ async function getOnchainNativeTokenBalance(
       display: displayBalance,
     };
   } catch (e) {
-    return null;
+    logger.sentry('Error getOnchainNativeTokenBalance', e);
+    return { amount: '0', display: '' };
   }
 }

--- a/src/hooks/useUpdateAssetOnchainBalance.js
+++ b/src/hooks/useUpdateAssetOnchainBalance.js
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import { getOnchainAssetBalance } from '../handlers/assets';
 import { dataUpdateAssets } from '../redux/data';
 import useAccountAssets from './useAccountAssets';
 import useAccountSettings from './useAccountSettings';
+import { getOnChainAssetBalance } from '@cardstack/services/assets';
 import { logger } from '@rainbow-me/utils';
 
 export default function useUpdateAssetOnchainBalance() {
@@ -13,11 +13,11 @@ export default function useUpdateAssetOnchainBalance() {
 
   const useUpdateAssetOnchainBalance = useCallback(
     async (assetToUpdate, accountAddress, successCallback) => {
-      const balance = await getOnchainAssetBalance(
-        assetToUpdate,
+      const balance = await getOnChainAssetBalance({
+        asset: assetToUpdate,
         accountAddress,
-        network
-      );
+        network,
+      });
       if (balance && balance?.amount !== assetToUpdate?.balance?.amount) {
         // Now we need to update the asset
         // First in the state

--- a/src/hooks/useWalletBalances.js
+++ b/src/hooks/useWalletBalances.js
@@ -31,6 +31,7 @@ const useWalletBalances = wallets => {
       });
     });
 
+    // TODO: check if this can be replaced by SDK
     try {
       // Check all the ETH balances at once
       const balanceCheckerContractAddress = getConstantByNetwork(

--- a/src/parsers/accounts.js
+++ b/src/parsers/accounts.js
@@ -1,6 +1,5 @@
 import {
   add,
-  convertAmountAndPriceToNativeDisplay,
   convertAmountToNativeDisplay,
   convertAmountToPercentageDisplay,
 } from '@cardstack/cardpay-sdk';
@@ -76,23 +75,10 @@ export const parseAssetsNative = (assets, nativeCurrency) =>
       value: 0,
     });
 
-    const priceUnit = get(assetNativePrice, 'value', 0);
-
-    const hasPrice = priceUnit;
-
-    // Only try to convertAmount if there's a price otherwise use default balance
-    const nativeDisplay = hasPrice
-      ? convertAmountAndPriceToNativeDisplay(
-          get(asset, 'balance.amount', 0),
-          priceUnit,
-          nativeCurrency
-        )
-      : asset?.native?.balance;
-
     return {
       ...asset,
       native: {
-        balance: nativeDisplay,
+        ...asset.native,
         change: isLowerCaseMatch(get(asset, 'symbol'), nativeCurrency)
           ? null
           : assetNativePrice.relative_change_24h
@@ -100,10 +86,6 @@ export const parseAssetsNative = (assets, nativeCurrency) =>
               assetNativePrice.relative_change_24h
             )
           : '',
-        price: {
-          amount: priceUnit,
-          display: convertAmountToNativeDisplay(priceUnit, nativeCurrency),
-        },
       },
     };
   });

--- a/src/parsers/accounts.js
+++ b/src/parsers/accounts.js
@@ -3,7 +3,6 @@ import {
   convertAmountAndPriceToNativeDisplay,
   convertAmountToNativeDisplay,
   convertAmountToPercentageDisplay,
-  convertRawAmountToBalance,
 } from '@cardstack/cardpay-sdk';
 import { get, map, toUpper } from 'lodash';
 import AssetTypes from '@rainbow-me/helpers/assetTypes';
@@ -14,15 +13,8 @@ import { getTokenMetadata, isLowerCaseMatch } from '@rainbow-me/utils';
  * @param  {Object} [data]
  * @return {Array}
  */
-export const parseAccountAssets = assets => {
-  return assets.map(assetData => {
-    const asset = parseAsset(assetData.asset);
-    return {
-      ...asset,
-      balance: convertRawAmountToBalance(assetData.quantity, asset),
-    };
-  });
-};
+export const parseAccountAssets = assets =>
+  assets.map(assetData => parseAsset(assetData.asset));
 
 // eslint-disable-next-line no-useless-escape
 const sanitize = s => s.replace(/[^a-z0-9áéíóúñü \.,_@:-]/gim, '');

--- a/src/screens/SendSheetEOA.js
+++ b/src/screens/SendSheetEOA.js
@@ -195,6 +195,10 @@ const useSendSheetScreen = () => {
       } else {
         setSelected(newSelected);
         sendUpdateAssetAmount('');
+
+        // Selection might be empty so we check before trying to update
+        if (isEmpty(newSelected)) return;
+
         // Since we don't trust the balance from zerion,
         // let's hit the blockchain and update it
         updateAssetOnchainBalanceIfNeeded(


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

The balance contract was intermittently throwing  errors probably because of the amount of tokens, this PR fixes this issue by fetching the balances from the sdk also it:

- Migrates assets service to typescript
- Clean up unused code
- Clean up dup code
- Centralize assets data structure to be modified on fallbackHelper, instead of being "parsed" in the UI only, which was proving to be difficult to find why some UI had the right behavior and other didn't.

Ps: I'll be adding tests to assets services, just put the PR up so the reviews can start 

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2687)

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<img width="400" alt="Screenshot" src="https://user-images.githubusercontent.com/20520102/144605525-297dad4b-5c68-440f-86af-9e8c95ea4b38.png"> 
