### PR TITLE
[CS-2925] Fix Depot/EOA send screen UI breaks on Android

### DIFF
--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -28,7 +28,6 @@ import {
 import {
   bottomSheetPreset,
   expandedPreset,
-  sheetPreset,
 } from '@rainbow-me/navigation/effects';
 import { nativeStackModalConfig } from '@rainbow-me/navigation/config';
 import RainbowRoutes from '@rainbow-me/navigation/routesNames';
@@ -59,12 +58,12 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
   BUY_PREPAID_CARD: { component: BuyPrepaidCard },
   SEND_FLOW_DEPOT: {
     component: SendSheetDepot,
-    options: sheetPreset as StackNavigationOptions,
+    options: expandedPreset as StackNavigationOptions,
     listeners: dismissAndroidKeyboardOnClose,
   },
   SEND_FLOW_EOA: {
     component: SendSheetEOA,
-    options: sheetPreset as StackNavigationOptions,
+    options: expandedPreset as StackNavigationOptions,
     listeners: dismissAndroidKeyboardOnClose,
   },
   PAY_MERCHANT: {

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -28,6 +28,7 @@ import {
 import {
   bottomSheetPreset,
   expandedPreset,
+  sheetPreset,
 } from '@rainbow-me/navigation/effects';
 import { nativeStackModalConfig } from '@rainbow-me/navigation/config';
 import RainbowRoutes from '@rainbow-me/navigation/routesNames';
@@ -58,12 +59,12 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
   BUY_PREPAID_CARD: { component: BuyPrepaidCard },
   SEND_FLOW_DEPOT: {
     component: SendSheetDepot,
-    options: expandedPreset as StackNavigationOptions,
+    options: sheetPreset as StackNavigationOptions,
     listeners: dismissAndroidKeyboardOnClose,
   },
   SEND_FLOW_EOA: {
     component: SendSheetEOA,
-    options: expandedPreset as StackNavigationOptions,
+    options: sheetPreset as StackNavigationOptions,
     listeners: dismissAndroidKeyboardOnClose,
   },
   PAY_MERCHANT: {

--- a/src/components/fields/UnderlineField.js
+++ b/src/components/fields/UnderlineField.js
@@ -10,7 +10,7 @@ import React, {
 import { useTheme } from '../../context/ThemeContext';
 import ExchangeInput from '../exchange/ExchangeInput';
 import { Row } from '../layout';
-import { Button, Container } from '@cardstack/components';
+import { Button, Container, Text } from '@cardstack/components';
 import { useDimensions } from '@rainbow-me/hooks';
 
 const defaultFormatter = string => string;
@@ -30,6 +30,7 @@ const UnderlineField = (
     placeholder,
     testID,
     value: valueProp,
+    rightLabel,
     ...props
   },
   forwardedRef
@@ -116,11 +117,23 @@ const UnderlineField = (
           testID={testID + '-input'}
           value={formattedValue}
         />
-        {buttonText && isFocused && (
-          <Button onPress={handleButtonPress} variant="tiny">
-            {buttonText}
-          </Button>
-        )}
+        <Container flexDirection="row">
+          {buttonText && isFocused && (
+            <Button onPress={handleButtonPress} variant="tiny">
+              {buttonText}
+            </Button>
+          )}
+          {rightLabel && (
+            <Text
+              fontSize={17}
+              fontWeight="700"
+              lineHeight={24}
+              paddingLeft={2}
+            >
+              {rightLabel}
+            </Text>
+          )}
+        </Container>
       </Row>
       <Container
         border-radius={1}

--- a/src/components/fields/UnderlineField.js
+++ b/src/components/fields/UnderlineField.js
@@ -125,7 +125,7 @@ const UnderlineField = (
       <Container
         border-radius={1}
         flexDirection="row"
-        height={isFocused ? 2 : 1}
+        height={2}
         overflow="hidden"
         width="100%"
       >

--- a/src/components/send/SendAssetForm.js
+++ b/src/components/send/SendAssetForm.js
@@ -1,7 +1,4 @@
-import React, { Fragment } from 'react';
-import { KeyboardArea } from 'react-native-keyboard-area';
-import styled from 'styled-components';
-
+import React from 'react';
 import AssetTypes from '../../helpers/assetTypes';
 import { useAsset } from '../../hooks';
 import { SendCoinRow } from '../coin-row';
@@ -11,10 +8,6 @@ import { Icon } from '../icons';
 import SendAssetFormCollectible from './SendAssetFormCollectible';
 import SendAssetFormToken from './SendAssetFormToken';
 import { CenteredContainer, Container } from '@cardstack/components';
-
-const KeyboardSizeView = styled(KeyboardArea)`
-  background-color: ${({ theme: { colors } }) => colors.white};
-`;
 
 export default function SendAssetForm({
   assetAmount,
@@ -76,22 +69,19 @@ export default function SendAssetForm({
             txSpeedRenderer={txSpeedRenderer}
           />
         ) : (
-          <Fragment>
-            <SendAssetFormToken
-              {...props}
-              assetAmount={assetAmount}
-              buttonRenderer={buttonRenderer}
-              nativeAmount={nativeAmount}
-              nativeCurrency={nativeCurrency}
-              onChangeAssetAmount={onChangeAssetAmount}
-              onChangeNativeAmount={onChangeNativeAmount}
-              onFocus={onFocus}
-              selected={selectedAsset}
-              sendMaxBalance={sendMaxBalance}
-              txSpeedRenderer={txSpeedRenderer}
-            />
-            {ios ? <KeyboardSizeView isOpen /> : null}
-          </Fragment>
+          <SendAssetFormToken
+            {...props}
+            assetAmount={assetAmount}
+            buttonRenderer={buttonRenderer}
+            nativeAmount={nativeAmount}
+            nativeCurrency={nativeCurrency}
+            onChangeAssetAmount={onChangeAssetAmount}
+            onChangeNativeAmount={onChangeNativeAmount}
+            onFocus={onFocus}
+            selected={selectedAsset}
+            sendMaxBalance={sendMaxBalance}
+            txSpeedRenderer={txSpeedRenderer}
+          />
         )}
       </Container>
     </Container>

--- a/src/components/send/SendAssetFormField.js
+++ b/src/components/send/SendAssetFormField.js
@@ -1,10 +1,8 @@
 import React, { useCallback } from 'react';
 
 import { UnderlineField } from '../fields';
-import { CenteredContainer, Text } from '@cardstack/components';
+import { Button, CenteredContainer, Text } from '@cardstack/components';
 
-// set currency label with fixed width to have same width inputs. 100 is good for longest currency label for now
-const CURRENCY_LABEL_WIDTH = 100;
 export default function SendAssetFormField({
   autoFocus,
   format,
@@ -19,6 +17,8 @@ export default function SendAssetFormField({
   testID,
   ...props
 }) {
+  const [isFocused, setIsFocused] = useState(autoFocus);
+
   const handlePressButton = useCallback(
     event => {
       onPressButton?.(event);
@@ -26,24 +26,41 @@ export default function SendAssetFormField({
     [onPressButton]
   );
 
+  const handleBlur = useCallback(() => {
+    setIsFocused(false);
+  }, []);
+
+  const handleFocus = useCallback(
+    event => {
+      setIsFocused(true);
+      onFocus?.(event);
+    },
+    [onFocus]
+  );
+
   return (
-    <CenteredContainer flexDirection="row" {...props}>
+    <CenteredContainer {...props} flexDirection="row">
       <UnderlineField
         autoFocus={autoFocus}
-        buttonText="Max"
+        flex={1}
         flexGrow={1}
         format={format}
         keyboardType="decimal-pad"
         mask={mask}
+        onBlur={handleBlur}
         onChange={onChange}
-        onFocus={onFocus}
-        onPressButton={handlePressButton}
+        onFocus={handleFocus}
         placeholder={placeholder}
         testID={testID}
         value={value}
       />
-      <CenteredContainer width={CURRENCY_LABEL_WIDTH}>
-        <Text fontSize={20} fontWeight="700">
+      <CenteredContainer flexDirection="row" position="absolute" right={0}>
+        {isFocused && (
+          <Button onPress={handlePressButton} variant="tiny">
+            Max
+          </Button>
+        )}
+        <Text fontSize={20} fontWeight="700" lineHeight={24} paddingLeft={2}>
           {label?.length > labelMaxLength
             ? label.substring(0, labelMaxLength)
             : label}

--- a/src/components/send/SendAssetFormField.js
+++ b/src/components/send/SendAssetFormField.js
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react';
 
 import { UnderlineField } from '../fields';
-import { RowWithMargins } from '../layout';
-import { Text } from '@cardstack/components';
+import { CenteredContainer, Text } from '@cardstack/components';
 
+const CURRENCY_LABEL_WIDTH = 100;
 export default function SendAssetFormField({
   autoFocus,
   format,
@@ -16,7 +16,6 @@ export default function SendAssetFormField({
   placeholder,
   value,
   testID,
-  ...props
 }) {
   const handlePressButton = useCallback(
     event => {
@@ -26,16 +25,11 @@ export default function SendAssetFormField({
   );
 
   return (
-    <RowWithMargins
-      align="center"
-      flex={1}
-      justify="space-between"
-      margin={23}
-      {...props}
-    >
+    <CenteredContainer flexDirection="row">
       <UnderlineField
         autoFocus={autoFocus}
         buttonText="Max"
+        flexGrow={1}
         format={format}
         keyboardType="decimal-pad"
         mask={mask}
@@ -46,16 +40,13 @@ export default function SendAssetFormField({
         testID={testID}
         value={value}
       />
-      <Text
-        fontSize={20}
-        fontWeight="700"
-        position="absolute"
-        textAlign="right"
-      >
-        {label?.length > labelMaxLength
-          ? label.substring(0, labelMaxLength)
-          : label}
-      </Text>
-    </RowWithMargins>
+      <CenteredContainer width={CURRENCY_LABEL_WIDTH}>
+        <Text fontSize={20} fontWeight="700">
+          {label?.length > labelMaxLength
+            ? label.substring(0, labelMaxLength)
+            : label}
+        </Text>
+      </CenteredContainer>
+    </CenteredContainer>
   );
 }

--- a/src/components/send/SendAssetFormField.js
+++ b/src/components/send/SendAssetFormField.js
@@ -3,6 +3,7 @@ import React, { useCallback } from 'react';
 import { UnderlineField } from '../fields';
 import { CenteredContainer, Text } from '@cardstack/components';
 
+// set currency label with fixed width to have same width inputs. 100 is good for longest currency label for now
 const CURRENCY_LABEL_WIDTH = 100;
 export default function SendAssetFormField({
   autoFocus,
@@ -16,6 +17,7 @@ export default function SendAssetFormField({
   placeholder,
   value,
   testID,
+  ...props
 }) {
   const handlePressButton = useCallback(
     event => {
@@ -25,7 +27,7 @@ export default function SendAssetFormField({
   );
 
   return (
-    <CenteredContainer flexDirection="row">
+    <CenteredContainer flexDirection="row" {...props}>
       <UnderlineField
         autoFocus={autoFocus}
         buttonText="Max"

--- a/src/components/send/SendAssetFormField.js
+++ b/src/components/send/SendAssetFormField.js
@@ -1,71 +1,41 @@
-import React, { useCallback } from 'react';
-
+import React from 'react';
 import { UnderlineField } from '../fields';
-import { Button, CenteredContainer, Text } from '@cardstack/components';
+import { CenteredContainer } from '@cardstack/components';
 
-export default function SendAssetFormField({
+const SendAssetFormField = ({
   autoFocus,
   format,
   label,
   labelMaxLength = 9,
   mask,
   onChange,
-  onFocus,
   onPressButton,
   placeholder,
   value,
   testID,
   ...props
-}) {
-  const [isFocused, setIsFocused] = useState(autoFocus);
+}) => (
+  <CenteredContainer {...props} flexDirection="row">
+    <UnderlineField
+      autoFocus={autoFocus}
+      buttonText="Max"
+      flex={1}
+      flexGrow={1}
+      format={format}
+      keyboardType="decimal-pad"
+      mask={mask}
+      onChange={onChange}
+      onPressButton={onPressButton}
+      placeholder={placeholder}
+      rightLabel={
+        label?.length > labelMaxLength
+          ? label.substring(0, labelMaxLength)
+          : label
+      }
+      testID={testID}
+      value={value}
+    />
+  </CenteredContainer>
+);
 
-  const handlePressButton = useCallback(
-    event => {
-      onPressButton?.(event);
-    },
-    [onPressButton]
-  );
-
-  const handleBlur = useCallback(() => {
-    setIsFocused(false);
-  }, []);
-
-  const handleFocus = useCallback(
-    event => {
-      setIsFocused(true);
-      onFocus?.(event);
-    },
-    [onFocus]
-  );
-
-  return (
-    <CenteredContainer {...props} flexDirection="row">
-      <UnderlineField
-        autoFocus={autoFocus}
-        flex={1}
-        flexGrow={1}
-        format={format}
-        keyboardType="decimal-pad"
-        mask={mask}
-        onBlur={handleBlur}
-        onChange={onChange}
-        onFocus={handleFocus}
-        placeholder={placeholder}
-        testID={testID}
-        value={value}
-      />
-      <CenteredContainer flexDirection="row" position="absolute" right={0}>
-        {isFocused && (
-          <Button onPress={handlePressButton} variant="tiny">
-            Max
-          </Button>
-        )}
-        <Text fontSize={20} fontWeight="700" lineHeight={24} paddingLeft={2}>
-          {label?.length > labelMaxLength
-            ? label.substring(0, labelMaxLength)
-            : label}
-        </Text>
-      </CenteredContainer>
-    </CenteredContainer>
-  );
-}
+export default SendAssetFormField;

--- a/src/components/send/SendAssetFormToken.js
+++ b/src/components/send/SendAssetFormToken.js
@@ -1,25 +1,8 @@
 import { nativeCurrencies } from '@cardstack/cardpay-sdk';
 import React, { Fragment } from 'react';
-import styled from 'styled-components';
-import { Column, ColumnWithMargins } from '../layout';
 import SendAssetFormField from './SendAssetFormField';
-import { useDimensions } from '@rainbow-me/hooks';
+import { Container } from '@cardstack/components';
 import { removeLeadingZeros } from '@rainbow-me/utils';
-
-const footerMargin = 31;
-const FooterContainer = styled(ColumnWithMargins).attrs(({ deviceHeight }) => ({
-  justify: 'end',
-  margin: deviceHeight > 812 ? footerMargin : footerMargin / 2,
-}))`
-  flex: 1;
-  width: 100%;
-  z-index: 3;
-`;
-
-const FormContainer = styled(Column)`
-  flex: ${({ isSmallPhone }) => (android ? 1.8 : isSmallPhone ? 1.75 : 1)};
-  width: 100%;
-`;
 
 export default function SendAssetFormToken({
   assetAmount,
@@ -33,45 +16,40 @@ export default function SendAssetFormToken({
   sendMaxBalance,
   txSpeedRenderer,
   showNativeCurrencyField = true,
-  ...props
 }) {
-  const { isSmallPhone, height: deviceHeight } = useDimensions();
-
   const { mask: nativeMask, placeholder: nativePlaceholder } = nativeCurrencies[
     nativeCurrency
   ];
 
   return (
-    <Fragment>
-      <FormContainer isSmallPhone={isSmallPhone} {...props}>
+    <>
+      <SendAssetFormField
+        format={removeLeadingZeros}
+        label={selected.symbol}
+        onChange={onChangeAssetAmount}
+        onFocus={onFocus}
+        onPressButton={sendMaxBalance}
+        placeholder="0"
+        testID="selected-asset-field"
+        value={assetAmount}
+      />
+      {showNativeCurrencyField && (
         <SendAssetFormField
-          format={removeLeadingZeros}
-          label={selected.symbol}
-          onChange={onChangeAssetAmount}
+          autoFocus
+          label={nativeCurrency}
+          mask={nativeMask}
+          onChange={onChangeNativeAmount}
           onFocus={onFocus}
           onPressButton={sendMaxBalance}
-          placeholder="0"
-          testID="selected-asset-field"
-          value={assetAmount}
+          placeholder={nativePlaceholder}
+          testID="selected-asset-quantity-field"
+          value={nativeAmount}
         />
-        {showNativeCurrencyField && (
-          <SendAssetFormField
-            autoFocus
-            label={nativeCurrency}
-            mask={nativeMask}
-            onChange={onChangeNativeAmount}
-            onFocus={onFocus}
-            onPressButton={sendMaxBalance}
-            placeholder={nativePlaceholder}
-            testID="selected-asset-quantity-field"
-            value={nativeAmount}
-          />
-        )}
-      </FormContainer>
-      <FooterContainer deviceHeight={deviceHeight}>
+      )}
+      <Container marginTop={12}>
         {buttonRenderer}
         {txSpeedRenderer}
-      </FooterContainer>
-    </Fragment>
+      </Container>
+    </>
   );
 }

--- a/src/components/send/SendAssetFormToken.js
+++ b/src/components/send/SendAssetFormToken.js
@@ -47,7 +47,7 @@ export default function SendAssetFormToken({
           value={nativeAmount}
         />
       )}
-      <Container marginTop={12}>
+      <Container marginTop={10}>
         {buttonRenderer}
         {txSpeedRenderer}
       </Container>

--- a/src/components/send/SendAssetFormToken.js
+++ b/src/components/send/SendAssetFormToken.js
@@ -37,6 +37,7 @@ export default function SendAssetFormToken({
         <SendAssetFormField
           autoFocus
           label={nativeCurrency}
+          marginTop={5}
           mask={nativeMask}
           onChange={onChangeNativeAmount}
           onFocus={onFocus}

--- a/src/components/send/SendAssetFormToken.js
+++ b/src/components/send/SendAssetFormToken.js
@@ -26,6 +26,7 @@ export default function SendAssetFormToken({
       <SendAssetFormField
         format={removeLeadingZeros}
         label={selected.symbol}
+        marginTop={5}
         onChange={onChangeAssetAmount}
         onFocus={onFocus}
         onPressButton={sendMaxBalance}
@@ -37,7 +38,7 @@ export default function SendAssetFormToken({
         <SendAssetFormField
           autoFocus
           label={nativeCurrency}
-          marginTop={5}
+          marginTop={10}
           mask={nativeMask}
           onChange={onChangeNativeAmount}
           onFocus={onFocus}
@@ -47,7 +48,7 @@ export default function SendAssetFormToken({
           value={nativeAmount}
         />
       )}
-      <Container marginTop={10}>
+      <Container marginTop={5}>
         {buttonRenderer}
         {txSpeedRenderer}
       </Container>

--- a/src/components/send/SendHeader.js
+++ b/src/components/send/SendHeader.js
@@ -6,9 +6,7 @@ import { useNavigation } from '../../navigation/Navigation';
 import Divider from '../Divider';
 import { AddContactButton, PasteAddressButton } from '../buttons';
 import { AddressField } from '../fields';
-import { Icon } from '../icons';
 import { Row } from '../layout';
-import { SheetHandle as SheetHandleAndroid } from '../sheet';
 import { Text } from '@cardstack/components';
 import { useClipboard, useDimensions } from '@rainbow-me/hooks';
 import Routes from '@rainbow-me/routes';
@@ -21,19 +19,6 @@ const AddressInputContainer = styled(Row).attrs({ align: 'center' })`
   overflow: hidden;
   width: 100%;
 `;
-
-const SheetHandle = android
-  ? styled(SheetHandleAndroid)`
-      margin-top: 6;
-    `
-  : styled(Icon).attrs(({ theme: { colors } }) => ({
-      color: colors.sendScreen.grey,
-      name: 'handle',
-      testID: 'sheet-handle',
-    }))`
-      height: 11;
-      margin-top: 13;
-    `;
 
 const DefaultContactItem = {
   address: '',
@@ -125,7 +110,6 @@ export default function SendHeader({
 
   return (
     <Fragment>
-      <SheetHandle />
       <AddressInputContainer isSmallPhone={isSmallPhone}>
         <Text fontSize={15} fontWeight="600" marginRight={2}>
           To:

--- a/src/components/send/SendSheet.js
+++ b/src/components/send/SendSheet.js
@@ -1,11 +1,7 @@
 import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useState } from 'react';
 import { StatusBar } from 'react-native';
-import { getStatusBarHeight } from 'react-native-iphone-x-helper';
-import { KeyboardArea } from 'react-native-keyboard-area';
-import styled from 'styled-components';
 import { checkIsValidAddressOrDomain } from '../../helpers/validators';
-import { Column } from '../layout';
 import {
   SendAssetForm,
   SendAssetList,
@@ -14,40 +10,12 @@ import {
   SendHeader,
   SendTransactionSpeed,
 } from '.';
-import { Device } from '@cardstack/utils';
+import { Sheet } from '@cardstack/components';
 import {
   useAccountSettings,
   useContacts,
   useDimensions,
 } from '@rainbow-me/hooks';
-import { borders } from '@rainbow-me/styles';
-import { deviceUtils } from '@rainbow-me/utils';
-
-const sheetHeight = deviceUtils.dimensions.height - (android ? 30 : 10);
-const statusBarHeight = getStatusBarHeight(true);
-
-const Container = styled.View`
-  background-color: ${({ theme: { colors } }) => colors.transparent};
-  flex: 1;
-  padding-top: ${statusBarHeight};
-  width: 100%;
-`;
-
-const SheetContainer = styled(Column).attrs({
-  align: 'center',
-  flex: 1,
-})`
-  ${borders.buildRadius('top', 16)};
-  background-color: ${({ theme: { colors } }) => colors.white};
-  height: ${Device.isAndroid ? sheetHeight : '100%'};
-  width: 100%;
-`;
-
-const KeyboardSizeView = styled(KeyboardArea)`
-  width: 100%;
-  background-color: ${({ showAssetForm, theme: { colors } }) =>
-    showAssetForm ? colors.lighterGrey : colors.white};
-`;
 
 export const useShowAssetFlags = (isValidAddress, selected) => ({
   showAssetList: isValidAddress && isEmpty(selected),
@@ -119,79 +87,74 @@ export default function SendSheet({
   );
 
   return (
-    <Container>
+    <Sheet isFullScreen>
       {ios && <StatusBar barStyle="light-content" />}
-      <SheetContainer>
-        <SendHeader
-          contacts={contacts}
-          isValidAddress={isValidAddress}
-          onChangeAddressInput={onChangeInput}
-          onFocus={handleFocus}
-          onPressPaste={setRecipient}
-          onRefocusInput={triggerFocus}
-          recipient={recipient}
-          recipientFieldRef={recipientFieldRef}
+      <SendHeader
+        contacts={contacts}
+        isValidAddress={isValidAddress}
+        onChangeAddressInput={onChangeInput}
+        onFocus={handleFocus}
+        onPressPaste={setRecipient}
+        onRefocusInput={triggerFocus}
+        recipient={recipient}
+        recipientFieldRef={recipientFieldRef}
+        removeContact={onRemoveContact}
+        showAssetList={showAssetList}
+      />
+      {showEmptyState && (
+        <SendContactList
+          contacts={filteredContacts}
+          currentInput={currentInput}
+          onPressContact={setRecipient}
           removeContact={onRemoveContact}
-          showAssetList={showAssetList}
         />
-        {showEmptyState && (
-          <SendContactList
-            contacts={filteredContacts}
-            currentInput={currentInput}
-            onPressContact={setRecipient}
-            removeContact={onRemoveContact}
-          />
-        )}
-        {showAssetList && (
-          <SendAssetList
-            allAssets={allAssets}
-            collectibles={sendableCollectibles}
-            fetchData={fetchData}
-            hiddenCoins={hiddenCoins}
-            nativeCurrency={nativeCurrency}
-            network={network}
-            onSelectAsset={onSelectAsset}
-            pinnedCoins={pinnedCoins}
-            savings={savings}
-          />
-        )}
-        {showAssetForm && (
-          <SendAssetForm
-            allAssets={allAssets}
-            assetAmount={amountDetails.assetAmount}
-            buttonRenderer={
-              <SendButton
-                assetAmount={amountDetails.assetAmount}
-                isAuthorizing={isAuthorizing}
-                isSufficientBalance={amountDetails.isSufficientBalance}
-                isSufficientGas={isSufficientGas}
-                onPress={onSendPress}
-                smallButton={isTinyPhone}
-                testID="send-sheet-confirm"
-              />
-            }
-            nativeAmount={amountDetails.nativeAmount}
-            nativeCurrency={nativeCurrency}
-            onChangeAssetAmount={onChangeAssetAmount}
-            onChangeNativeAmount={onChangeNativeAmount}
-            onFocus={handleFocus}
-            onResetAssetSelection={onResetAssetSelection}
-            selected={selected}
-            sendMaxBalance={onMaxBalancePress}
-            showNativeCurrencyField={showNativeCurrencyField}
-            txSpeedRenderer={
-              <SendTransactionSpeed
-                gasPrice={selectedGasPrice}
-                nativeCurrencySymbol={nativeCurrencySymbol}
-                onPressTransactionSpeed={onPressTransactionSpeed}
-              />
-            }
-          />
-        )}
-        {android && showAssetForm ? (
-          <KeyboardSizeView showAssetForm={showAssetForm} />
-        ) : null}
-      </SheetContainer>
-    </Container>
+      )}
+      {showAssetList && (
+        <SendAssetList
+          allAssets={allAssets}
+          collectibles={sendableCollectibles}
+          fetchData={fetchData}
+          hiddenCoins={hiddenCoins}
+          nativeCurrency={nativeCurrency}
+          network={network}
+          onSelectAsset={onSelectAsset}
+          pinnedCoins={pinnedCoins}
+          savings={savings}
+        />
+      )}
+      {showAssetForm && (
+        <SendAssetForm
+          allAssets={allAssets}
+          assetAmount={amountDetails.assetAmount}
+          buttonRenderer={
+            <SendButton
+              assetAmount={amountDetails.assetAmount}
+              isAuthorizing={isAuthorizing}
+              isSufficientBalance={amountDetails.isSufficientBalance}
+              isSufficientGas={isSufficientGas}
+              onPress={onSendPress}
+              smallButton={isTinyPhone}
+              testID="send-sheet-confirm"
+            />
+          }
+          nativeAmount={amountDetails.nativeAmount}
+          nativeCurrency={nativeCurrency}
+          onChangeAssetAmount={onChangeAssetAmount}
+          onChangeNativeAmount={onChangeNativeAmount}
+          onFocus={handleFocus}
+          onResetAssetSelection={onResetAssetSelection}
+          selected={selected}
+          sendMaxBalance={onMaxBalancePress}
+          showNativeCurrencyField={showNativeCurrencyField}
+          txSpeedRenderer={
+            <SendTransactionSpeed
+              gasPrice={selectedGasPrice}
+              nativeCurrencySymbol={nativeCurrencySymbol}
+              onPressTransactionSpeed={onPressTransactionSpeed}
+            />
+          }
+        />
+      )}
+    </Sheet>
   );
 }

--- a/src/components/send/SendTransactionSpeed.js
+++ b/src/components/send/SendTransactionSpeed.js
@@ -27,7 +27,7 @@ export default function SendTransactionSpeed({
   const time = isGasNumber ? '' : get(gasPrice, 'estimatedTime.display', '');
 
   return (
-    <Row justify="center">
+    <Row justify="center" marginTop={2}>
       <Touchable
         disabled={!onPressTransactionSpeed}
         flexDirection="row"


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

SendSheet had an issue with Android keyboard open state handling, so refactored using Sheet component and also updated UI to be keep same when keyboard state changes.
<!-- Include a summary of the changes. -->

- [x] Completes #CS-2925

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->
![Jan-12-2022 17-00-03](https://user-images.githubusercontent.com/16714648/149096655-24ed3f56-3bae-4157-a47d-be1607ba3af6.gif)


<img width="336" alt="Screen Shot 2022-01-12 at 4 52 17 PM" src="https://user-images.githubusercontent.com/16714648/149095098-0a4dac63-679f-4c78-a9c7-621f9a360f7b.png">
<img width="343" alt="Screen Shot 2022-01-12 at 4 51 49 PM" src="https://user-images.githubusercontent.com/16714648/149095115-8285aab6-8bae-4ff9-84ad-52fe252395f3.png">

<img width="400" alt="Screen Shot 2022-01-12 at 4 52 06 PM" src="https://user-images.githubusercontent.com/16714648/149095140-e5778758-9f9d-4413-9106-8d7799203d14.png">


