### PR TITLE
[CS-2708]: Use queryWrapper on claim revenue

### DIFF
--- a/cardstack/src/services/merchant/merchant-api.ts
+++ b/cardstack/src/services/merchant/merchant-api.ts
@@ -1,71 +1,19 @@
-import { getSDK } from '@cardstack/cardpay-sdk';
-import Web3 from 'web3';
-import BigNumber from 'bignumber.js';
 import { CacheTags, safesApi } from '../safes-api';
-import HDProvider from '@cardstack/models/hd-provider';
-import Web3Instance from '@cardstack/models/web3-instance';
-import { TokenType } from '@cardstack/types';
+import { queryPromiseWrapper } from '../utils';
+import { ClaimRevenueQueryParams } from './merchant-types';
+import { claimMerchantRevenue } from './merchant-service';
 
 const merchantApi = safesApi.injectEndpoints({
   endpoints: builder => ({
-    // TODO: add types and move to merchant-services
-    claimRevenue: builder.mutation<any, any>({
-      async queryFn({
-        selectedWallet,
-        network,
-        accountAddress,
-        revenueBalances,
-        merchantSafeAddress,
-      }) {
-        try {
-          const web3 = await Web3Instance.get({
-            selectedWallet,
-            network,
-          });
-
-          const revenuePool = await getSDK('RevenuePool', web3);
-
-          const promises = revenueBalances.map(async (token: TokenType) => {
-            const claimEstimateAmount = Web3.utils.toWei(
-              new BigNumber(token.balance.amount)
-                .div(new BigNumber('2'))
-                .toPrecision(8)
-                .toString()
-            );
-
-            const gasEstimate = await revenuePool.claimGasEstimate(
-              merchantSafeAddress,
-              token.tokenAddress,
-              // divide amount by 2 for estimate since we can't estimate the full amount
-              // and the amount doesn't affect the gas price
-              claimEstimateAmount
-            );
-
-            const claimAmount = new BigNumber(
-              Web3.utils.toWei(token.balance.amount)
-            )
-              .minus(new BigNumber(gasEstimate))
-              .toString();
-
-            await revenuePool.claim(
-              merchantSafeAddress,
-              token.tokenAddress,
-              claimAmount,
-              undefined,
-              { from: accountAddress }
-            );
-          });
-
-          const response = await Promise.all(promises);
-
-          // resets signed provider and web3 instance to kill poller
-          await HDProvider.reset();
-
-          // TODO: create wrapper to data and error
-          return { data: response };
-        } catch (error) {
-          return { error: { status: 418, data: error } };
-        }
+    claimRevenue: builder.mutation<void, ClaimRevenueQueryParams>({
+      async queryFn(params) {
+        return queryPromiseWrapper<void, ClaimRevenueQueryParams>(
+          claimMerchantRevenue,
+          params,
+          {
+            errorLogMessage: 'Error claiming merchant revenue',
+          }
+        );
       },
       invalidatesTags: [CacheTags.SAFES],
     }),

--- a/cardstack/src/services/merchant/merchant-service.ts
+++ b/cardstack/src/services/merchant/merchant-service.ts
@@ -1,0 +1,58 @@
+import { getSDK } from '@cardstack/cardpay-sdk';
+import Web3 from 'web3';
+import BigNumber from 'bignumber.js';
+import { ClaimRevenueQueryParams } from './merchant-types';
+import { TokenType } from '@cardstack/types';
+import Web3Instance from '@cardstack/models/web3-instance';
+import HDProvider from '@cardstack/models/hd-provider';
+
+// Mutations
+
+export const claimMerchantRevenue = async ({
+  selectedWallet,
+  network,
+  accountAddress,
+  revenueBalances,
+  merchantSafeAddress,
+}: ClaimRevenueQueryParams) => {
+  const web3 = await Web3Instance.get({
+    selectedWallet,
+    network,
+  });
+
+  const revenuePool = await getSDK('RevenuePool', web3);
+
+  const promises = revenueBalances.map(async (token: TokenType) => {
+    const claimEstimateAmount = Web3.utils.toWei(
+      new BigNumber(token.balance.amount)
+        .div(new BigNumber('2'))
+        .toPrecision(8)
+        .toString()
+    );
+
+    const gasEstimate = await revenuePool.claimGasEstimate(
+      merchantSafeAddress,
+      token.tokenAddress,
+      // divide amount by 2 for estimate since we can't estimate the full amount
+      // and the amount doesn't affect the gas price
+      claimEstimateAmount
+    );
+
+    const claimAmount = new BigNumber(Web3.utils.toWei(token.balance.amount))
+      .minus(new BigNumber(gasEstimate))
+      .toString();
+
+    await revenuePool.claim(
+      merchantSafeAddress,
+      token.tokenAddress,
+      claimAmount,
+      undefined,
+      { from: accountAddress }
+    );
+  });
+
+  await Promise.all(promises);
+
+  // resets signed provider and web3 instance to kill poller
+  await HDProvider.reset();
+};

--- a/cardstack/src/services/merchant/merchant-service.ts
+++ b/cardstack/src/services/merchant/merchant-service.ts
@@ -23,18 +23,15 @@ export const claimMerchantRevenue = async ({
   const revenuePool = await getSDK('RevenuePool', web3);
 
   const promises = revenueBalances.map(async (token: TokenType) => {
+    // divide amount by 2 for estimate since we can't estimate the full amount
+    // and the amount doesn't affect the gas price
     const claimEstimateAmount = Web3.utils.toWei(
-      new BigNumber(token.balance.amount)
-        .div(new BigNumber('2'))
-        .toPrecision(8)
-        .toString()
+      new BigNumber(token.balance.amount).div(new BigNumber('2')).toString()
     );
 
     const gasEstimate = await revenuePool.claimGasEstimate(
       merchantSafeAddress,
       token.tokenAddress,
-      // divide amount by 2 for estimate since we can't estimate the full amount
-      // and the amount doesn't affect the gas price
       claimEstimateAmount
     );
 

--- a/cardstack/src/services/merchant/merchant-types.ts
+++ b/cardstack/src/services/merchant/merchant-types.ts
@@ -1,0 +1,11 @@
+import { TokenType } from '@cardstack/types';
+import { Network } from '@rainbow-me/helpers/networkTypes';
+import { RainbowWallet } from '@rainbow-me/model/wallet';
+
+export interface ClaimRevenueQueryParams {
+  selectedWallet: RainbowWallet;
+  network: Network;
+  accountAddress: string;
+  merchantSafeAddress: string;
+  revenueBalances: TokenType[];
+}


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

queryWrapper has a sentry breadcrumb and exception step on error cases, since we need to add a breadcrumb for this step, I took the opportunity to already refactor claimingRevenue to use queryWrapper and be a "service" which automatically adds the sentry step.
