### PR TITLE
[CS-2569] Notifications Preferences

### DIFF
--- a/cardstack/src/components/OptionsList/index.ts
+++ b/cardstack/src/components/OptionsList/index.ts
@@ -1,0 +1,1 @@
+export * from './OptionsList';

--- a/cardstack/src/components/OptionsList/index.ts
+++ b/cardstack/src/components/OptionsList/index.ts
@@ -1,1 +1,0 @@
-export * from './OptionsList';

--- a/cardstack/src/helpers/__mocks__/hubMocks.ts
+++ b/cardstack/src/helpers/__mocks__/hubMocks.ts
@@ -558,3 +558,26 @@ export const wyrePriceData = {
     ],
   },
 };
+
+export const notificationsPreferences = {
+  data: [
+    {
+      type: 'notification-preference',
+      attributes: {
+        'owner-address': '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13',
+        'push-client-id': '1234567',
+        'notification-type': 'merchant_claim',
+        status: 'disabled',
+      },
+    },
+    {
+      type: 'notification-preference',
+      attributes: {
+        'owner-address': '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13',
+        'push-client-id': '1234567',
+        'notification-type': 'customer_payment',
+        status: 'enabled',
+      },
+    },
+  ],
+};

--- a/cardstack/src/hooks/index.ts
+++ b/cardstack/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './transaction-confirmation/use-transaction-confirmation';
 export * from './transactions';
 export * from './use-lifetime-earnings-data';
 export * from './prepaid-card/useAuthToken';
+export * from './notifications-preferences/useUpdateNotificationPreferences';

