### PR TITLE
[CS-2771][Android]: Fix import, change wallet and backup sheet

### DIFF
--- a/cardstack/src/components/PinnedHiddenSection/PinnedHiddenSectionMenu.tsx
+++ b/cardstack/src/components/PinnedHiddenSection/PinnedHiddenSectionMenu.tsx
@@ -6,7 +6,7 @@ import {
   usePinnedAndHiddenItemOptions,
 } from '@rainbow-me/hooks';
 import { showActionSheetWithOptions } from '@rainbow-me/utils';
-import { layoutOpacityAnimation } from '@cardstack/utils';
+import { layoutEasingAnimation } from '@cardstack/utils';
 
 const actionSheetOptions = {
   Edit: { idx: 0 },
@@ -21,7 +21,7 @@ const PinnedHiddenSectionMenu = ({
   const { editing: editingSection, toggle } = usePinnedAndHiddenItemOptions();
 
   const toggleEditingPinnedHidden = useCallback(() => {
-    layoutOpacityAnimation();
+    layoutEasingAnimation();
 
     type && toggle(type);
   }, [toggle, type]);

--- a/cardstack/src/components/Sheet/Sheet.story.tsx
+++ b/cardstack/src/components/Sheet/Sheet.story.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
+import { View } from 'react-native';
 import { Sheet } from '../.';
 
 const Stack = createStackNavigator();
@@ -23,4 +24,8 @@ const reactNavigationDecorator = (story: any) => {
 
 storiesOf('Sheet', module)
   .addDecorator(reactNavigationDecorator)
-  .add('Default', () => <Sheet />);
+  .add('Default', () => (
+    <Sheet>
+      <View />
+    </Sheet>
+  ));

--- a/cardstack/src/components/Sheet/Sheet.tsx
+++ b/cardstack/src/components/Sheet/Sheet.tsx
@@ -88,7 +88,7 @@ const Sheet = ({
     <Container flex={1} justifyContent="flex-end" style={containerStyle}>
       <TouchableBackDrop onPress={goBack} />
       <KeyboardAvoidingView
-        behavior={Device.isIOS ? 'padding' : 'height'}
+        behavior={Device.keyboardBehavior}
         style={wrapperStyle}
       >
         <CenteredContainer paddingVertical={4}>

--- a/cardstack/src/components/Sheet/Sheet.tsx
+++ b/cardstack/src/components/Sheet/Sheet.tsx
@@ -1,64 +1,112 @@
-import React, { ReactNode } from 'react';
+import React, { memo, ReactNode, useMemo } from 'react';
 import { useSafeArea } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import { KeyboardAvoidingView, StatusBar, StyleSheet } from 'react-native';
+import { ScrollView } from '../ScrollView';
+import { CenteredContainer } from '../Container';
 import { TouchableBackDrop } from './TouchableBackDrop';
-import { Container, ContainerProps } from '@cardstack/components';
-import { useDimensions } from '@rainbow-me/hooks';
+import { SheetHandle } from './SheetHandle';
+import { Container } from '@cardstack/components';
 
-export const Sheet = ({
-  borderRadius = 39,
+import { Device } from '@cardstack/utils';
+import { shadow } from '@rainbow-me/styles';
+
+const styles = StyleSheet.create({
+  wrapperBase: {
+    justifyContent: 'flex-end',
+    backgroundColor: 'white',
+    minHeight: '40%',
+  },
+});
+
+const layouts = {
+  contentPaddingBottom: {
+    scrollable: 42,
+    fixed: 30,
+  },
+  wrapperFlex: {
+    full: 1,
+    fixed: 0,
+  },
+};
+
+export interface SheetProps {
+  children: ReactNode;
+  borderRadius?: number;
+  hideHandle?: boolean;
+  isFullScreen?: boolean;
+  scrollEnabled?: boolean;
+  shadowEnabled?: boolean;
+}
+
+const Sheet = ({
+  borderRadius = 30,
   children,
   hideHandle = false,
-  ...props
+  isFullScreen = false,
+  scrollEnabled = false,
+  shadowEnabled = false,
 }: SheetProps) => {
-  const { goBack } = useNavigation();
   const insets = useSafeArea();
-  const { isTallPhone } = useDimensions();
+  const { goBack } = useNavigation();
+
+  const containerStyle = useMemo(
+    () => ({
+      // Android barHeight or iOS top insets
+      paddingTop: StatusBar.currentHeight || insets.top,
+    }),
+    [insets]
+  );
+
+  const wrapperStyle = useMemo(() => {
+    const { full, fixed } = layouts.wrapperFlex;
+
+    const flex = isFullScreen ? full : fixed;
+    const shadowStyle = shadowEnabled ? shadow.buildAsObject(0, 1, 2) : {};
+
+    return {
+      ...styles.wrapperBase,
+      ...shadowStyle,
+      flex,
+      borderTopStartRadius: borderRadius,
+      borderTopEndRadius: borderRadius,
+    };
+  }, [borderRadius, isFullScreen, shadowEnabled]);
+
+  const contentContainerStyle = useMemo(() => {
+    const { scrollable, fixed } = layouts.contentPaddingBottom;
+
+    const isScrollableOrHasBottom = insets.bottom || scrollEnabled;
+
+    return {
+      flexGrow: 1,
+      paddingBottom: isScrollableOrHasBottom ? scrollable : fixed,
+    };
+  }, [insets, scrollEnabled]);
 
   return (
-    <Container flex={1} justifyContent="flex-end">
+    <Container flex={1} justifyContent="flex-end" style={containerStyle}>
       <TouchableBackDrop onPress={goBack} />
-      <Container
-        width="100%"
-        backgroundColor="white"
-        borderTopStartRadius={borderRadius}
-        borderTopEndRadius={borderRadius}
-        style={{
-          paddingBottom: isTallPhone
-            ? Math.round(insets.top / 2.5)
-            : Math.round(insets.top / 1.2),
-        }}
-        {...props}
+      <KeyboardAvoidingView
+        behavior={Device.isIOS ? 'padding' : 'height'}
+        style={wrapperStyle}
       >
-        <Container
-          paddingTop={hideHandle ? 0 : 3}
-          paddingBottom={4}
-          height={5}
-          justifyContent="center"
-          alignItems="center"
-          flex={-1}
+        <CenteredContainer paddingVertical={4}>
+          {!hideHandle && <SheetHandle />}
+        </CenteredContainer>
+        <ScrollView
+          contentContainerStyle={contentContainerStyle}
+          directionalLockEnabled
+          keyboardShouldPersistTaps="always"
+          scrollEnabled={scrollEnabled}
+          showsVerticalScrollIndicator={false}
+          scrollEventThrottle={16}
         >
-          {!hideHandle && (
-            <Container
-              backgroundColor="black"
-              height={5}
-              width={36}
-              borderRadius={5}
-              opacity={0.25}
-            />
-          )}
-        </Container>
-        {children}
-      </Container>
+          {children}
+        </ScrollView>
+      </KeyboardAvoidingView>
     </Container>
   );
 };
 
-export interface SheetProps extends ContainerProps {
-  /** optional children */
-  children?: ReactNode;
-  /** borderRadius for initials */
-  borderRadius?: number;
-  /** hideHandle */
-  hideHandle?: boolean;
-}
+export default memo(Sheet);

--- a/cardstack/src/components/Sheet/index.ts
+++ b/cardstack/src/components/Sheet/index.ts
@@ -1,2 +1,2 @@
-export * from './Sheet';
+export { default as Sheet } from './Sheet';
 export * from './SheetHandle';

--- a/cardstack/src/components/TransactionConfirmationSheet/TransactionConfirmationSheet.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/TransactionConfirmationSheet.tsx
@@ -17,7 +17,7 @@ import {
   Text,
   Touchable,
 } from '@cardstack/components';
-import { layoutOpacityAnimation } from '@cardstack/utils';
+import { layoutEasingAnimation } from '@cardstack/utils';
 
 export interface TransactionConfirmationDisplayProps {
   dappUrl?: string;
@@ -47,7 +47,7 @@ export const TransactionConfirmationSheet = (
   );
 
   const onInfoPress = useCallback(() => {
-    layoutOpacityAnimation();
+    layoutEasingAnimation();
 
     setShowFullMessage(!showFullMessage);
   }, [showFullMessage]);

--- a/cardstack/src/screens/LoadingOverlayScreen.tsx
+++ b/cardstack/src/screens/LoadingOverlayScreen.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { useRoute } from '@react-navigation/core';
 import { LoadingOverlay } from '@cardstack/components';
+import { useBlockBackButton } from '@rainbow-me/hooks/useBlockBackButton';
 
 const LoadingOverlayScreen = () => {
   const {
     params: { title, subTitle },
   } = useRoute() as { params: { title: string; subTitle: string } };
+
+  useBlockBackButton();
 
   return <LoadingOverlay title={title} subTitle={subTitle} />;
 };

--- a/cardstack/src/theme/buttonVariants.ts
+++ b/cardstack/src/theme/buttonVariants.ts
@@ -176,6 +176,14 @@ export const buttonVariants = {
   extraSmall: {
     ...extraSmall,
   },
+  extraSmallDark: {
+    ...extraSmall,
+    ...dark,
+    textStyle: {
+      ...extraSmall.textStyle,
+      ...dark.textStyle,
+    },
+  },
   tiny,
   tinyOpacity,
   invalid: { ...invalid },

--- a/cardstack/src/utils/device.ts
+++ b/cardstack/src/utils/device.ts
@@ -7,6 +7,7 @@ const Device = {
   isIOS,
   isAndroid,
   supportsFiatOnRamp: isIOS,
+  keyboardBehavior: isIOS ? ('padding' as const) : undefined,
 };
 
 export { Device };

--- a/cardstack/src/utils/layouts.ts
+++ b/cardstack/src/utils/layouts.ts
@@ -14,7 +14,7 @@ export const hitSlop = {
   },
 };
 
-export const layoutOpacityAnimation = () => {
+export const layoutEasingAnimation = () => {
   LayoutAnimation.configureNext(
     LayoutAnimation.create(200, 'easeInEaseOut', 'opacity')
   );

--- a/src/components/backup/RestoreSheetFirstStep.js
+++ b/src/components/backup/RestoreSheetFirstStep.js
@@ -12,7 +12,7 @@ export default function RestoreSheetFirstStep({
     <Container marginTop={2} paddingHorizontal={2}>
       <Text
         fontSize={18}
-        fontWeight="700"
+        fontWeight="bold"
         marginBottom={5}
         marginTop={2}
         textAlign="center"

--- a/src/components/list/ListHeader.js
+++ b/src/components/list/ListHeader.js
@@ -6,7 +6,7 @@ import { ContextMenu } from '../context-menu';
 import { Row } from '../layout';
 import { Button, Container, Text } from '@cardstack/components';
 import { colors as cardstackColors } from '@cardstack/theme';
-import { layoutOpacityAnimation } from '@cardstack/utils';
+import { layoutEasingAnimation } from '@cardstack/utils';
 import { padding } from '@rainbow-me/styles';
 
 export const ListHeaderHeight = 44;
@@ -41,7 +41,7 @@ export default function ListHeader({
   const { setIsCoinListEdited } = useCoinListEditOptions();
 
   const handlePress = useCallback(() => {
-    layoutOpacityAnimation();
+    layoutEasingAnimation();
 
     setIsCoinListEdited(false);
   }, [setIsCoinListEdited]);

--- a/src/components/send/SendAssetList.js
+++ b/src/components/send/SendAssetList.js
@@ -21,7 +21,7 @@ import {
 import { Centered } from '../layout';
 import SavingsListHeader from '../savings/SavingsListHeader';
 import TokenFamilyHeader from '../token-family/TokenFamilyHeader';
-import { layoutOpacityAnimation } from '@cardstack/utils';
+import { layoutEasingAnimation } from '@cardstack/utils';
 import { ImgixImage } from '@rainbow-me/images';
 
 const dividerMargin = 10;
@@ -225,7 +225,7 @@ export default class SendAssetList extends React.Component {
       visibleAssetsLength,
     } = this.state;
 
-    layoutOpacityAnimation();
+    layoutEasingAnimation();
 
     openCards[index] = !openCards[index];
     this.setState({ openCards });
@@ -283,13 +283,13 @@ export default class SendAssetList extends React.Component {
   };
 
   changeOpenSavings = () => {
-    layoutOpacityAnimation();
+    layoutEasingAnimation();
 
     this.setState(prevState => ({ openSavings: !prevState.openSavings }));
   };
 
   changeOpenShitcoins = () => {
-    layoutOpacityAnimation();
+    layoutEasingAnimation();
 
     this.setState(prevState => ({ openShitcoins: !prevState.openShitcoins }));
   };

--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -25,7 +25,6 @@ import { SwipeNavigator } from './SwipeNavigator';
 import {
   closeKeyboardOnClose,
   defaultScreenStackOptions,
-  restoreSheetConfig,
   stackNavigationConfig,
   wyreWebviewOptions,
 } from './config';
@@ -196,13 +195,12 @@ function MainNavigator() {
       <Stack.Screen
         component={RestoreSheet}
         name={Routes.RESTORE_SHEET}
-        {...restoreSheetConfig}
         options={bottomSheetPreset}
       />
       <Stack.Screen
         component={ImportSeedPhraseFlowNavigator}
         name={Routes.IMPORT_SEED_PHRASE_SHEET_NAVIGATOR}
-        options={sheetPresetWithSmallGestureResponseDistance}
+        options={bottomSheetPreset}
       />
       <Stack.Screen
         component={AddCashFlowNavigator}

--- a/src/navigation/Routes.ios.js
+++ b/src/navigation/Routes.ios.js
@@ -30,7 +30,6 @@ import {
   expandedAssetSheetConfig,
   nativeStackDefaultConfig,
   nativeStackDefaultConfigWithoutStatusBar,
-  restoreSheetConfig,
   savingsSheetConfig,
   stackNavigationConfig,
 } from './config';
@@ -110,6 +109,7 @@ function ImportSeedPhraseFlowNavigator() {
       <Stack.Screen
         component={ImportSeedPhraseSheet}
         name={Routes.IMPORT_SEED_PHRASE_SHEET}
+        options={bottomSheetPreset}
       />
     </Stack.Navigator>
   );
@@ -191,12 +191,12 @@ function NativeStackFallbackNavigator() {
       <Stack.Screen
         component={ImportSeedPhraseSheet}
         name={Routes.IMPORT_SEED_PHRASE_SHEET}
-        options={{
-          ...sheetPreset,
-          onTransitionStart: () => {
-            StatusBar.setBarStyle('light-content');
-          },
-        }}
+        options={bottomSheetPreset}
+      />
+      <Stack.Screen
+        component={RestoreSheet}
+        name={Routes.RESTORE_SHEET}
+        options={bottomSheetPreset}
       />
       <Stack.Screen
         component={AddCashSheet}
@@ -318,11 +318,6 @@ function NativeStackNavigator() {
           onAppear: null,
           topOffset: 0,
         }}
-      />
-      <NativeStack.Screen
-        component={RestoreSheet}
-        name={Routes.RESTORE_SHEET}
-        {...restoreSheetConfig}
       />
       <NativeStack.Screen
         component={SavingsSheet}

--- a/src/navigation/config.js
+++ b/src/navigation/config.js
@@ -83,41 +83,6 @@ export const expandedAssetSheetConfig = {
   }),
 };
 
-const restoreSheetSizes = {
-  ...backupSheetSizes,
-  medium: 505,
-  short: 363,
-};
-
-export const restoreSheetConfig = {
-  options: ({ navigation, route }) => {
-    const {
-      params: {
-        longFormHeight,
-        step = WalletBackupStepTypes.first,
-        ...params
-      } = {},
-    } = route;
-
-    let heightForStep = restoreSheetSizes.short;
-    if (step === WalletBackupStepTypes.cloud) {
-      heightForStep = restoreSheetSizes.long;
-    }
-
-    if (longFormHeight !== heightForStep) {
-      navigation.setParams({
-        longFormHeight: heightForStep,
-      });
-    }
-
-    return buildCoolModalConfig({
-      ...params,
-      backgroundColor: colors.themedColors.dark,
-      longFormHeight: heightForStep,
-    });
-  },
-};
-
 export const savingsSheetConfig = {
   options: ({ route: { params = {} } }) => ({
     ...buildCoolModalConfig({

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -11,7 +11,6 @@ import React, {
 import { InteractionManager } from 'react-native';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import { useDispatch } from 'react-redux';
-import styled from 'styled-components';
 
 import Divider from '../components/Divider';
 import WalletList from '../components/change-wallet/WalletList';
@@ -42,14 +41,6 @@ import {
 import Routes from '@rainbow-me/routes';
 import { deviceUtils, showActionSheetWithOptions } from '@rainbow-me/utils';
 import logger from 'logger';
-
-const Whitespace = styled.View`
-  background-color: ${({ theme: { colors } }) => colors.white};
-  bottom: -400px;
-  height: 400px;
-  position: absolute;
-  width: 100%;
-`;
 
 const getWalletRowCount = wallets => {
   let count = 0;
@@ -93,13 +84,13 @@ export default function ChangeWalletSheet() {
   const listPaddingBottom = 6;
   const walletRowHeight = 60;
   const maxListHeight = deviceHeight - 220;
-  let headerHeight = android ? 0 : 30;
+  let headerHeight = 30;
   let listHeight =
     walletRowHeight * walletRowCount + footerHeight + listPaddingBottom;
   let scrollEnabled = false;
   let showDividers = false;
   if (listHeight > maxListHeight) {
-    headerHeight = android ? 0 : 40;
+    headerHeight = 40;
     listHeight = maxListHeight;
     scrollEnabled = true;
     showDividers = true;
@@ -430,8 +421,7 @@ export default function ChangeWalletSheet() {
   }, [navigate]);
 
   return (
-    <Sheet borderRadius={30} hideHandle={false}>
-      {android && <Whitespace />}
+    <Sheet>
       <Container height={headerHeight}>
         <Text fontSize={18} fontWeight="700" textAlign="center">
           Accounts

--- a/src/screens/ImportSeedPhraseSheet.js
+++ b/src/screens/ImportSeedPhraseSheet.js
@@ -8,20 +8,22 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { InteractionManager, StatusBar } from 'react-native';
-import { KeyboardArea } from 'react-native-keyboard-area';
-import styled from 'styled-components';
+import { InteractionManager } from 'react-native';
 
-import { Centered, Column, Row } from '../components/layout';
-import { SheetHandle } from '../components/sheet';
 import {
   InvalidPasteToast,
   ToastPositionContainer,
 } from '../components/toasts';
 import { useTheme } from '../context/ThemeContext';
 import NetworkTypes, { networkTypes } from '../helpers/networkTypes';
-import { Button, Input, Text } from '@cardstack/components';
-import isNativeStackAvailable from '@rainbow-me/helpers/isNativeStackAvailable';
+import {
+  Button,
+  CenteredContainer,
+  Container,
+  Input,
+  Sheet,
+  Text,
+} from '@cardstack/components';
 import {
   isValidSeedPhrase,
   isValidWallet,
@@ -30,7 +32,6 @@ import walletLoadingStates from '@rainbow-me/helpers/walletLoadingStates';
 import {
   useAccountSettings,
   useClipboard,
-  useDimensions,
   useInitializeWallet,
   useInvalidPaste,
   useKeyboardHeight,
@@ -39,9 +40,7 @@ import {
   useWallets,
 } from '@rainbow-me/hooks';
 import { useNavigation } from '@rainbow-me/navigation';
-import { sheetVerticalOffset } from '@rainbow-me/navigation/effects';
 import Routes from '@rainbow-me/routes';
-import { borders, padding } from '@rainbow-me/styles';
 import {
   deviceUtils,
   ethereumUtils,
@@ -49,61 +48,11 @@ import {
 } from '@rainbow-me/utils';
 import logger from 'logger';
 
-const sheetBottomPadding = 19;
-
-const Container = styled.View`
-  flex: 1;
-  padding-top: ${android
-    ? 0
-    : isNativeStackAvailable
-    ? 0
-    : sheetVerticalOffset};
-  ${android ? `margin-top: ${sheetVerticalOffset};` : ''}
-  ${android
-    ? `background-color: ${({ theme: { colors } }) => colors.transparent};`
-    : ''}
-`;
-
-const Footer = styled(Row).attrs({
-  align: 'start',
-  justify: 'end',
-})`
-  bottom: ${android ? 15 : 0};
-  position: ${android ? 'absolute' : 'relative'};
-  right: 0;
-  width: 100%;
-  ${android
-    ? `top: ${({ isSmallPhone }) =>
-        isSmallPhone ? sheetBottomPadding * 2 : 0};`
-    : ``}
-  ${android ? 'margin-right: 18;' : ''}
-`;
-
-const KeyboardSizeView = styled(KeyboardArea)`
-  background-color: ${({ theme: { colors } }) => colors.white};
-`;
-
-const SecretTextAreaContainer = styled(Centered)`
-  ${padding(0, 42)};
-  flex: 1;
-`;
-
-const Sheet = styled(Column).attrs({
-  align: 'center',
-  flex: 1,
-})`
-  ${borders.buildRadius('top', isNativeStackAvailable ? 0 : 16)};
-  ${padding(0, 15, sheetBottomPadding)};
-  background-color: ${({ theme: { colors } }) => colors.white};
-  z-index: 1;
-`;
-
 export default function ImportSeedPhraseSheet() {
   const { accountAddress } = useAccountSettings();
   const { setIsWalletLoading, wallets } = useWallets();
   const { getClipboard, hasClipboardData, clipboard } = useClipboard();
   const { onInvalidPaste } = useInvalidPaste();
-  const { isSmallPhone } = useDimensions();
   const keyboardHeight = useKeyboardHeight();
   const { goBack, navigate, replace, setParams } = useNavigation();
   const initializeWallet = useInitializeWallet();
@@ -280,65 +229,62 @@ export default function ImportSeedPhraseSheet() {
   const { colors } = useTheme();
 
   return (
-    <Container testID="import-sheet">
-      <StatusBar barStyle="dark-content" />
-      <Sheet>
-        <SheetHandle marginBottom={7} marginTop={6} />
-        <Text fontSize={18} fontWeight="700">
+    <>
+      <Sheet isFullScreen>
+        <Text fontSize={18} fontWeight="bold" textAlign="center">
           Add account
         </Text>
-        <SecretTextAreaContainer>
-          <Input
-            autoCapitalize="none"
-            autoCorrect={false}
-            autoFocus
-            enablesReturnKeyAutomatically
-            fontSize={18}
-            fontWeight="600"
-            keyboardType={android ? 'visible-password' : 'default'}
-            marginBottom={android ? 14 : 0}
-            minHeight={android ? 100 : 50}
-            multiline
-            numberOfLines={3}
-            onChangeText={handleSetSeedPhrase}
-            onFocus={handleFocus}
-            onSubmitEditing={handlePressImportButton}
-            placeholder="Enter seed phrase or secret recovery phrase"
-            placeholderTextColor={colors.alpha(colors.blueGreyDark, 0.3)}
-            ref={inputRef}
-            returnKeyType="done"
-            size="large"
-            spellCheck={false}
-            testID="import-sheet-input"
-            textAlign="center"
-            value={seedPhrase}
-          />
-        </SecretTextAreaContainer>
-        <Footer isSmallPhone={isSmallPhone}>
-          {seedPhrase ? (
-            <Button
-              disabled={!isSecretValid}
-              loading={busy}
-              onPress={handlePressImportButton}
-              variant="extraSmall"
-            >
-              Import
-            </Button>
-          ) : (
-            <Button
-              disabled={!isClipboardValidSecret}
-              onPress={handlePressPasteButton}
-              variant="tinyDark"
-            >
-              Paste
-            </Button>
-          )}
-        </Footer>
+        <Container flex={1} paddingHorizontal={4}>
+          <CenteredContainer flex={1}>
+            <Input
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoFocus
+              enablesReturnKeyAutomatically
+              fontSize={18}
+              fontWeight="600"
+              keyboardType={android ? 'visible-password' : 'default'}
+              multiline
+              numberOfLines={3}
+              onChangeText={handleSetSeedPhrase}
+              onFocus={handleFocus}
+              onSubmitEditing={handlePressImportButton}
+              placeholder="Enter seed phrase or secret recovery phrase"
+              placeholderTextColor={colors.alpha(colors.blueGreyDark, 0.3)}
+              ref={inputRef}
+              returnKeyType="done"
+              size="large"
+              spellCheck={false}
+              testID="import-sheet-input"
+              textAlign="center"
+              value={seedPhrase}
+            />
+          </CenteredContainer>
+          <Container alignSelf="flex-end">
+            {seedPhrase ? (
+              <Button
+                disabled={!isSecretValid}
+                loading={busy}
+                onPress={handlePressImportButton}
+                variant="extraSmall"
+              >
+                Import
+              </Button>
+            ) : (
+              <Button
+                disabled={!isClipboardValidSecret}
+                onPress={handlePressPasteButton}
+                variant="extraSmallDark"
+              >
+                Paste
+              </Button>
+            )}
+          </Container>
+        </Container>
       </Sheet>
       <ToastPositionContainer bottom={keyboardHeight}>
         <InvalidPasteToast />
       </ToastPositionContainer>
-      {ios ? <KeyboardSizeView isOpen /> : null}
-    </Container>
+    </>
   );
 }

--- a/src/screens/QRScannerScreen.js
+++ b/src/screens/QRScannerScreen.js
@@ -19,7 +19,6 @@ import {
 import { useHeight, useWalletConnectConnections } from '@rainbow-me/hooks';
 import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
-import { shadow } from '@rainbow-me/styles';
 
 const Background = styled.View`
   background-color: black;
@@ -72,11 +71,7 @@ const QRScannerScreen = () => {
         </CameraDimmer>
 
         <Container bottom={0} position="absolute" width="100%">
-          <Sheet
-            borderRadius={20}
-            css={shadow.buildAsObject(0, 1, 2)}
-            hideHandle
-          >
+          <Sheet borderRadius={20} hideHandle shadowEnabled>
             {walletConnectorsCount ? (
               <>
                 <FlatList

--- a/src/screens/RestoreSheet.js
+++ b/src/screens/RestoreSheet.js
@@ -2,28 +2,20 @@ import { useRoute } from '@react-navigation/native';
 import { forEach } from 'lodash';
 import React, { useCallback } from 'react';
 import { InteractionManager, StatusBar } from 'react-native';
-import { getSoftMenuBarHeight } from 'react-native-extra-dimensions-android';
 import RestoreCloudStep from '../components/backup/RestoreCloudStep';
 import RestoreSheetFirstStep from '../components/backup/RestoreSheetFirstStep';
-import { Column } from '../components/layout';
-import { SlackSheet } from '../components/sheet';
 
+import { Sheet } from '@cardstack/components';
 import { Device } from '@cardstack/utils';
 import WalletBackupStepTypes from '@rainbow-me/helpers/walletBackupStepTypes';
 import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
-import { useDimensions } from '@rainbow-me/hooks';
 import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
 
 export default function RestoreSheet() {
   const { goBack, navigate, setParams } = useNavigation();
-  const { height: deviceHeight } = useDimensions();
   const {
-    params: {
-      longFormHeight = 0,
-      step = WalletBackupStepTypes.first,
-      userData,
-    } = {},
+    params: { step = WalletBackupStepTypes.first, userData } = {},
   } = useRoute();
 
   const onCloudRestore = useCallback(async () => {
@@ -51,28 +43,21 @@ export default function RestoreSheet() {
 
   const enableCloudRestore = walletsBackedUp > 0;
 
-  const wrapperHeight =
-    deviceHeight + longFormHeight + (android ? getSoftMenuBarHeight() : 0);
+  const isCloudStep = step === WalletBackupStepTypes.cloud;
 
   return (
-    <Column height={wrapperHeight}>
+    <Sheet isFullScreen={isCloudStep}>
       <StatusBar barStyle="light-content" />
-      <SlackSheet
-        contentHeight={longFormHeight}
-        deferredHeight={android}
-        testID="restore-sheet"
-      >
-        {step === WalletBackupStepTypes.cloud ? (
-          <RestoreCloudStep userData={userData} />
-        ) : (
-          <RestoreSheetFirstStep
-            enableCloudRestore={enableCloudRestore}
-            onCloudRestore={onCloudRestore}
-            onManualRestore={onManualRestore}
-            walletsBackedUp={walletsBackedUp}
-          />
-        )}
-      </SlackSheet>
-    </Column>
+      {isCloudStep ? (
+        <RestoreCloudStep userData={userData} />
+      ) : (
+        <RestoreSheetFirstStep
+          enableCloudRestore={enableCloudRestore}
+          onCloudRestore={onCloudRestore}
+          onManualRestore={onManualRestore}
+          walletsBackedUp={walletsBackedUp}
+        />
+      )}
+    </Sheet>
   );
 }

--- a/src/screens/RestoreSheet.js
+++ b/src/screens/RestoreSheet.js
@@ -6,7 +6,7 @@ import RestoreCloudStep from '../components/backup/RestoreCloudStep';
 import RestoreSheetFirstStep from '../components/backup/RestoreSheetFirstStep';
 
 import { Sheet } from '@cardstack/components';
-import { Device } from '@cardstack/utils';
+import { Device, layoutEasingAnimation } from '@cardstack/utils';
 import WalletBackupStepTypes from '@rainbow-me/helpers/walletBackupStepTypes';
 import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
 import { useNavigation } from '@rainbow-me/navigation';
@@ -19,6 +19,9 @@ export default function RestoreSheet() {
   } = useRoute();
 
   const onCloudRestore = useCallback(async () => {
+    // Animate transforming into backup sheet
+    layoutEasingAnimation();
+
     if (Device.isIOS) {
       setParams({ step: WalletBackupStepTypes.cloud });
     }
@@ -46,7 +49,7 @@ export default function RestoreSheet() {
   const isCloudStep = step === WalletBackupStepTypes.cloud;
 
   return (
-    <Sheet isFullScreen={isCloudStep}>
+    <Sheet isFullScreen={isCloudStep} scrollEnabled={isCloudStep}>
       <StatusBar barStyle="light-content" />
       {isCloudStep ? (
         <RestoreCloudStep userData={userData} />


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds the same behavior for android and iOS on the restore/import sheets, also fixed the button layout on import sheet step, fixes the ChangeWallet sheet overlapping and disables android back button on LoadingOverlay 

PS: there's room for improvement on closing the keyboard within a modal for android, but we can track it later.

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2771)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<img width="300" alt="Screenshot" src=https://user-images.githubusercontent.com/20520102/145432147-012245e8-79e8-4915-9fd1-442f1fc5db00.png>


https://user-images.githubusercontent.com/20520102/145431342-9604f511-1dd2-4d21-a08a-7a89b3896c1f.mov

