### PR TITLE
[CS-2930]: Crash on BuyPrepaidCard

### DIFF
--- a/cardstack/src/hooks/prepaid-card/useBuyPrepaidCard.ts
+++ b/cardstack/src/hooks/prepaid-card/useBuyPrepaidCard.ts
@@ -99,6 +99,8 @@ export default function useBuyPrepaidCard() {
     WyrePriceData[] | undefined
   >();
 
+  const [isPurchaseInProgress, setIsPurchaseInProgress] = useState(false);
+
   const [
     custodialWalletData,
     setCustodialWalletData,
@@ -403,6 +405,8 @@ export default function useBuyPrepaidCard() {
 
   /* eslint-disable react-hooks/exhaustive-deps */
   const handlePurchase = useCallback(async () => {
+    setIsPurchaseInProgress(true);
+
     const amount =
       (card?.['source-currency-price'] || 0) *
       currencyConversionRates[nativeCurrency];
@@ -477,6 +481,8 @@ export default function useBuyPrepaidCard() {
         message: `Purchase not completed \nReservation Id: ${reservation?.id}`,
       });
     }
+
+    setIsPurchaseInProgress(false);
   }, [
     card,
     nativeCurrency,
@@ -496,6 +502,7 @@ export default function useBuyPrepaidCard() {
     card,
     setCard,
     handlePurchase,
+    isPurchaseInProgress,
     setIsInventoryLoading,
     isInventoryLoading,
     inventoryData,

--- a/cardstack/src/screens/BuyPrepaidCard/BuyPrepaidCard.tsx
+++ b/cardstack/src/screens/BuyPrepaidCard/BuyPrepaidCard.tsx
@@ -35,6 +35,7 @@ const BuyPrepaidCard = () => {
     onSelectCard,
     card,
     handlePurchase,
+    isPurchaseInProgress,
     isInventoryLoading,
     inventoryData,
     network,
@@ -96,7 +97,7 @@ const BuyPrepaidCard = () => {
           >
             {isDisabled ? null : (
               <ApplePayButton
-                disabled={isDisabled}
+                disabled={isPurchaseInProgress}
                 onSubmit={handlePurchase}
                 onDisabledPress={() => console.log('onDisablePress')}
               />


### PR DESCRIPTION
### Description

Crash is happening because Apple purchase button could be tapped multiple times before action completed.
This PR adds a Purchase In Progress state for useBuyPrepaidCard hook so the UI can respond properly and avoid repeated requests to open PKPaymentAuthorizationViewController.

Fixes Sentry issue [CARDWALLET-MOBILE-5F](https://sentry.io/organizations/cardstack/issues/2925602334/?project=5868654&query=is%3Aunresolved)

- [x] Completes #(CS-2930)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->
