### PR TITLE
Quickfix: More margin for longer texts on Notice Banner

### DIFF
--- a/cardstack/src/components/Notice/Notice.tsx
+++ b/cardstack/src/components/Notice/Notice.tsx
@@ -3,6 +3,8 @@ import { Container, Touchable, Icon, Text } from '@cardstack/components';
 import { NoticeType } from '@cardstack/types';
 import { ColorTypes } from '@cardstack/theme';
 import { layoutEasingAnimation } from '@cardstack/utils';
+import { differenceInCalendarDays } from 'date-fns';
+import { Colors } from 'react-native/Libraries/NewAppScreen';
 
 interface NoticeStyle {
   iconColor: ColorTypes;
@@ -73,7 +75,7 @@ export const Notice = ({
             <Container margin={1} />
             <Text
               fontWeight="bold"
-              marginRight={4}
+              marginRight={8}
               color={noticeColorConfig[type].textColor}
             >
               {description}

--- a/cardstack/src/components/Notice/Notice.tsx
+++ b/cardstack/src/components/Notice/Notice.tsx
@@ -3,8 +3,6 @@ import { Container, Touchable, Icon, Text } from '@cardstack/components';
 import { NoticeType } from '@cardstack/types';
 import { ColorTypes } from '@cardstack/theme';
 import { layoutEasingAnimation } from '@cardstack/utils';
-import { differenceInCalendarDays } from 'date-fns';
-import { Colors } from 'react-native/Libraries/NewAppScreen';
 
 interface NoticeStyle {
   iconColor: ColorTypes;


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Notice banner was bleeding a bit when the text was too long, so this PR increases the right margin a bit.

No related ticked.

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

After:

<img width="364" alt="Screen Shot 2022-01-18 at 17 54 17" src="https://user-images.githubusercontent.com/129619/150017810-8449e839-4260-466f-b678-5d0039f9f86f.png">

Now:

<img width="364" alt="Screen Shot 2022-01-18 at 17 56 39" src="https://user-images.githubusercontent.com/129619/150017836-fe518c7f-4b16-49ac-a490-98c99a5358a8.png">

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->
