### PR TITLE
Update @react-native-community/async-storage to @react-native-async-storage/async-storage

### DIFF
--- a/cardstack/src/components/DiscordPromoBanner/__tests__/useDiscordPromoBanner.test.ts
+++ b/cardstack/src/components/DiscordPromoBanner/__tests__/useDiscordPromoBanner.test.ts
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { act, renderHook } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react-native';
 import { Linking } from 'react-native';

--- a/cardstack/src/components/DiscordPromoBanner/useDiscordPromoBanner.ts
+++ b/cardstack/src/components/DiscordPromoBanner/useDiscordPromoBanner.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Linking } from 'react-native';
 
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { SettingsExternalURLs } from '@cardstack/constants';
 import { SHOW_PROMO_BANNER_KEY, useWorker } from '@cardstack/utils';
 

--- a/cardstack/src/components/SystemNotification/SystemNotification.tsx
+++ b/cardstack/src/components/SystemNotification/SystemNotification.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Animated, TouchableOpacity } from 'react-native';
 
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import downIcon from '../../assets/chevron-down.png';
 import { AnimatedContainer, AnimatedText } from '../Animated';
 import { Container, Icon, Text, IconName } from '@cardstack/components';

--- a/cardstack/src/test-utils/jest-setup.js
+++ b/cardstack/src/test-utils/jest-setup.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-undef */
 import '@testing-library/jest-native/extend-expect';
+import 'react-native-gesture-handler/jestSetup';
+import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
 
 // GLOBAL LIBS MOCKS
 
@@ -124,9 +126,7 @@ jest.mock('react-native-public-ip', () => ({
   publicIP: jest.fn(),
 }));
 
