### PR TITLE
[CS-2782]: Add missing route on android

### DIFF
--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -231,6 +231,11 @@ function MainOuterNavigator() {
         options={sheetPreset}
       />
       <OuterStack.Screen
+        component={ExpandedAssetSheet}
+        name={Routes.EXPANDED_ASSET_SHEET_DRILL}
+        options={sheetPreset}
+      />
+      <OuterStack.Screen
         component={SettingsModal}
         name={Routes.SETTINGS_MODAL}
         options={settingsPreset}


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

For now android and ios uses separate navigators, and one route was missing, this PR adds it in order to fixed the nested chart/send modal sheet that was not being triggered. Ideally we should have this `EXPANDED_ASSET_SHEET_DRILL` as a shared route between both platforms but its not worth do to that right now, bc I'm planning on doing this while fixing the sheet.


### Screenshots

<!-- Screenshots or animated GIFs included here -->

<img width="300" alt="Screenshot" src=https://user-images.githubusercontent.com/20520102/145631640-d733abb5-48ff-4fb7-af9a-b873745153cb.png> 

