### PR TITLE
[CS-2940]: fix auto select single prepaid card

### DIFF
--- a/cardstack/src/screens/PayMerchant/usePayMerchant.ts
+++ b/cardstack/src/screens/PayMerchant/usePayMerchant.ts
@@ -238,14 +238,16 @@ export const usePayMerchant = () => {
 
   // Updating in case first render selected is undefined
   useEffect(() => {
-    if (
-      !selectedPrepaidCard?.address &&
-      hasMultipleCards &&
-      (sortedPrepaidCards[0]?.spendFaceValue || 0) > spendAmount
-    ) {
-      selectPrepaidCard(sortedPrepaidCards[0]);
+    const firstPrepaidCard = sortedPrepaidCards[0];
+    const noCardSelected = !selectedPrepaidCard?.address;
+
+    const firstCardHasEnoughBalance =
+      (firstPrepaidCard?.spendFaceValue || 0) > spendAmount;
+
+    if (noCardSelected && firstCardHasEnoughBalance) {
+      selectPrepaidCard(firstPrepaidCard);
     }
-  }, [hasMultipleCards, sortedPrepaidCards, selectedPrepaidCard, spendAmount]);
+  }, [sortedPrepaidCards, selectedPrepaidCard, spendAmount]);
 
   useEffect(() => {
     // Go to choose prepaid card step if have multiple prepaid cards and has amount in deeplink


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

We don't need to check `hasMultipleCards` in other to auto select the first prepaid card, this introduced this bug, where if we have a single prepaid card nothing is selected and we get a not enough balance error even though we have balance. This PR removes this check, and adds meaningful variables for better readability.
 
<!-- Include a summary of the changes. -->

- [x] Completes #(CS-2940)

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

gif is attached to [issue](https://linear.app/cardstack/issue/CS-2940/[request-payment]-user-is-unable-to-pay-if-theres-only-one-pre-paid-on), bc file was too big for github.