-jest.mock('@react-native-community/async-storage', () => ({
-  AsyncStorage: jest.fn(),
-}));
+jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
 
 jest.mock('@apollo/client', () => ({
   ApolloClient: jest.fn(),

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -462,7 +462,7 @@ PODS:
   - reactnativeslackbottomsheet (0.5.0):
     - PanModal
     - React
-  - RNCAsyncStorage (1.12.1):
+  - RNCAsyncStorage (1.15.14):
     - React-Core
   - RNCClipboard (1.2.3):
     - React
@@ -654,7 +654,7 @@ DEPENDENCIES:
   - ReactNativeDarkMode (from `../node_modules/react-native-dark-mode`)
   - "ReactNativePayments (from `../node_modules/@rainbow-me/react-native-payments/lib/ios`)"
   - reactnativeslackbottomsheet (from `../node_modules/react-native-slack-bottom-sheet`)
-  - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCClipboard (from `../node_modules/@react-native-community/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
@@ -832,7 +832,7 @@ EXTERNAL SOURCES:
   reactnativeslackbottomsheet:
     :path: "../node_modules/react-native-slack-bottom-sheet"
   RNCAsyncStorage:
-    :path: "../node_modules/@react-native-community/async-storage"
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNCClipboard:
     :path: "../node_modules/@react-native-community/clipboard"
   RNCMaskedView:
@@ -976,7 +976,7 @@ SPEC CHECKSUMS:
   ReactNativeDarkMode: 0178ffca3b10f6a7c9f49d6f9810232b328fa949
   ReactNativePayments: 40a266450628c05db440fe219b631210e4358a49
   reactnativeslackbottomsheet: d44b4c59c1e69c045983044d2f361d256d3ddb98
-  RNCAsyncStorage: b03032fdbdb725bea0bd9e5ec5a7272865ae7398
+  RNCAsyncStorage: ea6b5c280997b2b32a587793163b1f10e580c4f7
   RNCClipboard: 48eaf27bea3de7c9a265529725434268d47a2ee9
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNDeviceInfo: 6f20764111df002b4484f90cbe0a861be29bcc6c

--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -838,7 +838,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Rainbow/Pods-Rainbow-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@lavamoat/preinstall-always-fail": "^1.0.0",
     "@rainbow-me/react-native-animated-number": "^0.0.2",
     "@rainbow-me/react-native-payments": "1.1.5",
-    "@react-native-community/async-storage": "^1.11.0",
+    "@react-native-async-storage/async-storage": "^1.15.14",
     "@react-native-community/blur": "^3.6.0",
     "@react-native-community/clipboard": "git+https://github.com/gnardini/clipboard#01d1c13",
     "@react-native-community/masked-view": "^0.1.5",

--- a/src/App.js
+++ b/src/App.js
@@ -98,7 +98,7 @@ class App extends Component {
   async componentDidMount() {
     if (__DEV__) {
       const RNAsyncStorageFlipper = require('rn-async-storage-flipper').default;
-      const AsyncStorage = require('@react-native-community/async-storage')
+      const AsyncStorage = require('@react-native-async-storage/async-storage')
         .default;
       RNAsyncStorageFlipper(AsyncStorage);
     }

--- a/src/components/settings-menu/DeveloperSettings.js
+++ b/src/components/settings-menu/DeveloperSettings.js
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import React, { useCallback, useContext } from 'react';
 import { Alert, ScrollView } from 'react-native';
 import { Restart } from 'react-native-restart';

--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -1,5 +1,5 @@
 import { getConstantByNetwork } from '@cardstack/cardpay-sdk';
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import React, { useCallback, useMemo } from 'react';
 import { Linking, NativeModules, ScrollView, Share } from 'react-native';
 import styled from 'styled-components';

--- a/src/handlers/localstorage/removeWallet.js
+++ b/src/handlers/localstorage/removeWallet.js
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { concat, flatten, keys, map } from 'lodash';
 import NetworkTypes from '../../helpers/networkTypes';
 import { accountLocalKeys } from './accountLocal';

--- a/src/helpers/RainbowContext.js
+++ b/src/helpers/RainbowContext.js
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import React, {
   createContext,
   useCallback,

--- a/src/hooks/usePinnedAndHiddenItemOptions.tsx
+++ b/src/hooks/usePinnedAndHiddenItemOptions.tsx
@@ -1,4 +1,4 @@
-import { useAsyncStorage } from '@react-native-community/async-storage';
+import { useAsyncStorage } from '@react-native-async-storage/async-storage';
 import { union, without } from 'lodash';
 import React, {
   createContext,

--- a/src/initializers/storage.js
+++ b/src/initializers/storage.js
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
 import Storage from 'react-native-storage';
 

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useRoute } from '@react-navigation/core';
 import React, { useEffect, useState } from 'react';
 import { StatusBar } from 'react-native';

--- a/src/utils/ethereumUtils.js
+++ b/src/utils/ethereumUtils.js
@@ -6,7 +6,7 @@ import {
   subtract,
 } from '@cardstack/cardpay-sdk';
 import { Wallet } from '@ethersproject/wallet';
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { captureException } from '@sentry/react-native';
 import { mnemonicToSeed } from 'bip39';
 import {

--- a/src/utils/reviewAlert.js
+++ b/src/utils/reviewAlert.js
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Alert, Linking, NativeModules } from 'react-native';
 const { RainbowRequestReview } = NativeModules;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3581,12 +3581,12 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@react-native-community/async-storage@^1.11.0":
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.12.1.tgz#25f821b4f6b13abe005ad67e47c6f1cee9f27b24"
-  integrity sha512-70WGaH3PKYASi4BThuEEKMkyAgE9k7VytBqmgPRx3MzJx9/MkspwqJGmn3QLCgHLIFUgF1pit2mWICbRJ3T3lg==
+"@react-native-async-storage/async-storage@^1.15.14":
+  version "1.15.14"
+  resolved "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.14.tgz#8165d3f78798b46e693169795b62e40142064273"
+  integrity sha512-eJF2horabXazwszCyyXDe4w7sBSWlB0WPA8akKXuN2n7WXKHYeQJPN41lS9OahrhSZuZwqftNFE9VWgPXA8wyA==
   dependencies:
-    deep-assign "^3.0.0"
+    merge-options "^3.0.4"
 
 "@react-native-community/blur@^3.6.0":
   version "3.6.0"
@@ -8563,13 +8563,6 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
-
-deep-assign@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-3.0.0.tgz#c8e4c4d401cba25550a2f0f486a2e75bc5f219a2"
-  integrity sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==
-  dependencies:
-    is-obj "^1.0.0"
 
 deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.1.1"
@@ -14945,6 +14938,13 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
@react-native-community/async-storage has been renamed to @react-native-async-storage/async-storage, and the new version includes a mock suitable for use with jest.

These dev env steps are required after this change:

* remove Pods directory (ios/Pods)
* clean build directory through Xcode (in menu: Product -> Clean Build Folder)
* install dependencies again (pod install)
