### PR TITLE
[CS-2995] Investigate feasibility of onramper

### DIFF
--- a/src/components/settings-menu/DeveloperSettings.js
+++ b/src/components/settings-menu/DeveloperSettings.js
@@ -38,7 +38,7 @@ const DeveloperSettings = () => {
    */
   const openOnramperWebview = useCallback(async () => {
     const params = {
-      apiKey: 'OUR_API_KEY',
+      // apiKey: 'OUR_API_KEY',
       color: '00EBE5', // button color
       wallets: `ETH:${selectedWallet?.addresses?.[0].address}`,
       isAddressEditable: 'false',

--- a/src/components/settings-menu/DeveloperSettings.js
+++ b/src/components/settings-menu/DeveloperSettings.js
@@ -1,6 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import React, { useCallback, useContext } from 'react';
-import { Alert, ScrollView } from 'react-native';
+import { Alert, ScrollView, Linking } from 'react-native';
 import { Restart } from 'react-native-restart';
 import GanacheUtils from '../../../cardstack/src/utils/ganache-utils';
 import { ListFooter, ListItem } from '../list';
@@ -18,7 +18,7 @@ import Routes from '@rainbow-me/routes';
 const DeveloperSettings = () => {
   const { navigate } = useNavigation();
   const { config, setConfig } = useContext(RainbowContext);
-  const { wallets } = useWallets();
+  const { wallets, selectedWallet } = useWallets();
 
   const onNetworkChange = useCallback(
     value => {
@@ -32,6 +32,28 @@ const DeveloperSettings = () => {
       navigate(Routes.PROFILE_SCREEN);
     });
   }, [navigate]);
+
+  /**
+   * Opens Onramper Webview for testing porpuses.
+   */
+  const openOnramperWebview = useCallback(async () => {
+    const params = {
+      apiKey: 'OUR_API_KEY',
+      color: '00EBE5', // button color
+      wallets: `ETH:${selectedWallet?.addresses?.[0].address}`,
+      isAddressEditable: 'false',
+    };
+    // URLSearchParams does not work on Android:
+    // https://github.com/facebook/react-native/issues/23922
+    // const url = new URL(`https://widget.onramper.com`);
+    // url.search = new URLSearchParams(params);
+    // Linking.openURL(url.href);
+    const url = `https://widget.onramper.com?${Object.entries(params)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('&')}`;
+    console.log(url);
+    Linking.openURL(url);
+  }, [selectedWallet]);
 
   const removeBackups = async () => {
     const newWallets = { ...wallets };
@@ -73,6 +95,11 @@ const DeveloperSettings = () => {
         label="‍👾 Connect to ganache"
         onPress={connectToGanache}
         testID="ganache-section"
+      />
+      <ListItem
+        label="🤑 Open Onramper"
+        onPress={openOnramperWebview}
+        testID="onramper-section"
       />
       <ListFooter />
 

--- a/src/components/settings-menu/DeveloperSettings.js
+++ b/src/components/settings-menu/DeveloperSettings.js
@@ -1,6 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import React, { useCallback, useContext } from 'react';
-import { Alert, ScrollView, Linking } from 'react-native';
+import { Alert, Linking, ScrollView } from 'react-native';
 import { Restart } from 'react-native-restart';
 import GanacheUtils from '../../../cardstack/src/utils/ganache-utils';
 import { ListFooter, ListItem } from '../list';


### PR DESCRIPTION
`Onramper` works both with a Widget and an API, so in theory, we could integrate it with our own UI, but only for the first part of the purchase, once users select the gateway we'll have to open a Webview anyways.

That said, the widget looks simpler to integrate and will lead to less maintenance on our end.

While opening the widget, we can set what wallets the funds will be deposited to.

Do we have a production key already? If not, we can request one here: https://docs.google.com/forms/d/e/1FAIpQLSdnmTskkGA5QJGjC1eVRcqXZouuGe_ojltlBFs5nFClrSl_gA/viewform

This PR is a simple POC for integrating Onramper by using the standard Linking API from RN. It's missing our apiKey, so I'm not sure if it will work properly or not. It can be accessed inside our Developer Settings, as in the video below.

- [x] Completes #(CS-2995)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

https://user-images.githubusercontent.com/129619/151373559-50c4d47d-d356-4a09-b78b-6cb794ebfde8.mp4
