### PR TITLE
[CS-2032] Show net earned amount in activities screen transaction listing for merchant revenue

### DIFF
--- a/cardstack/src/components/Transactions/Merchant/MerchantEarnedSpendAndRevenueTransaction.tsx
+++ b/cardstack/src/components/Transactions/Merchant/MerchantEarnedSpendAndRevenueTransaction.tsx
@@ -46,7 +46,7 @@ export const MerchantEarnedSpendAndRevenueTransaction = ({
           </Container>
           <Container flexDirection="row" alignItems="center">
             <Text size="xs" weight="extraBold" marginRight={2}>
-              {`+ ${item.balance.display}`}
+              {`+ ${item.netEarned.display}`}
             </Text>
             <CoinIcon
               address={item.token.address}

--- a/cardstack/src/hooks/transactions/use-merchant-transactions.tsx
+++ b/cardstack/src/hooks/transactions/use-merchant-transactions.tsx
@@ -6,7 +6,7 @@ import { useGetMerchantTransactionHistoryDataQuery } from '@cardstack/graphql';
 import { MerchantClaimStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-claim-strategy';
 import { MerchantWithdrawStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-withdraw-strategy';
 import { MerchantDepositStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-deposit-strategy';
-import { MerchantPrepaidCardIssuancetrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-prepaid-card-issuance-strategy';
+import { MerchantPrepaidCardIssuanceStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-prepaid-card-issuance-strategy';
 import { MerchantEarnedRevenueStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-revenue-strategy';
 import { MerchantEarnedSpendStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-strategy';
 import logger from 'logger';
@@ -24,7 +24,7 @@ const typeToStrategies: {
   unclaimedRevenue: [MerchantClaimStrategy, MerchantEarnedRevenueStrategy],
   availableBalances: [
     MerchantClaimStrategy,
-    MerchantPrepaidCardIssuancetrategy,
+    MerchantPrepaidCardIssuanceStrategy,
     MerchantWithdrawStrategy,
     MerchantDepositStrategy,
   ],

--- a/cardstack/src/transaction-mapping-strategies/context.ts
+++ b/cardstack/src/transaction-mapping-strategies/context.ts
@@ -13,7 +13,7 @@ import { MerchantEarnedRevenueStrategy } from './transaction-mapping-strategy-ty
 import { MerchantEarnedSpendAndRevenueStrategy } from './transaction-mapping-strategy-types/merchant-earned-spend-and-revenue-strategy';
 import { MerchantWithdrawStrategy } from './transaction-mapping-strategy-types/merchant-withdraw-strategy';
 import { MerchantDepositStrategy } from './transaction-mapping-strategy-types/merchant-deposit-strategy';
-import { MerchantPrepaidCardIssuancetrategy } from './transaction-mapping-strategy-types/merchant-prepaid-card-issuance-strategy';
+import { MerchantPrepaidCardIssuanceStrategy } from './transaction-mapping-strategy-types/merchant-prepaid-card-issuance-strategy';
 import { MerchantEarnedSpendStrategy } from './transaction-mapping-strategy-types/merchant-earned-spend-strategy';
 import { PrepaidCardCreationStrategy } from './transaction-mapping-strategy-types/prepaid-card-creation-strategy';
 import { PrepaidCardPaymentStrategy } from './transaction-mapping-strategy-types/prepaid-card-payment-strategy';
@@ -36,7 +36,7 @@ export type TransactionMappingStrategy =
   | typeof MerchantEarnedRevenueStrategy
   | typeof MerchantWithdrawStrategy
   | typeof MerchantDepositStrategy
-  | typeof MerchantPrepaidCardIssuancetrategy;
+  | typeof MerchantPrepaidCardIssuanceStrategy;
 
 interface TransactionData {
   transactions: (AdvancedTransactionFragment | undefined)[];

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/merchant-earned-spend-and-revenue-strategy.test.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/merchant-earned-spend-and-revenue-strategy.test.ts
@@ -1,0 +1,84 @@
+import { MerchantEarnedSpendAndRevenueStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-and-revenue-strategy';
+import { MERCHANT_EARNED_SPEND_MOCK_DATA } from '@cardstack/utils/__mocks__/merchant-strategies';
+
+const mockServices = jest.requireActual('../../../services');
+jest.mock('../../../services', () => ({
+  ...mockServices,
+  fetchHistoricalPrice: jest.fn().mockReturnValue(Promise.resolve(0)),
+  getNativeBalanceFromOracle: jest.fn().mockReturnValue(0.0000974),
+}));
+
+describe('MerchantEarnedSpendAndRevenueStrategy', () => {
+  const contructorParams = {
+    accountAddress: '0x64Fbf34FaC77696112F1Abaa69D28211214d76c7',
+    currencyConversionRates: {
+      AUD: 1.362445,
+      CAD: 1.262345,
+      CNY: 6.432498,
+      EUR: 0.846102,
+      GBP: 0.72197,
+      INR: 73.445498,
+      JPY: 109.350353,
+      KRW: 1166.819664,
+      NZD: 1.402265,
+      RUB: 72.280298,
+      TRY: 8.429594,
+      USD: 1,
+      ZAR: 14.41804,
+    },
+    depotAddress: '0xF48c7B663DFCa76E1954bC44f7Fc006e2e04b09C',
+    merchantSafeAddress: '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
+    merchantSafeAddresses: [
+      '0x51217e4769DFD61a42f8A509d4DCcC5683BFCB21',
+      '0xb891ad9b23826e61F010D5cd90d6a24Ea55010Bd',
+      '0x1D2BCdFb26319d1F5919aa66b105AE972946b9fE',
+      '0x6A4946bF21df59C58d4129802e0a37Ac649e6ae7',
+      '0x8de5D051565dF590A92f00a57B6d24609a17BC01',
+      '0x372582b0290cab3fcEb009A0F3869D50a00276D2',
+      '0x9Ed84407e5ed5B7c0323E5653A06F4528357e3B5',
+      '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
+    ],
+    nativeCurrency: 'USD',
+    prepaidCardAddresses: ['0x35Ae15dCEB6930756A59EfcC2169d2b834CdD371'],
+    transaction: MERCHANT_EARNED_SPEND_MOCK_DATA,
+  };
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const strategy = new MerchantEarnedSpendAndRevenueStrategy(contructorParams);
+
+  test('returns the proper object', async () => {
+    const value = await strategy.mapTransaction();
+    expect(value).toEqual({
+      address: '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
+      balance: {
+        amount: '1.497005988023952095',
+        display: '1.497 DAI',
+      },
+      infoDid: '3a13a41e-e44a-4b0f-b079-2d3d53571870',
+      native: {
+        amount: '0',
+        display: '$0.00 USD',
+      },
+      netEarned: {
+        amount: '1.489520958083832335',
+        display: '1.49 DAI',
+      },
+      nativeBalanceDisplay: '$1.50 USD',
+      spendBalanceDisplay: '§150 SPEND',
+      timestamp: 1629156261,
+      token: {
+        address: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+        name: 'Dai Stablecoin.CPXD',
+        symbol: 'DAI',
+      },
+      transactionHash:
+        '0x5293d95a240c231852724fd31ff6df119e5b5cf7661a7aec38f7cf10893dc2eb',
+      type: 'merchantEarnedSpendAndRevenue',
+    });
+  });
+
+  test('returns true with proper constructors', () => {
+    expect(strategy.handlesTransaction()).toBeTruthy();
+  });
+});

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/merchant-earned-spend-and-revenue-strategy.test.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/merchant-earned-spend-and-revenue-strategy.test.ts
@@ -47,7 +47,7 @@ describe('MerchantEarnedSpendAndRevenueStrategy', () => {
   // @ts-ignore
   const strategy = new MerchantEarnedSpendAndRevenueStrategy(contructorParams);
 
-  test('returns the proper object', async () => {
+  it('returns the proper object', async () => {
     const value = await strategy.mapTransaction();
     expect(value).toEqual({
       address: '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
@@ -78,7 +78,7 @@ describe('MerchantEarnedSpendAndRevenueStrategy', () => {
     });
   });
 
-  test('returns true with proper constructors', () => {
+  it('returns true with proper constructors', () => {
     expect(strategy.handlesTransaction()).toBeTruthy();
   });
 });

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/merchant-earned-spend-strategy.test.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/merchant-earned-spend-strategy.test.ts
@@ -40,7 +40,7 @@ describe('MerchantEarnedSpendStrategy', () => {
   // @ts-ignore
   const strategy = new MerchantEarnedSpendStrategy(contructorParams);
 
-  test('returns the proper object', async () => {
+  it('returns the proper object', async () => {
     const value = await strategy.mapTransaction();
     expect(value).toEqual({
       address: '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
@@ -54,7 +54,7 @@ describe('MerchantEarnedSpendStrategy', () => {
     });
   });
 
-  test('returns true with proper constructors', () => {
+  it('returns true with proper constructors', () => {
     expect(strategy.handlesTransaction()).toBeTruthy();
   });
 });

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/merchant-earned-spend-strategy.test.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/merchant-earned-spend-strategy.test.ts
@@ -1,23 +1,6 @@
 import { MerchantEarnedSpendStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-strategy';
 import { MERCHANT_EARNED_SPEND_MOCK_DATA } from '@cardstack/utils/__mocks__/merchant-strategies';
 
-jest.mock('../../../utils', () => ({ deviceUtils: { isIOS14: false } }));
-
-jest.mock('@rainbow-me/references', () => ({
-  shitcoins: 'JSON-MOCK-RETURN',
-}));
-
-const result = {
-  address: '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
-  infoDid: '3a13a41e-e44a-4b0f-b079-2d3d53571870',
-  nativeBalanceDisplay: '$1.50 USD',
-  spendBalanceDisplay: '§150 SPEND',
-  timestamp: '1629156260',
-  transactionHash:
-    '0x5293d95a240c231852724fd31ff6df119e5b5cf7661a7aec38f7cf10893dc2eb',
-  type: 'merchantEarnedSpend',
-};
-
 describe('MerchantEarnedSpendStrategy', () => {
   const contructorParams = {
     accountAddress: '0x64Fbf34FaC77696112F1Abaa69D28211214d76c7',
@@ -55,15 +38,23 @@ describe('MerchantEarnedSpendStrategy', () => {
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  const MerchantInstance = new MerchantEarnedSpendStrategy(contructorParams);
+  const strategy = new MerchantEarnedSpendStrategy(contructorParams);
 
   test('returns the proper object', async () => {
-    MerchantInstance.mapTransaction().then(value => {
-      expect(value).toBe(result);
+    const value = await strategy.mapTransaction();
+    expect(value).toEqual({
+      address: '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
+      infoDid: '3a13a41e-e44a-4b0f-b079-2d3d53571870',
+      nativeBalanceDisplay: '$1.50 USD',
+      spendBalanceDisplay: '§150 SPEND',
+      timestamp: '1629156260',
+      transactionHash:
+        '0x5293d95a240c231852724fd31ff6df119e5b5cf7661a7aec38f7cf10893dc2eb',
+      type: 'merchantEarnedSpend',
     });
   });
 
   test('returns true with proper constructors', () => {
-    expect(MerchantInstance.handlesTransaction()).toBeTruthy();
+    expect(strategy.handlesTransaction()).toBeTruthy();
   });
 });

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/prepaid-card-payment-strategy.test.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/prepaid-card-payment-strategy.test.ts
@@ -95,7 +95,7 @@ describe('PrepaidCardPaymentStrategy', () => {
   // @ts-ignore
   const PrepaidCardPayment = new PrepaidCardPaymentStrategy(contructorParams);
 
-  test('returns the proper object', async () => {
+  it('returns the proper object', async () => {
     PrepaidCardPayment.mapTransaction()
       .then(value => {
         expect(value).toEqual(result);
@@ -103,7 +103,7 @@ describe('PrepaidCardPaymentStrategy', () => {
       .catch(err => console.log('Error: ', err));
   });
 
-  test('returns the proper object without merchant info and card customization', async () => {
+  it('returns the proper object without merchant info and card customization', async () => {
     const newParams = {
       ...contructorParams,
       transaction: {
@@ -132,11 +132,11 @@ describe('PrepaidCardPaymentStrategy', () => {
       .catch(err => console.log('Error: ', err));
   });
 
-  test('returns true with proper constructors', () => {
+  it('returns true with proper constructors', () => {
     expect(PrepaidCardPayment.handlesTransaction()).toBeTruthy();
   });
 
-  test('returns false with empty prepaidCardPayments', () => {
+  it('returns false with empty prepaidCardPayments', () => {
     const newParams = {
       ...contructorParams,
       transaction: { prepaidCardPayments: [] },

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-prepaid-card-issuance-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-prepaid-card-issuance-strategy.ts
@@ -9,7 +9,7 @@ import {
 } from '@cardstack/types';
 import { fetchHistoricalPrice } from '@cardstack/services';
 
-export class MerchantPrepaidCardIssuancetrategy extends BaseStrategy {
+export class MerchantPrepaidCardIssuanceStrategy extends BaseStrategy {
   handlesTransaction(): boolean {
     const { prepaidCardIssuance } = this.transaction;
 

--- a/cardstack/src/types/transaction-types.ts
+++ b/cardstack/src/types/transaction-types.ts
@@ -168,8 +168,8 @@ export interface MerchantEarnedRevenueTransactionTypeTxn {
   protocolFee: string;
   revenueCollected: string;
   spendConversionRate: string;
-  netEarned: string;
-  netEarnedNative: string;
+  netEarned: BalanceType;
+  netEarnedNativeDisplay: string;
 }
 
 export interface MerchantEarnedRevenueTransactionType {
@@ -252,6 +252,7 @@ export interface MerchantEarnedSpendAndRevenueTransactionType {
   address: string;
   balance: BalanceType;
   native: BalanceType;
+  netEarned: BalanceType;
   token: {
     address: string;
     name?: string | null;

--- a/cardstack/src/utils/__tests__/merchant-utils.test.ts
+++ b/cardstack/src/utils/__tests__/merchant-utils.test.ts
@@ -100,8 +100,11 @@ describe('Merchant utils', () => {
         protocolFee: '0.0025 DAI',
         spendConversionRate: '$0.01 USD',
         revenueCollected: '0.499 DAI',
-        netEarned: '0.497 DAI',
-        netEarnedNative: '$0.0000974 USD',
+        netEarned: {
+          amount: '0.496506986027944111',
+          display: '0.497 DAI',
+        },
+        netEarnedNativeDisplay: '$0.0000974 USD',
       });
     });
   });

--- a/cardstack/src/utils/merchant-utils.ts
+++ b/cardstack/src/utils/merchant-utils.ts
@@ -221,7 +221,7 @@ export async function getMerchantEarnedTransactionDetails(
     nativeCurrency,
   });
 
-  const netFormattedValue = convertRawAmountToBalance(
+  const netEarned = convertRawAmountToBalance(
     subtract(prepaidCardPaymentTransaction.issuingTokenAmount, feeCollectedRaw),
     {
       decimals: 18,
@@ -249,8 +249,11 @@ export async function getMerchantEarnedTransactionDetails(
       nativeCurrency,
       currencyConversionRates
     ).nativeBalanceDisplay,
-    netEarned: netFormattedValue.display,
-    netEarnedNative: convertAmountToNativeDisplay(netValue, nativeCurrency),
+    netEarned,
+    netEarnedNativeDisplay: convertAmountToNativeDisplay(
+      netValue,
+      nativeCurrency
+    ),
   };
 }
 

--- a/src/components/expanded-state/MerchantTransactionExpandedState.tsx
+++ b/src/components/expanded-state/MerchantTransactionExpandedState.tsx
@@ -113,7 +113,7 @@ const EarnedTransaction = (data: EarnedTransactionProps) => {
     revenueCollected,
     spendConversionRate,
     netEarned,
-    netEarnedNative,
+    netEarnedNativeDisplay,
     txRowProps,
   } = data;
   const earnedItems = [
@@ -148,8 +148,8 @@ const EarnedTransaction = (data: EarnedTransactionProps) => {
         <HorizontalDivider />
         <ItemDetail
           description="NET EARNED"
-          subValue={netEarnedNative}
-          value={`+ ${netEarned}`}
+          subValue={netEarnedNativeDisplay}
+          value={`+ ${netEarned.display}`}
         />
       </Container>
     </>
@@ -197,13 +197,13 @@ export default function MerchantTransactionExpandedState(
   const network = useRainbowSelector(state => state.settings.network);
   const earnedTxnData = {
     ...transactionData,
-    subText: transactionData.netEarned,
+    subText: transactionData.netEarned.display,
   };
 
   const rowProps = {
     ...props.asset,
     primaryText: `+ ${transactionData.netEarned}`,
-    subText: transactionData.netEarnedNative,
+    subText: transactionData.netEarnedNativeDisplay,
   };
 
   return useMemo(


### PR DESCRIPTION
Before:

<img width="420" src="https://user-images.githubusercontent.com/353/147294098-516eadae-e285-41cb-9f92-5cef63b4315e.png">

After:

<img width="420" src="https://user-images.githubusercontent.com/353/147294121-ae77857b-9caa-4b56-b176-6c1562e187c2.png">

@topwebtek7 there is a breaking API change that may clash with your payment details work