### PR TITLE
[CS-2670]: Workaround for Sheets covering statusbar on android

### DIFF
--- a/cardstack/src/components/Sheet/Sheet.tsx
+++ b/cardstack/src/components/Sheet/Sheet.tsx
@@ -37,6 +37,7 @@ export interface SheetProps {
   isFullScreen?: boolean;
   scrollEnabled?: boolean;
   shadowEnabled?: boolean;
+  overlayColor?: string;
 }
 
 const Sheet = ({
@@ -46,6 +47,7 @@ const Sheet = ({
   isFullScreen = false,
   scrollEnabled = false,
   shadowEnabled = false,
+  overlayColor = 'transparent',
 }: SheetProps) => {
   const insets = useSafeArea();
   const { goBack } = useNavigation();
@@ -54,8 +56,9 @@ const Sheet = ({
     () => ({
       // Android barHeight or iOS top insets
       paddingTop: StatusBar.currentHeight || insets.top,
+      backgroundColor: overlayColor,
     }),
-    [insets]
+    [insets, overlayColor]
   );
 
   const wrapperStyle = useMemo(() => {

--- a/src/components/sheet/SlackSheet.js
+++ b/src/components/sheet/SlackSheet.js
@@ -3,6 +3,7 @@ import React, { Fragment, useEffect, useMemo, useRef } from 'react';
 import {
   KeyboardAvoidingView,
   Pressable,
+  StatusBar,
   StyleSheet,
   TouchableWithoutFeedback,
 } from 'react-native';
@@ -116,6 +117,13 @@ export default function SlackSheet({
       )
     : props => <Container backgroundColor={bg} flex={1} {...props} />;
 
+  const oldTopCondition =
+    deferredHeight || ios
+      ? 0
+      : contentHeight && additionalTopPadding
+      ? deviceHeight - contentHeight
+      : 0;
+
   return (
     <Fragment>
       {android ? (
@@ -123,18 +131,15 @@ export default function SlackSheet({
       ) : null}
       <Container
         backgroundColor={bg}
+        borderTopLeftRadius={30}
+        borderTopRightRadius={30}
         bottom={0}
         left={0}
         overflow="hidden"
         position="absolute"
         right={0}
-        top={
-          deferredHeight || ios
-            ? 0
-            : contentHeight && additionalTopPadding
-            ? deviceHeight - contentHeight
-            : 0
-        }
+        // Temp workaround until migration os SlackSheet to Sheet
+        top={android ? StatusBar.currentHeight : oldTopCondition}
         {...props}
       >
         {android && (

--- a/src/handlers/walletReadyEvents.js
+++ b/src/handlers/walletReadyEvents.js
@@ -25,22 +25,6 @@ export const runKeychainIntegrityChecks = () => {
 export const runWalletBackupStatusChecks = () => {
   const state = store.getState();
   const { selected, wallets } = state.wallets;
-  const {
-    prepaidCards = [],
-    merchantSafes = [],
-    depots = [],
-    assets = [],
-  } = state.data;
-
-  // Skip check if EOA has no safes or assets
-  if (
-    !prepaidCards.length &&
-    !merchantSafes.length &&
-    !depots.length &&
-    !assets.length
-  ) {
-    return;
-  }
 
   // count how many visible, non-imported and non-readonly wallets are not backed up
   const rainbowWalletsNotBackedUp = filter(wallets, wallet => {

--- a/src/screens/BackupSheet.js
+++ b/src/screens/BackupSheet.js
@@ -12,7 +12,8 @@ import {
 } from '../components/backup';
 import { SlackSheet } from '../components/sheet';
 import { cloudPlatform } from '../utils/platform';
-import { Container } from '@cardstack/components';
+import { Container, Sheet } from '@cardstack/components';
+import { Device } from '@cardstack/utils';
 import showWalletErrorAlert from '@rainbow-me/helpers/support';
 import WalletBackupStepTypes from '@rainbow-me/helpers/walletBackupStepTypes';
 import {
@@ -185,7 +186,29 @@ export default function BackupSheet() {
   return (
     <Container flex={1} testID="backup-sheet">
       <StatusBar barStyle="light-content" />
-      <SlackSheet flex={1}>{renderStep()}</SlackSheet>
+      <PlataformSheet step={step}>{renderStep()}</PlataformSheet>
     </Container>
   );
 }
+
+// Temp workaround until nav redesign
+const PlataformSheet = ({ children, step }) => {
+  const isFullScreenStep =
+    step === WalletBackupStepTypes.manual ||
+    step === WalletBackupStepTypes.cloud;
+
+  const bgColor =
+    step === WalletBackupStepTypes.cloud ? 'black' : 'transparent';
+
+  return Device.isAndroid ? (
+    <Sheet
+      isFullScreen={isFullScreenStep}
+      overlayColor={bgColor}
+      scrollEnabled={isFullScreenStep}
+    >
+      {children}
+    </Sheet>
+  ) : (
+    <SlackSheet flex={1}>{children}</SlackSheet>
+  );
+};


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

We have the `SlackSheet` and some native navigation behaviors that works great for iOS but not so much for Android, the goal is to have both platforms using the same component and navigation stack, which will require a good amount of work, right now to avoid breaking what works good on iOS but add some improvement to android I created this workaround which is not great, but it's useful, as we can gradually start to migrate every component that uses `SlackSheet` to the new `Sheet` component while having Android showing at least the status bar.
Also, as requested by @kdowlin it reverts the change to just ask for backup if user has assets 

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<img width="300" alt="Screenshot" src=https://user-images.githubusercontent.com/20520102/146077608-f98fa1a1-45f8-4657-a4ee-73ce0c1dbf24.png> 

<img width="300" alt="Screenshot" src=https://user-images.githubusercontent.com/20520102/146078224-7bcb4692-2621-40cb-acaf-4fcbf07b0317.png> 

<img width="300" alt="Screenshot" src=https://user-images.githubusercontent.com/20520102/146078156-9a1845ba-bf42-4806-bbcc-e408d7c49dca.png> 
