### PR TITLE
Fix merchant claim notification handling and show local notification on same network and EOA only

### DIFF
--- a/cardstack/src/notification-handler/merchantClaim.ts
+++ b/cardstack/src/notification-handler/merchantClaim.ts
@@ -2,12 +2,14 @@ import { MerchantSafe, NativeCurrency } from '@cardstack/cardpay-sdk';
 import { Navigation } from '@rainbow-me/navigation';
 import { MainRoutes } from '@cardstack/navigation/routes';
 import { updateMerchantSafeWithCustomization } from '@cardstack/utils';
+import store from '@rainbow-me/redux/store';
 import Logger from 'logger';
 import {
   getSafeData,
   getRevenuePoolBalances,
   updateSafeWithTokenPrices,
 } from '@cardstack/services';
+import { MerchantSafeType } from '@cardstack/types';
 import { getNativeCurrency } from '@rainbow-me/handlers/localstorage/globalSettings';
 
 export type MerchantClaimNotificationBody = {
@@ -18,6 +20,21 @@ export const merchantClaimHandler = async (
   data: MerchantClaimNotificationBody
 ) => {
   try {
+    const { merchantSafes } = store.getState().data;
+
+    const merchantData = merchantSafes.find(
+      (merchantSafe: MerchantSafeType) =>
+        merchantSafe.address === data.merchantId
+    );
+
+    if (merchantData) {
+      Navigation.handleAction(MainRoutes.MERCHANT_SCREEN, {
+        merchantSafe: merchantData,
+      });
+
+      return;
+    }
+
     const merchantSafe = (await getSafeData(data.merchantId)) as MerchantSafe;
 
     if (merchantSafe) {

--- a/src/App.js
+++ b/src/App.js
@@ -130,7 +130,7 @@ class App extends Component {
     );
 
     this.backgroundNotificationListener = messaging().setBackgroundMessageHandler(
-      this.onRemoteNotification
+      notificationHandler
     );
 
     messaging().onNotificationOpenedApp(remoteMessage => {


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

- Fixed merchant claim notification handling so it can open Merchant Screen properly from notification when app closed state
- Displayed local notification when notification's network and EOA's matched

Tried to switch account when different EOA notification banner pressed, but it has some difficulties, I think we can tackle this in another ticket

<!-- Include a summary of the changes. -->

- [x] Completes #CS-2617

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Jan-28-2022 19-13-55](https://user-images.githubusercontent.com/16714648/151537525-d3fa065f-9c68-4ce5-be36-b7061ed02d6e.gif)

