### PR TITLE
[CS-2783][Android]: Open payment flow from in-app qrReader and universal link

### DIFF
--- a/cardstack/src/components/PrepaidCard/MediumPrepaidCard.tsx
+++ b/cardstack/src/components/PrepaidCard/MediumPrepaidCard.tsx
@@ -21,6 +21,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 1,
     borderStyle: 'solid',
     borderRadius: 10,
+    elevation: 2,
   },
 });
 

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -19,6 +19,7 @@ import { expandedPreset, sheetPreset } from '@rainbow-me/navigation/effects';
 import { nativeStackModalConfig } from '@rainbow-me/navigation/config';
 import RainbowRoutes from '@rainbow-me/navigation/routesNames';
 import SendSheetEOA from '@rainbow-me/screens/SendSheetEOA';
+import { Device } from '@cardstack/utils';
 
 interface ScreenNavigation {
   component: React.ComponentType<any>;
@@ -86,6 +87,22 @@ export const GlobalScreens: Record<
   },
 };
 
+// TODO: Merge paths once, navigation redesign happens
+const sharedNavigatorPath = {
+  [RainbowRoutes.MAIN_NAVIGATOR]: {
+    initialRouteName: RainbowRoutes.SWIPE_LAYOUT,
+    screens: {
+      [MainRoutes.PAY_MERCHANT]: 'pay/:network/:merchantAddress',
+    },
+  },
+};
+
+const iOSNavigatorPath = {
+  [RainbowRoutes.STACK]: {
+    screens: sharedNavigatorPath,
+  },
+};
+
 export const linking = {
   prefixes: [
     'https://wallet.cardstack.com',
@@ -93,17 +110,6 @@ export const linking = {
     'cardwallet://',
   ],
   config: {
-    screens: {
-      [RainbowRoutes.STACK]: {
-        screens: {
-          [RainbowRoutes.MAIN_NAVIGATOR]: {
-            initialRouteName: RainbowRoutes.SWIPE_LAYOUT,
-            screens: {
-              [MainRoutes.PAY_MERCHANT]: 'pay/:network/:merchantAddress',
-            },
-          },
-        },
-      },
-    },
+    screens: Device.isIOS ? iOSNavigatorPath : sharedNavigatorPath,
   },
 };

--- a/cardstack/src/screens/PayMerchant/ChoosePrepaidCard.tsx
+++ b/cardstack/src/screens/PayMerchant/ChoosePrepaidCard.tsx
@@ -11,7 +11,11 @@ import {
   Touchable,
   Text,
 } from '@cardstack/components';
-import { convertSpendForBalanceDisplay, splitAddress } from '@cardstack/utils';
+import {
+  convertSpendForBalanceDisplay,
+  Device,
+  splitAddress,
+} from '@cardstack/utils';
 import { PrepaidCardType } from '@cardstack/types';
 import { useRainbowSelector } from '@rainbow-me/redux/hooks';
 import MediumPrepaidCard from '@cardstack/components/PrepaidCard/MediumPrepaidCard';
@@ -170,6 +174,10 @@ interface PrepaidCardItemProps {
   isLastItem: boolean;
 }
 
+// Android has a shadow issue,
+// the default opacity adds a weird shadow on press
+const activeOpacity = Device.isAndroid ? 0.85 : undefined;
+
 const PrepaidCardItem = memo(
   ({
     item,
@@ -211,6 +219,7 @@ const PrepaidCardItem = memo(
         onPress={handleOnPress}
         width="100%"
         disabled={isInsufficientFund}
+        activeOpacity={activeOpacity}
       >
         <Container
           flexDirection="row"


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
Opens payment flow from in-app QRCode reader and from universal link while app on background, does not handle the app closed case yet, will be handled on a diff ticket, also adds shadow for android card, it was all white, without any borders 

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

https://user-images.githubusercontent.com/20520102/145626894-ca7a87a2-1a5f-4caa-88a2-4fddf9dbb564.mp4