--- a/cardstack/src/hooks/notifications-preferences/useUpdateNotificationPreferences.ts
+++ b/cardstack/src/hooks/notifications-preferences/useUpdateNotificationPreferences.ts
@@ -33,7 +33,7 @@ export const useUpdateNotificationPreferences = () => {
   }, [authToken]);
 
   const onUpdateOptionStatus = useCallback(
-    async (value, item) => {
+    async (item, value) => {
       const updateList = options?.map(
         (option: NotificationsPreferenceDataType) => {
           if (

--- a/cardstack/src/hooks/notifications-preferences/useUpdateNotificationPreferences.ts
+++ b/cardstack/src/hooks/notifications-preferences/useUpdateNotificationPreferences.ts
@@ -1,0 +1,76 @@
+import { useEffect, useCallback, useState } from 'react';
+import { useAuthToken } from '@cardstack/hooks';
+
+import { getFCMToken } from '@cardstack/models/firebase';
+import {
+  getNotificationsPreferences,
+  setNotificationsPreferences,
+} from '@cardstack/services/hub-service';
+import { NotificationsPreferenceDataType } from '@cardstack/types';
+
+export enum NotificationsOptionsStrings {
+  'merchant_claim' = 'Merchant Claim',
+  'customer_payment' = 'New Payment Received',
+}
+
+export const useUpdateNotificationPreferences = () => {
+  const { authToken, isLoading, error } = useAuthToken();
+
+  const [options, setOptions] = useState<
+    NotificationsPreferenceDataType[] | undefined
+  >([]);
+
+  const fetchNotificationPreferences = useCallback(async () => {
+    const { fcmToken } = await getFCMToken();
+
+    if (fcmToken) {
+      const result = await getNotificationsPreferences(authToken, fcmToken);
+
+      if (result && result.length > 0) {
+        setOptions(result);
+      }
+    }
+  }, [authToken]);
+
+  const onUpdateOptionStatus = useCallback(
+    async (value, item) => {
+      const updateList = options?.map(
+        (option: NotificationsPreferenceDataType) => {
+          if (
+            option.attributes['notification-type'] ===
+            item.attributes['notification-type']
+          ) {
+            option.attributes.status = value ? 'enabled' : 'disabled';
+          }
+
+          return option;
+        }
+      );
+
+      setOptions(updateList);
+
+      const updateItem = updateList?.find(
+        o =>
+          o.attributes['notification-type'] ===
+          item.attributes['notification-type']
+      );
+
+      const { fcmToken } = await getFCMToken();
+
+      if (fcmToken && authToken && updateItem) {
+        await setNotificationsPreferences(authToken, fcmToken, updateItem);
+      }
+    },
+    [authToken, options]
+  );
+
+  useEffect(() => {
+    if (!isLoading && authToken) fetchNotificationPreferences();
+  }, [authToken, isLoading, fetchNotificationPreferences]);
+
+  return {
+    options,
+    onUpdateOptionStatus,
+    error,
+  };
+};

--- a/cardstack/src/hooks/notifications-preferences/useUpdateNotificationPreferences.ts
+++ b/cardstack/src/hooks/notifications-preferences/useUpdateNotificationPreferences.ts
@@ -1,7 +1,6 @@
 import { useEffect, useCallback, useState } from 'react';
 import { useAuthToken } from '@cardstack/hooks';
 
-import { getFCMToken } from '@cardstack/models/firebase';
 import {
   getNotificationsPreferences,
   setNotificationsPreferences,
@@ -21,14 +20,10 @@ export const useUpdateNotificationPreferences = () => {
   >([]);
 
   const fetchNotificationPreferences = useCallback(async () => {
-    const { fcmToken } = await getFCMToken();
+    const result = await getNotificationsPreferences(authToken);
 
-    if (fcmToken) {
-      const result = await getNotificationsPreferences(authToken, fcmToken);
-
-      if (result && result.length > 0) {
-        setOptions(result);
-      }
+    if (result && result.length > 0) {
+      setOptions(result);
     }
   }, [authToken]);
 
@@ -55,10 +50,8 @@ export const useUpdateNotificationPreferences = () => {
           item.attributes['notification-type']
       );
 
-      const { fcmToken } = await getFCMToken();
-
-      if (fcmToken && authToken && updateItem) {
-        await setNotificationsPreferences(authToken, fcmToken, updateItem);
+      if (authToken && updateItem) {
+        await setNotificationsPreferences(authToken, updateItem);
       }
     },
     [authToken, options]

--- a/cardstack/src/hooks/prepaid-card/useAuthToken.ts
+++ b/cardstack/src/hooks/prepaid-card/useAuthToken.ts
@@ -40,5 +40,5 @@ export const useAuthToken = (seedPhrase?: string) => {
     }
   }, [error]);
 
-  return { authToken, isLoading };
+  return { authToken, isLoading, error };
 };

--- a/cardstack/src/services/hub-service.ts
+++ b/cardstack/src/services/hub-service.ts
@@ -9,6 +9,7 @@ import {
   ReservationData,
   OrderData,
   WyrePriceData,
+  NotificationsPreferenceDataType,
 } from '@cardstack/types';
 import logger from 'logger';
 import { Network } from '@rainbow-me/helpers/networkTypes';
@@ -149,6 +150,58 @@ export const unregisterFcmToken = async (
   } catch (e: any) {
     logger.sentry(
       'Error while unregistering fcmToken from hub',
+      e?.response || e
+    );
+  }
+};
+
+export const getNotificationsPreferences = async (
+  authToken: string,
+  fcmToken: string
+): Promise<NotificationsPreferenceDataType[] | undefined> => {
+  try {
+    const network: Network = await getNetwork();
+    const hubURL = getHubUrl(network);
+
+    const results = await axios.get(
+      `${hubURL}/api/notification-preferences/${fcmToken}`,
+      axiosConfig(authToken)
+    );
+
+    return results?.data?.data as NotificationsPreferenceDataType[];
+  } catch (e: any) {
+    logger.sentry(
+      'Error while fetching notifications preferences from hub',
+      e?.response || e
+    );
+  }
+};
+
+export const setNotificationsPreferences = async (
+  authToken: string,
+  fcmToken: string,
+  update: NotificationsPreferenceDataType
+) => {
+  try {
+    const network: Network = await getNetwork();
+    const hubURL = getHubUrl(network);
+
+    await axios.put(
+      `${hubURL}/api/notification-preferences/${fcmToken}`,
+      JSON.stringify({
+        data: {
+          type: 'notification-preference',
+          attributes: {
+            'notification-type': update.attributes['notification-type'],
+            status: update.attributes.status,
+          },
+        },
+      }),
+      axiosConfig(authToken)
+    );
+  } catch (e: any) {
+    logger.sentry(
+      'Error while saving notifications preferences on hub',
       e?.response || e
     );
   }

--- a/cardstack/src/services/hub-service.ts
+++ b/cardstack/src/services/hub-service.ts
@@ -14,6 +14,7 @@ import {
 import logger from 'logger';
 import { Network } from '@rainbow-me/helpers/networkTypes';
 import HDProvider from '@cardstack/models/hd-provider';
+import { getFCMToken } from '@cardstack/models/firebase';
 
 const HUB_URL_STAGING = 'https://hub-staging.stack.cards';
 const HUB_URL_PROD = 'https://hub.cardstack.com';
@@ -156,12 +157,12 @@ export const unregisterFcmToken = async (
 };
 
 export const getNotificationsPreferences = async (
-  authToken: string,
-  fcmToken: string
+  authToken: string
 ): Promise<NotificationsPreferenceDataType[] | undefined> => {
   try {
     const network: Network = await getNetwork();
     const hubURL = getHubUrl(network);
+    const { fcmToken } = await getFCMToken();
 
     const results = await axios.get(
       `${hubURL}/api/notification-preferences/${fcmToken}`,
@@ -179,12 +180,12 @@ export const getNotificationsPreferences = async (
 
 export const setNotificationsPreferences = async (
   authToken: string,
-  fcmToken: string,
   update: NotificationsPreferenceDataType
 ) => {
   try {
     const network: Network = await getNetwork();
     const hubURL = getHubUrl(network);
+    const { fcmToken } = await getFCMToken();
 
     await axios.put(
       `${hubURL}/api/notification-preferences/${fcmToken}`,

--- a/cardstack/src/types/NotificationsPreferenceDataType.ts
+++ b/cardstack/src/types/NotificationsPreferenceDataType.ts
@@ -1,0 +1,11 @@
+type NotificationStatusType = 'disabled' | 'enabled';
+
+export interface NotificationsPreferenceDataType {
+  type: string;
+  attributes: {
+    status: NotificationStatusType;
+    'owner-address': string;
+    'push-client-id': string;
+    'notification-type': string;
+  };
+}

--- a/cardstack/src/types/index.ts
+++ b/cardstack/src/types/index.ts
@@ -11,3 +11,4 @@ export * from './transaction-confirmation-types';
 export * from './transaction-types';
 export * from './NoticeType';
 export * from './IncidentType';
+export * from './NotificationsPreferenceDataType';

--- a/src/components/settings-menu/NotificationsSection.tsx
+++ b/src/components/settings-menu/NotificationsSection.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { FlatList, Switch } from 'react-native';
+import { Container, Skeleton, Text } from '@cardstack/components';
+import {
+  NotificationsOptionsStrings,
+  useUpdateNotificationPreferences,
+} from '@cardstack/hooks';
+import { NotificationsPreferenceDataType } from '@cardstack/types';
+
+const NotificationsSection = () => {
+  const {
+    options,
+    onUpdateOptionStatus,
+    error,
+  } = useUpdateNotificationPreferences();
+
+  const OptionListItem = ({
+    item,
+  }: {
+    item: NotificationsPreferenceDataType;
+  }) => {
+    return (
+      <Container
+        alignItems="center"
+        flexDirection="row"
+        justifyContent="space-between"
+        paddingHorizontal={6}
+        paddingVertical={2}
+        testID="option-item"
+      >
+        <Text>
+          {
+            NotificationsOptionsStrings[
+              item?.attributes[
+                'notification-type'
+              ] as keyof typeof NotificationsOptionsStrings
+            ]
+          }
+        </Text>
+        <Switch
+          onValueChange={value => onUpdateOptionStatus(item, value)}
+          value={item?.attributes.status === 'enabled'}
+        />
+      </Container>
+    );
+  };
+
+  const ListError = () => (
+    <Container alignItems="center" flex={1} justifyContent="center">
+      <Text>{error}</Text>
+    </Container>
+  );
+
+  const ListLoading = () => (
+    <Container flexDirection="column" paddingHorizontal={6} paddingVertical={2}>
+      <Skeleton height={40} light marginBottom={1} width="100%" />
+      <Skeleton height={40} light width="100%" />
+    </Container>
+  );
+
+  return (
+    <FlatList
+      ListEmptyComponent={error ? ListError : ListLoading}
+      contentContainerStyle={{ paddingTop: 16 }}
+      data={options}
+      keyExtractor={(item: NotificationsPreferenceDataType) =>
+        item.attributes['notification-type']
+      }
+      renderItem={OptionListItem}
+    />
+  );
+};
+
+export default NotificationsSection;

--- a/src/components/settings-menu/NotificationsSection.tsx
+++ b/src/components/settings-menu/NotificationsSection.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { FlatList, Switch } from 'react-native';
+import React, { useCallback, useMemo } from 'react';
+import { FlatList, ListRenderItemInfo, StyleSheet, Switch } from 'react-native';
 import { Container, Skeleton, Text } from '@cardstack/components';
 import {
   NotificationsOptionsStrings,
@@ -14,61 +14,84 @@ const NotificationsSection = () => {
     error,
   } = useUpdateNotificationPreferences();
 
-  const OptionListItem = ({
-    item,
-  }: {
-    item: NotificationsPreferenceDataType;
-  }) => {
-    return (
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<NotificationsPreferenceDataType>) => {
+      return (
+        <Container
+          alignItems="center"
+          flexDirection="row"
+          justifyContent="space-between"
+          paddingHorizontal={6}
+          paddingVertical={2}
+          testID="option-item"
+        >
+          <Text>
+            {
+              NotificationsOptionsStrings[
+                item?.attributes[
+                  'notification-type'
+                ] as keyof typeof NotificationsOptionsStrings
+              ]
+            }
+          </Text>
+          <Switch
+            onValueChange={value => onUpdateOptionStatus(item, value)}
+            value={item?.attributes.status === 'enabled'}
+          />
+        </Container>
+      );
+    },
+    [onUpdateOptionStatus]
+  );
+
+  const ListError = useMemo(
+    () => (
+      <Container alignItems="center" flex={1} justifyContent="center">
+        <Text>{error}</Text>
+      </Container>
+    ),
+    [error]
+  );
+
+  const ListLoading = useMemo(
+    () => (
       <Container
-        alignItems="center"
-        flexDirection="row"
-        justifyContent="space-between"
+        flexDirection="column"
         paddingHorizontal={6}
         paddingVertical={2}
-        testID="option-item"
       >
-        <Text>
-          {
-            NotificationsOptionsStrings[
-              item?.attributes[
-                'notification-type'
-              ] as keyof typeof NotificationsOptionsStrings
-            ]
-          }
-        </Text>
-        <Switch
-          onValueChange={value => onUpdateOptionStatus(item, value)}
-          value={item?.attributes.status === 'enabled'}
-        />
+        {[...Array(2)].map((v, i) => (
+          <Skeleton
+            height={40}
+            key={`${i}`}
+            light
+            marginBottom={1}
+            width="100%"
+          />
+        ))}
       </Container>
-    );
-  };
-
-  const ListError = () => (
-    <Container alignItems="center" flex={1} justifyContent="center">
-      <Text>{error}</Text>
-    </Container>
+    ),
+    []
   );
 
-  const ListLoading = () => (
-    <Container flexDirection="column" paddingHorizontal={6} paddingVertical={2}>
-      <Skeleton height={40} light marginBottom={1} width="100%" />
-      <Skeleton height={40} light width="100%" />
-    </Container>
-  );
+  const keyExtractor = (item: NotificationsPreferenceDataType) =>
+    item.attributes['notification-type'];
 
   return (
     <FlatList
       ListEmptyComponent={error ? ListError : ListLoading}
-      contentContainerStyle={{ paddingTop: 16 }}
+      contentContainerStyle={styles.contentContainer}
       data={options}
-      keyExtractor={(item: NotificationsPreferenceDataType) =>
-        item.attributes['notification-type']
-      }
-      renderItem={OptionListItem}
+      keyExtractor={keyExtractor}
+      renderItem={renderItem}
     />
   );
 };
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    paddingTop: 16,
+  },
+});
 
 export default NotificationsSection;

--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -80,6 +80,7 @@ export default function SettingsSection({
   onPressCurrency,
   onPressIcloudBackup,
   onPressNetwork,
+  onPressNotifications,
   onPressShowSecret,
 }) {
   const { wallets } = useWallets();
@@ -180,6 +181,14 @@ export default function SettingsSection({
           <ListItemArrowGroup>
             {networkInfo?.[network]?.name}
           </ListItemArrowGroup>
+        </ListItem>
+        <ListItem
+          icon={<Icon color="settingsTeal" name="bell" />}
+          label="Notifications"
+          onPress={onPressNotifications}
+          testID="notifications-section"
+        >
+          <ListItemArrowGroup />
         </ListItem>
         <ListItem
           icon={<Icon color="settingsTeal" name="eye" />}

--- a/src/components/settings-menu/index.js
+++ b/src/components/settings-menu/index.js
@@ -1,4 +1,5 @@
 export { default as CurrencySection } from './CurrencySection';
 export { default as LanguageSection } from './LanguageSection';
 export { default as NetworkSection } from './NetworkSection';
+export { default as NotificationsSection } from './NotificationsSection';
 export { default as SettingsSection } from './SettingsSection';

--- a/src/screens/SettingsModal.js
+++ b/src/screens/SettingsModal.js
@@ -8,6 +8,7 @@ import {
   CurrencySection,
   LanguageSection,
   NetworkSection,
+  NotificationsSection,
   SettingsSection,
 } from '../components/settings-menu';
 import SettingsBackupView from '../components/settings-menu/BackupSection/SettingsBackupView';
@@ -85,6 +86,11 @@ const SettingsPages = {
     component: NetworkSection,
     key: 'NetworkSection',
     title: 'Network',
+  },
+  notifications: {
+    component: NotificationsSection,
+    key: 'NotificationsSection',
+    title: 'Notifications',
   },
 };
 
@@ -189,6 +195,9 @@ export default function SettingsModal() {
                 onPressDev={onPressSection(SettingsPages.dev)}
                 onPressLanguage={onPressSection(SettingsPages.language)}
                 onPressNetwork={onPressSection(SettingsPages.network)}
+                onPressNotifications={onPressSection(
+                  SettingsPages.notifications
+                )}
               />
             )}
           </Stack.Screen>


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Adds new Notifications Preferences:
- Notifications section to Settings screen;
- Service update on hub-service for getting and updating notif. options;
- Hook useUpdateNotificationPreferences for handling authToken and options state.

Note: Loading the auth token from using getHubAuthToken from hub-services is often failing with the error:
``` ERROR  Failed. {"errors": [{"detail": "Expired nonce", "status": "401", "title": "Invalid signature"}]}```

I'm investigating that now. The error does not seem to be related to this PR.

- [x] Completes #(CS-2569)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

https://user-images.githubusercontent.com/129619/151046073-24cf323f-de80-4584-a78d-f5116aa2d473.mp4

