### PR TITLE
Don't hide zero-balance prepaid cards

### DIFF
--- a/cardstack/src/services/gnosis-service.ts
+++ b/cardstack/src/services/gnosis-service.ts
@@ -46,7 +46,9 @@ export const fetchSafes = async (
   try {
     const safesInstance = await getSafesInstance();
 
-    const safes = (await safesInstance?.view(accountAddress))?.safes || [];
+    const safes =
+      (await safesInstance?.view(accountAddress, { viewAll: true }))?.safes ||
+      [];
 
     const safesWithTokenPrices = await Promise.all(
       safes?.map(safe => updateSafeWithTokenPrices(safe, nativeCurrency))
@@ -267,21 +269,18 @@ export const addNativePriceToToken = async (
 
   const isAmountDust = nativeBalance < 0.01;
 
-  //decimal places formatting for residual crypto values
-  const bufferValue = isAmountDust ? 0 : undefined;
   return {
     ...tokenInfo,
     balance: {
-      ...convertRawAmountToBalance(balance, { symbol, decimals }, bufferValue),
+      ...convertRawAmountToBalance(balance, { symbol, decimals }),
       wei: balance,
     },
     native: {
       balance: {
         amount: nativeBalance,
         display: convertAmountToNativeDisplay(
-          nativeBalance,
-          nativeCurrency,
-          bufferValue
+          isAmountDust ? 0 : nativeBalance,
+          nativeCurrency
         ),
       },
     },


### PR DESCRIPTION
### Description

Passes `viewAll: true` option to SDK when retrieving safes so that zero-balance prepaid cards are included in the results. Handling this without error required adjusting the balance formatting as well.
 
- [x] Completes #CS-1276

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/353/148475428-1c7c89a0-cf1a-443a-9b60-d3d260c5a2dc.png">
