### PR TITLE
[CS-2790]: Fix android prepaidCardModal overflow

### DIFF
--- a/cardstack/src/screens/PrepaidCardModal.tsx
+++ b/cardstack/src/screens/PrepaidCardModal.tsx
@@ -1,6 +1,6 @@
 import { useRoute } from '@react-navigation/core';
 import React, { memo } from 'react';
-import { SectionList } from 'react-native';
+import { SectionList, StatusBar, StyleSheet } from 'react-native';
 import { TransactionListLoading } from '../components/TransactionList/TransactionListLoading';
 import {
   Container,
@@ -14,6 +14,12 @@ import {
 } from '@cardstack/components';
 import { usePrepaidCardTransactions } from '@cardstack/hooks';
 import { sectionStyle } from '@cardstack/utils/layouts';
+
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: StatusBar.currentHeight || 1,
+  },
+});
 
 const PrepaidCardModal = () => {
   const {
@@ -30,7 +36,7 @@ const PrepaidCardModal = () => {
       flex={1}
       width="100%"
       alignItems="center"
-      paddingTop={1}
+      style={styles.container}
     >
       <SheetHandle color="buttonDarkBackground" opacity={1} />
       <PrepaidCard


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

The iOS bar is handled internally by the native Navigation style, and for Android we need to set the paddingTop based on the bar height, which is given by `StatusBar.currentHeight`  on Android and it's null on iOS
<!-- Include a summary of the changes. -->

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<img width="500" alt="Screenshot" src=https://user-images.githubusercontent.com/20520102/145874751-4d0f7872-68fa-4e10-aff7-aa739d74c77d.png> 
