### PR TITLE
[CS-2700]: Fix importing wallet infinite loading

### DIFF
--- a/src/hooks/useInitializeWallet.js
+++ b/src/hooks/useInitializeWallet.js
@@ -112,9 +112,8 @@ export default function useInitializeWallet() {
         hideSplashScreen();
         logger.sentry('Hide splash screen');
         initializeAccountData();
-        if (!isImporting) {
-          dispatch(appStateUpdate({ walletReady: true }));
-        }
+
+        dispatch(appStateUpdate({ walletReady: true }));
 
         logger.sentry('💰 Wallet initialized');
         return walletAddress;


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
While initializing a wallet, walletReady was never set to true if importing an account, which is already handle a few lines above this function, this `if(!importing)` was wrong so I removed it, because now we wait for walletReady to be true in order to fetch the safes. There's no .gif to preserve the account seed phrase safe but you can test locally, by totally reseting all the the app data and importing a new account from scratch.
