### PR TITLE
[CS-2988] Update Service Degradation Banner to have same border radius as the "Prepaid Cards are denominated in Spend" box

### DIFF
--- a/cardstack/src/components/Notice/Notice.tsx
+++ b/cardstack/src/components/Notice/Notice.tsx
@@ -59,7 +59,7 @@ export const Notice = ({
             paddingHorizontal={2}
             marginHorizontal={4}
             marginVertical={2}
-            borderRadius={50}
+            borderRadius={10}
             testID="notice-container"
             backgroundColor={noticeColorConfig[type].backgroundColor}
           >


### PR DESCRIPTION
### Description

Using 10pt for the radius of the notice too.

It would be better to have a generic Card component with these styles attributes.

- [x] Completes #(CS-2988)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

![Screenshot_20220127-114453_Card Wallet](https://user-images.githubusercontent.com/129619/151382112-7a977d2e-5476-4871-ab64-8e70aab5c8e7.jpg)

![Screenshot_20220127-114444_Card Wallet](https://user-images.githubusercontent.com/129619/151382105-7fdbcd77-5a88-4df3-9da8-87dc0977f1ac.jpg)


