### PR TITLE
[CS-2616] Add in-app notification handling for merchant payment received

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -264,6 +264,8 @@ dependencies {
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation 'io.github.novacrypto:BIP39:2019.01.27'
     implementation 'com.google.android.play:core:1.8.2'
+    implementation 'com.google.firebase:firebase-inappmessaging-display:17.2.0'
+    implementation 'com.google.guava:guava:31.0.1-jre'
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.fbjni'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,9 @@ allprojects {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
-
         maven { url 'https://www.jitpack.io' }
+        maven {
+            url "$rootDir/../node_modules/@notifee/react-native/android/libs"
+        }
     }
 }

--- a/cardstack/src/components/Transactions/Merchant/MerchantEarnedSpendAndRevenueTransaction.tsx
+++ b/cardstack/src/components/Transactions/Merchant/MerchantEarnedSpendAndRevenueTransaction.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import { useNavigation } from '@react-navigation/core';
+import { nativeCurrencies } from '@cardstack/cardpay-sdk';
 import { Icon } from '../../Icon';
 import {
   TransactionBase,
@@ -15,6 +16,32 @@ export interface MerchantEarnSpendAndRevenueTransactionProps
   extends TransactionBaseCustomizationProps {
   item: MerchantEarnedSpendAndRevenueTransactionType;
 }
+
+export const MerchantEarnedSpendAndRevenueTransactionFooter = ({
+  token,
+  netEarnedDisplayValue,
+}: {
+  token: { address: string; symbol?: string | null };
+  netEarnedDisplayValue: string;
+}) => (
+  <Container
+    paddingHorizontal={5}
+    flexDirection="row"
+    justifyContent="space-between"
+  >
+    <Container maxWidth={100}>
+      <Text variant="subText" marginBottom={1}>
+        Added to revenue pool
+      </Text>
+    </Container>
+    <Container flexDirection="row" alignItems="center">
+      <Text size="xs" weight="extraBold" marginRight={2}>
+        {`+ ${netEarnedDisplayValue}`}
+      </Text>
+      <CoinIcon address={token.address} symbol={token.symbol} size={20} />
+    </Container>
+  </Container>
+);
 
 export const MerchantEarnedSpendAndRevenueTransaction = ({
   item,
@@ -45,29 +72,12 @@ export const MerchantEarnedSpendAndRevenueTransaction = ({
         />
       }
       Footer={
-        <Container
-          paddingHorizontal={5}
-          flexDirection="row"
-          justifyContent="space-between"
-        >
-          <Container maxWidth={100}>
-            <Text variant="subText" marginBottom={1}>
-              Added to revenue pool
-            </Text>
-          </Container>
-          <Container flexDirection="row" alignItems="center">
-            <Text size="xs" weight="extraBold" marginRight={2}>
-              {`+ ${item.netEarned.display}`}
-            </Text>
-            <CoinIcon
-              address={item.token.address}
-              symbol={item.token.symbol}
-              size={20}
-            />
-          </Container>
-        </Container>
+        <MerchantEarnedSpendAndRevenueTransactionFooter
+          token={item.token}
+          netEarnedDisplayValue={item.netEarned.display}
+        />
       }
-      primaryText={`+ ${item.spendBalanceDisplay} SPEND`}
+      primaryText={`+ ${item.spendBalanceDisplay} ${nativeCurrencies.SPD.currency}`}
       statusIconName="arrow-down"
       statusText="Received"
       subText={item.nativeBalanceDisplay}

--- a/cardstack/src/components/Transactions/Merchant/MerchantEarnedSpendAndRevenueTransaction.tsx
+++ b/cardstack/src/components/Transactions/Merchant/MerchantEarnedSpendAndRevenueTransaction.tsx
@@ -17,13 +17,15 @@ export interface MerchantEarnSpendAndRevenueTransactionProps
   item: MerchantEarnedSpendAndRevenueTransactionType;
 }
 
+interface MerchantEarnedSpendAndRevenueTransactionFooter {
+  token: { address: string; symbol?: string | null };
+  netEarnedDisplayValue: string;
+}
+
 export const MerchantEarnedSpendAndRevenueTransactionFooter = ({
   token,
   netEarnedDisplayValue,
-}: {
-  token: { address: string; symbol?: string | null };
-  netEarnedDisplayValue: string;
-}) => (
+}: MerchantEarnedSpendAndRevenueTransactionFooter) => (
   <Container
     paddingHorizontal={5}
     flexDirection="row"

--- a/cardstack/src/models/firebase.ts
+++ b/cardstack/src/models/firebase.ts
@@ -35,11 +35,6 @@ export const getFCMToken = async (): Promise<FCMTokenStorageType> => {
       return { fcmToken: null };
     }
 
-    console.log('{ fcmToken, addressesByNetwork }---', {
-      fcmToken,
-      addressesByNetwork,
-    });
-
     return { fcmToken, addressesByNetwork };
   } catch {
     return { fcmToken: null };

--- a/cardstack/src/models/firebase.ts
+++ b/cardstack/src/models/firebase.ts
@@ -39,16 +39,19 @@ export const getFCMToken = async (): Promise<FCMTokenStorageType> => {
 };
 
 export const removeFCMToken = async (address: string) => {
-  const network: Network = await getNetwork();
   const { fcmToken, addressesByNetwork } = await getFCMToken();
-  // remove fcm token in asyncStorage
+
+  // remove address from AsyncStorage for all networks
+  for (const networkName in addressesByNetwork) {
+    addressesByNetwork[networkName as Network] = addressesByNetwork[
+      networkName as Network
+    ].filter((addr: string) => addr !== address);
+  }
+
   await saveLocal(DEVICE_FCM_TOKEN_KEY, {
     data: {
       ...addressesByNetwork,
       fcmToken,
-      [network]: (addressesByNetwork?.[network] || []).filter(
-        (addr: string) => addr !== address
-      ),
     },
   });
 };

--- a/cardstack/src/models/firebase.ts
+++ b/cardstack/src/models/firebase.ts
@@ -14,7 +14,7 @@ import { Network } from '@rainbow-me/helpers/networkTypes';
 const DEVICE_FCM_TOKEN_KEY = 'cardwalletFcmToken';
 type FCMTokenStorageType = {
   fcmToken: string | null;
-  addressesByNetwork?: Record<Network, string | string[]>;
+  addressesByNetwork?: Record<Network, string[]>;
 };
 
 const getPermissionStatus = (): Promise<FirebaseMessagingTypes.AuthorizationStatus> =>
@@ -38,9 +38,24 @@ export const getFCMToken = async (): Promise<FCMTokenStorageType> => {
   }
 };
 
+export const removeFCMToken = async (address: string) => {
+  const network: Network = await getNetwork();
+  const { fcmToken, addressesByNetwork } = await getFCMToken();
+  // remove fcm token in asyncStorage
+  await saveLocal(DEVICE_FCM_TOKEN_KEY, {
+    data: {
+      ...addressesByNetwork,
+      fcmToken,
+      [network]: (addressesByNetwork?.[network] || []).filter(
+        (addr: string) => addr !== address
+      ),
+    },
+  });
+};
+
 interface isFCMTokenStoredProps {
   isTokenStored: boolean;
-  addressesByNetwork?: Record<Network, string | string[]>;
+  addressesByNetwork?: Record<Network, string[]>;
   fcmToken: string | null;
 }
 

--- a/cardstack/src/models/firebase.ts
+++ b/cardstack/src/models/firebase.ts
@@ -56,7 +56,7 @@ export const removeFCMToken = async (address: string) => {
 
       logger.sentry('UnregisterFcmToken response ---', unregisterResponse);
 
-      if (unregisterResponse && unregisterResponse.success) {
+      if (unregisterResponse?.success) {
         // remove address from AsyncStorage for all networks
         for (const networkName in addressesByNetwork) {
           addressesByNetwork[networkName as Network] = addressesByNetwork[

--- a/cardstack/src/notification-handler/index.ts
+++ b/cardstack/src/notification-handler/index.ts
@@ -1,0 +1,22 @@
+import { merchantPrepaidCardPaymentReceivedHandler } from './merchantPrepaidCardPaymentReceived';
+
+// add more notification types here
+export enum NotificationType {
+  'customer_payment' = 'customer_payment',
+}
+
+type NotificationDataType = {
+  notificationType: NotificationType;
+  transactionInformation: string;
+};
+
+export const notificationHandler = (data: NotificationDataType) => {
+  const { notificationType, transactionInformation } = data;
+  const transactionData = JSON.parse(transactionInformation); // parse to object as hub sends data as a string
+
+  switch (notificationType) {
+    case NotificationType.customer_payment:
+      merchantPrepaidCardPaymentReceivedHandler(transactionData);
+      break;
+  }
+};

--- a/cardstack/src/notification-handler/index.ts
+++ b/cardstack/src/notification-handler/index.ts
@@ -49,7 +49,6 @@ const notificationConfig: Record<NotificationType, NotificationConfig> = {
   [NotificationType.merchantClaim]: {
     title: 'Merchant claimed successfully',
     handler: data => {
-      logger.log('merchantClaim notif--', data);
       if (!data?.transactionInformation) return;
       // parse to object as hub sends data as a string
       const { transactionInformation } = data;
@@ -60,9 +59,8 @@ const notificationConfig: Record<NotificationType, NotificationConfig> = {
 };
 
 export const notificationHandler = ({ data }: NotificationInfoType) => {
-  const { notificationType } = data || {};
-
-  if (data && notificationType) {
+  if (data?.notificationType) {
+    const { notificationType } = data;
     notificationConfig?.[notificationType]?.handler(data);
   }
 };

--- a/cardstack/src/notification-handler/index.ts
+++ b/cardstack/src/notification-handler/index.ts
@@ -14,14 +14,14 @@ interface NotificationDataType {
 }
 
 interface NotificationInfoType {
-  data: NotificationDataType;
+  data?: NotificationDataType;
   body: string;
 }
 
 export const notificationHandler = ({ data }: NotificationInfoType) => {
-  const { notificationType } = data;
+  const { notificationType } = data || {};
 
-  if (notificationType) {
+  if (data && notificationType) {
     switch (notificationType) {
       case NotificationType.customer_payment:
         const { transactionInformation } = data;

--- a/cardstack/src/notification-handler/index.ts
+++ b/cardstack/src/notification-handler/index.ts
@@ -1,22 +1,61 @@
+import notifee from '@notifee/react-native';
 import { merchantPrepaidCardPaymentReceivedHandler } from './merchantPrepaidCardPaymentReceived';
+import logger from 'logger';
 
 // add more notification types here
 export enum NotificationType {
   'customer_payment' = 'customer_payment',
+  'merchant_claim' = 'merchant_claim',
 }
 
-type NotificationDataType = {
+interface NotificationDataType {
   notificationType: NotificationType;
   transactionInformation: string;
+}
+
+interface NotificationInfoType {
+  data: NotificationDataType;
+  body: string;
+}
+
+export const notificationHandler = ({ data }: NotificationInfoType) => {
+  const { notificationType } = data;
+
+  if (notificationType) {
+    switch (notificationType) {
+      case NotificationType.customer_payment:
+        const { transactionInformation } = data;
+        const transactionData = JSON.parse(transactionInformation); // parse to object as hub sends data as a string
+        merchantPrepaidCardPaymentReceivedHandler(transactionData);
+        break;
+    }
+  }
 };
 
-export const notificationHandler = (data: NotificationDataType) => {
-  const { notificationType, transactionInformation } = data;
-  const transactionData = JSON.parse(transactionInformation); // parse to object as hub sends data as a string
+export const displayLocalNotification = async (notificationData: any) => {
+  try {
+    const {
+      notification: { title, body },
+      data,
+    } = notificationData;
 
-  switch (notificationType) {
-    case NotificationType.customer_payment:
-      merchantPrepaidCardPaymentReceivedHandler(transactionData);
-      break;
+    let notificationTitle = title;
+    const { notificationType } = data;
+
+    // update notification title when no title from hub side(mostly had no title)
+    if (
+      !notificationTitle &&
+      notificationType === NotificationType.customer_payment
+    ) {
+      notificationTitle = 'Payment Received';
+    }
+
+    await notifee.displayNotification({
+      title: notificationTitle,
+      body,
+      data,
+    });
+  } catch (e) {
+    logger.sentry('Display LocalNotification failed - ', e);
   }
 };

--- a/cardstack/src/notification-handler/merchantClaim.ts
+++ b/cardstack/src/notification-handler/merchantClaim.ts
@@ -1,0 +1,30 @@
+import { Navigation } from '@rainbow-me/navigation';
+import { MainRoutes } from '@cardstack/navigation/routes';
+import store from '@rainbow-me/redux/store';
+import Logger from 'logger';
+import { MerchantSafeType } from '@cardstack/types';
+
+export type MerchantClaimNotificationBody = {
+  merchantId: string;
+};
+
+export const merchantClaimHandler = async (
+  data: MerchantClaimNotificationBody
+) => {
+  try {
+    const { merchantSafes } = store.getState().data;
+
+    const merchantData = merchantSafes.find(
+      (merchantSafe: MerchantSafeType) =>
+        merchantSafe.address === data.merchantId
+    );
+
+    if (merchantData) {
+      Navigation.handleAction(MainRoutes.MERCHANT_SCREEN, {
+        merchantSafe: merchantData,
+      });
+    }
+  } catch (e) {
+    Logger.sentry('merchantClaimHandler handling failed - ', e);
+  }
+};

--- a/cardstack/src/notification-handler/merchantPrepaidCardPaymentReceived.tsx
+++ b/cardstack/src/notification-handler/merchantPrepaidCardPaymentReceived.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { InteractionManager } from 'react-native';
+import {
+  convertRawAmountToNativeDisplay,
+  convertStringToNumber,
+} from '@cardstack/cardpay-sdk';
+import { PrepaidCardPayment } from '@cardstack/graphql';
+import { Navigation } from '@rainbow-me/navigation';
+import { fetchMerchantInfoFromDID } from '@cardstack/utils/merchant-utils';
+import { fetchHistoricalPrice } from '@cardstack/services';
+import {
+  convertSpendForBalanceDisplay,
+  getMerchantEarnedTransactionDetails,
+} from '@cardstack/utils';
+import store from '@rainbow-me/redux/store';
+import { MainRoutes } from '@cardstack/navigation/routes';
+import { SafeHeader } from '@cardstack/components';
+import Logger from 'logger';
+
+export type PrepaidCardPaymentReceivedNotificationBody = Omit<
+  PrepaidCardPayment,
+  '__typename'
+>;
+
+export const merchantPrepaidCardPaymentReceivedHandler = async (
+  data: PrepaidCardPaymentReceivedNotificationBody
+) => {
+  try {
+    const transaction = await mapMerchantPaymentTxToNavigationParams(data);
+    InteractionManager.runAfterInteractions(async () => {
+      Navigation.handleAction(MainRoutes.PAYMENT_RECEIVED_SHEET, {
+        transaction,
+      });
+    });
+  } catch (e) {
+    Logger.sentry('Push notification in-app handling failed - ', e);
+  }
+};
+
+export const mapMerchantPaymentTxToNavigationParams = async (
+  transactionDetails: PrepaidCardPaymentReceivedNotificationBody
+) => {
+  const {
+    merchantSafe,
+    spendAmount,
+    issuingToken,
+    issuingTokenAmount,
+    timestamp,
+    prepaidCard,
+  } = transactionDetails;
+
+  const merchantInfoDID = await fetchMerchantInfoFromDID(
+    merchantSafe?.infoDid || undefined
+  );
+
+  const { nativeCurrency } = store.getState().settings;
+
+  const {
+    rates: currencyConversionRates,
+  } = store.getState().currencyConversion;
+
+  const symbol = issuingToken.symbol || '';
+
+  const price = await fetchHistoricalPrice(symbol, timestamp, nativeCurrency);
+
+  const spendDisplay = convertSpendForBalanceDisplay(
+    spendAmount,
+    nativeCurrency,
+    currencyConversionRates
+  );
+
+  const nativeBalance = convertRawAmountToNativeDisplay(
+    issuingTokenAmount,
+    18,
+    price,
+    nativeCurrency
+  );
+
+  const earnedTransactionDetails = await getMerchantEarnedTransactionDetails(
+    transactionDetails,
+    nativeCurrency,
+    convertStringToNumber(nativeBalance.amount),
+    currencyConversionRates,
+    symbol
+  );
+
+  const token = {
+    address: issuingToken.id,
+    symbol: issuingToken.symbol,
+    name: issuingToken.name,
+  };
+
+  return {
+    Header: (
+      <SafeHeader
+        address={merchantSafe?.id || ''}
+        backgroundColor={merchantInfoDID?.color}
+        textColor={merchantInfoDID?.textColor}
+        rightText={merchantInfoDID?.name || 'Business'}
+        small
+      />
+    ),
+    statusIconName: 'arrow-down',
+    statusText: 'Received',
+    address: merchantSafe?.id || '',
+    fromAddress: prepaidCard.id,
+    spendBalanceDisplay: spendDisplay.tokenBalanceDisplay,
+    nativeBalanceDisplay: spendDisplay.nativeBalanceDisplay,
+    timestamp: Number(timestamp) + 1,
+    spendAmount,
+    transactionHash: transactionDetails.id,
+    token,
+    transaction: earnedTransactionDetails,
+  };
+};

--- a/cardstack/src/notification-handler/merchantPrepaidCardPaymentReceived.tsx
+++ b/cardstack/src/notification-handler/merchantPrepaidCardPaymentReceived.tsx
@@ -33,7 +33,10 @@ export const merchantPrepaidCardPaymentReceivedHandler = async (
       });
     });
   } catch (e) {
-    Logger.sentry('Push notification in-app handling failed - ', e);
+    Logger.sentry(
+      'merchantPrepaidCardPaymentReceivedHandler handling failed - ',
+      e
+    );
   }
 };
 

--- a/cardstack/src/redux/collectibles.ts
+++ b/cardstack/src/redux/collectibles.ts
@@ -25,6 +25,7 @@ import {
   assetsWithoutNFTsByFamily,
   getNFTFamilies,
 } from '@cardstack/parsers/collectibles';
+import logger from 'logger';
 
 // -- Constants ------------------------------------------------------------- //
 const COLLECTIBLES_LOAD_REQUEST = 'collectibles/COLLECTIBLES_LOAD_REQUEST';
@@ -81,7 +82,7 @@ export const collectiblesRefreshState = () => async (
     case NetworkTypes.sokol:
       return dispatch(fetchNFTsViaRpcNode());
     default:
-      console.log(
+      logger.log(
         `Skipping fetching collectibles because we have no mechanism to do so on ${network}`
       );
   }
@@ -243,7 +244,7 @@ const fetchNFTsViaRpcNode = () => async (
 
             return collectible;
           } catch (error) {
-            console.log('Error creating collectible', error);
+            logger.sentry('Error creating collectible', error);
 
             return null;
           }

--- a/cardstack/src/screens/sheets/Collectible/components/CollectibleHeader.tsx
+++ b/cardstack/src/screens/sheets/Collectible/components/CollectibleHeader.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useCallback } from 'react';
 import { Linking, Share } from 'react-native';
 import URL from 'url-parse';
+import logger from 'logger';
 
 import {
   AnimatedPressable,
@@ -23,7 +24,7 @@ function viewMenuItemLabel(collectible: CollectibleType) {
       return `View on ${tldFromUrlString(collectible.permalink)}`;
     }
   } catch (e) {
-    console.log('viewMenuItemLabel', e.message);
+    logger.log('viewMenuItemLabel', e.message);
     // do nothing
   }
 

--- a/cardstack/src/screens/sheets/PaymentReceived/PaymentReceivedSheet.tsx
+++ b/cardstack/src/screens/sheets/PaymentReceived/PaymentReceivedSheet.tsx
@@ -31,20 +31,17 @@ const PaymentReceivedSheet = () => {
 
   const {
     address,
+    fromAddress,
     spendBalanceDisplay,
     nativeBalanceDisplay,
     timestamp,
     transactionHash,
     transaction: transactionData,
     token,
+    Header,
   } = transaction;
 
   const network = useRainbowSelector(state => state.settings.network);
-
-  const earnedTxnData = {
-    ...transactionData,
-    subText: transactionData.netEarned.display,
-  };
 
   const rowProps = {
     ...transaction,
@@ -97,9 +94,9 @@ const PaymentReceivedSheet = () => {
           marginBottom={8}
           overflow="scroll"
         >
-          {transaction.Header}
-          <EarnedTransaction {...earnedTxnData} txRowProps={rowProps} />
-          <PaymentDetailsItem info={address} isPrepaidCard title="FROM" />
+          {Header}
+          <EarnedTransaction {...transactionData} txRowProps={rowProps} />
+          <PaymentDetailsItem info={fromAddress} isPrepaidCard title="FROM" />
           <PaymentDetailsItem info={transactionHash} title="TXN HASH" />
           <PaymentDetailsItem
             info={timestamp}
@@ -108,10 +105,7 @@ const PaymentReceivedSheet = () => {
             title="LOCAL TIME"
           />
         </Container>
-        <BlockscoutButton
-          network={network}
-          transactionHash={transaction.transactionHash}
-        />
+        <BlockscoutButton network={network} transactionHash={transactionHash} />
       </Container>
     </Sheet>
   );

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/merchant-earned-spend-and-revenue-strategy.test.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/merchant-earned-spend-and-revenue-strategy.test.ts
@@ -51,6 +51,7 @@ describe('MerchantEarnedSpendAndRevenueStrategy', () => {
     const value = await strategy.mapTransaction();
     expect(value).toEqual({
       address: '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
+      fromAddress: '0x72DB39da38fa313A004770E8C4d9416428068024',
       balance: {
         amount: '1.497005988023952095',
         display: '1.497 DAI',

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-and-revenue-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-and-revenue-strategy.ts
@@ -65,6 +65,7 @@ export class MerchantEarnedSpendAndRevenueStrategy extends BaseStrategy {
 
     return {
       address: prepaidCardPaymentTransaction.merchantSafe?.id || '',
+      fromAddress: prepaidCardPaymentTransaction.prepaidCard.id,
       balance: convertRawAmountToBalance(amount, {
         decimals: 18,
         symbol,

--- a/cardstack/src/types/transaction-types.ts
+++ b/cardstack/src/types/transaction-types.ts
@@ -252,6 +252,7 @@ export interface MerchantPrepaidCardIssuanceType {
 
 export interface MerchantEarnedSpendAndRevenueTransactionType {
   address: string;
+  fromAddress: string;
   balance: BalanceType;
   native: BalanceType;
   netEarned: BalanceType;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -503,6 +503,11 @@ PODS:
     - React
   - RNLocalize (2.1.5):
     - React-Core
+  - RNNotifee (4.0.1):
+    - React-Core
+    - RNNotifee/NotifeeCore (= 4.0.1)
+  - RNNotifee/NotifeeCore (4.0.1):
+    - React-Core
   - RNOS (1.2.8):
     - React
   - RNPermissions (3.0.5):
@@ -669,6 +674,7 @@ DEPENDENCIES:
   - RNKeyboard (from `../node_modules/react-native-keyboard-area`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
   - RNLocalize (from `../node_modules/react-native-localize`)
+  - "RNNotifee (from `../node_modules/@notifee/react-native`)"
   - RNOS (from `../node_modules/react-native-os`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
@@ -861,6 +867,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-keychain"
   RNLocalize:
     :path: "../node_modules/react-native-localize"
+  RNNotifee:
+    :path: "../node_modules/@notifee/react-native"
   RNOS:
     :path: "../node_modules/react-native-os"
   RNPermissions:
@@ -991,6 +999,7 @@ SPEC CHECKSUMS:
   RNKeyboard: ceec456427493b286539f40442620881b5840dff
   RNKeychain: b8e0711b959a19c5b057d1e970d3c83d159b6da5
   RNLocalize: 74b82db20cc3895ccc25af992c644879bcec2815
+  RNNotifee: ed6c0b5ffc0b021507fe196a1c4cfd1fe002410c
   RNOS: 31db6fa4a197d179afbba9e6b4d28d450a7f250b
   RNPermissions: 7043bacbf928eae25808275cfe73799b8f618911
   RNReactNativeHapticFeedback: 653a8c126a0f5e88ce15ffe280b3ff37e1fbb285

--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -643,7 +643,7 @@
 					13B07F861A680F5B00A75B9A = {
 						DevelopmentTeam = QS5AFH4668;
 						LastSwiftMigration = 1120;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.Push = {
 								enabled = 1;
@@ -972,13 +972,13 @@
 				ASSETCATALOG_COMPILER_OPTIMIZATION = time;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Rainbow/RainbowDebug.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = QS5AFH4668;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1025,7 +1025,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
 				PRODUCT_NAME = Rainbow;
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1041,11 +1041,11 @@
 				ASSETCATALOG_COMPILER_OPTIMIZATION = "";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Rainbow/RainbowRelease.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = QS5AFH4668;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1080,7 +1080,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
 				PRODUCT_NAME = Rainbow;
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1109,7 +1109,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -1132,11 +1132,11 @@
 				ASSETCATALOG_COMPILER_OPTIMIZATION = "";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Rainbow/Rainbow.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = QS5AFH4668;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1170,7 +1170,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
 				PRODUCT_NAME = Rainbow;
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1199,7 +1199,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PREPROCESSOR_DEFINITIONS = "LOCAL_RELEASE=1";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1223,11 +1223,11 @@
 				ASSETCATALOG_COMPILER_OPTIMIZATION = time;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Rainbow/Rainbow.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = QS5AFH4668;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1261,7 +1261,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
 				PRODUCT_NAME = Rainbow;
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1288,7 +1288,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -1331,7 +1331,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;

--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -643,7 +643,7 @@
 					13B07F861A680F5B00A75B9A = {
 						DevelopmentTeam = QS5AFH4668;
 						LastSwiftMigration = 1120;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.Push = {
 								enabled = 1;
@@ -972,13 +972,13 @@
 				ASSETCATALOG_COMPILER_OPTIMIZATION = time;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Rainbow/RainbowDebug.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = QS5AFH4668;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1025,7 +1025,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
 				PRODUCT_NAME = Rainbow;
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1041,11 +1041,11 @@
 				ASSETCATALOG_COMPILER_OPTIMIZATION = "";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Rainbow/RainbowRelease.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = QS5AFH4668;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1080,7 +1080,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
 				PRODUCT_NAME = Rainbow;
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1109,7 +1109,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -1132,11 +1132,11 @@
 				ASSETCATALOG_COMPILER_OPTIMIZATION = "";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Rainbow/Rainbow.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = QS5AFH4668;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1170,7 +1170,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
 				PRODUCT_NAME = Rainbow;
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1199,7 +1199,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PREPROCESSOR_DEFINITIONS = "LOCAL_RELEASE=1";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1223,11 +1223,11 @@
 				ASSETCATALOG_COMPILER_OPTIMIZATION = time;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Rainbow/Rainbow.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = QS5AFH4668;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1261,7 +1261,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
 				PRODUCT_NAME = Rainbow;
 				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1288,7 +1288,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -1331,7 +1331,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@ethersproject/units": "^5.0.8",
     "@ethersproject/wallet": "^5.0.9",
     "@lavamoat/preinstall-always-fail": "^1.0.0",
+    "@notifee/react-native": "^4.0.1",
     "@rainbow-me/react-native-animated-number": "^0.0.2",
     "@rainbow-me/react-native-payments": "1.1.5",
     "@react-native-async-storage/async-storage": "^1.15.14",

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import { ApolloProvider } from '@apollo/client';
+import { notificationHandler } from '@cardstack/notification-handler';
 import messaging from '@react-native-firebase/messaging';
 import * as Sentry from '@sentry/react-native';
 import { ThemeProvider } from '@shopify/restyle';
@@ -178,18 +179,24 @@ class App extends Component {
   };
 
   onRemoteNotification = notification => {
-    const topic = get(notification, 'data.topic');
+    const data = get(notification, 'data');
+    const topic = get(notification, 'topic');
     setTimeout(() => {
-      this.onPushNotificationOpened(topic);
+      this.onPushNotificationOpened(topic, data);
     }, WALLETCONNECT_SYNC_DELAY);
   };
 
-  onPushNotificationOpened = topic => {
+  onPushNotificationOpened = (topic, data) => {
     const { requestsForTopic } = this.props;
     const requests = requestsForTopic(topic);
-    if (requests) {
+
+    if (requests && Array.isArray(requests) && requests.length > 0) {
       // WC requests will open automatically
       return false;
+    }
+
+    if (data) {
+      notificationHandler(data);
     }
     // In the future, here  is where we should
     // handle all other kinds of push notifications

--- a/src/App.js
+++ b/src/App.js
@@ -134,8 +134,8 @@ class App extends Component {
     );
 
     messaging().onNotificationOpenedApp(remoteMessage => {
-      if (remoteMessage && remoteMessage.notification) {
-        notificationHandler(remoteMessage.notification);
+      if (remoteMessage) {
+        notificationHandler(remoteMessage);
       }
     });
 
@@ -143,8 +143,8 @@ class App extends Component {
     messaging()
       .getInitialNotification()
       .then(remoteMessage => {
-        if (remoteMessage && remoteMessage.notification) {
-          notificationHandler(remoteMessage.notification);
+        if (remoteMessage) {
+          notificationHandler(remoteMessage);
         }
       });
 

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -33,7 +33,6 @@ import { getRandomColor } from '../styles/colors';
 import { Container, Sheet, Text, Touchable } from '@cardstack/components';
 import { removeFCMToken } from '@cardstack/models/firebase';
 import { getAddressPreview } from '@cardstack/utils';
-
 import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
 import {
   useAccountSettings,

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -31,7 +31,7 @@ import {
 } from '../redux/wallets';
 import { getRandomColor } from '../styles/colors';
 import { Container, Sheet, Text, Touchable } from '@cardstack/components';
-import { getFCMToken } from '@cardstack/models/firebase';
+import { getFCMToken, removeFCMToken } from '@cardstack/models/firebase';
 import { unregisterFcmToken } from '@cardstack/services/hub-service';
 import { getAddressPreview } from '@cardstack/utils';
 import { getNetwork } from '@rainbow-me/handlers/localstorage/globalSettings';
@@ -161,6 +161,7 @@ export default function ChangeWalletSheet() {
       ) {
         const unregisterResponse = await unregisterFcmToken(fcmToken, address);
         logger.log('UnregisterFcmToken response ---', unregisterResponse);
+        removeFCMToken(address);
       }
       if (!hasVisibleAddresses) {
         delete newWallets[walletId];

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -31,10 +31,9 @@ import {
 } from '../redux/wallets';
 import { getRandomColor } from '../styles/colors';
 import { Container, Sheet, Text, Touchable } from '@cardstack/components';
-import { getFCMToken, removeFCMToken } from '@cardstack/models/firebase';
-import { unregisterFcmToken } from '@cardstack/services/hub-service';
+import { removeFCMToken } from '@cardstack/models/firebase';
 import { getAddressPreview } from '@cardstack/utils';
-import { getNetwork } from '@rainbow-me/handlers/localstorage/globalSettings';
+
 import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
 import {
   useAccountSettings,
@@ -153,26 +152,8 @@ export default function ChangeWalletSheet() {
       );
       setIsWalletLoading(WalletLoadingStates.DELETING_WALLET);
 
-      try {
-        const network = await getNetwork();
-        const { fcmToken, addressesByNetwork } = await getFCMToken();
-        if (
-          addressesByNetwork[network] &&
-          addressesByNetwork[network].includes(address)
-        ) {
-          const unregisterResponse = await unregisterFcmToken(
-            fcmToken,
-            address
-          );
-          logger.sentry('UnregisterFcmToken response ---', unregisterResponse);
-          if (unregisterResponse && unregisterResponse.success) {
-            await removeFCMToken(address);
-          }
-        }
-      } catch (e) {
-        logger.sentry('Unregister FcmToken failed --', e);
-      }
-
+      // unregister in hub and remove fcm for this account from asyncStorage
+      await removeFCMToken(address);
       if (!hasVisibleAddresses) {
         delete newWallets[walletId];
         await dispatch(walletsUpdate(newWallets));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -61,6 +61,8 @@
       "@cardstack/models/*": ["cardstack/src/models/*"],
       "@cardstack/navigation": ["cardstack/src/navigation"],
       "@cardstack/navigation/*": ["cardstack/src/navigation/*"],
+      "@cardstack/notification-handler": ["cardstack/src/notification-handler"],
+      "@cardstack/notification-handler/*": ["cardstack/src/notification-handler/*"],
       "@cardstack/parsers": ["cardstack/src/parsers"],
       "@cardstack/parsers/*": ["cardstack/src/parsers/*"],
       "@cardstack/redux": ["cardstack/src/redux"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3530,6 +3530,11 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@notifee/react-native@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@notifee/react-native/-/react-native-4.0.1.tgz#342ee79695f5753f8f32b9de48f428f6354c102e"
+  integrity sha512-vkRJnDMg7z21APm6RytD6ddHk4Og+zro/V0/Fk2a3Hvk1apDfSDXo1n4e3S+WPqsJEJSCXVGkRNWxam9Wq22sQ==
+
 "@npmcli/node-gyp@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@npmcli/node-gyp/-/node-gyp-1.0.2.tgz#3cdc1f30e9736dbc417373ed803b42b1a0a29ede"


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

In this PR, implemented push notification handling and localNotification, mapping merchant payment received and fixed small bugs like wrong from address in transaction strategy and removing token from asyncStorage.

So It shows local notification when received push notification(other than WC notification) and if user press that notification it does related action.

I was not able to record local notification behavior as strangely local notification does not show up only when it is connected to mac, but when you press local notification it shows up Payment Received Sheet.

Just realized handling open notification on different network does not work properly yet.. so working on it after added more into into notification data in hub side, maybe we can finish that in next pr
<!-- Include a summary of the changes. -->

- [x] Completes #CS-2616
- [x] Completes #CS-2617

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->


<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/16714648/150349182-3c315366-59ed-4536-8bdd-98adafcd5279.png">

![Jan-18-2022 22-00-33](https://user-images.githubusercontent.com/16714648/149953638-8f2068b7-28bb-4959-abf2-a1705286d26f.gif)

