### PR TITLE
[CS-2694] Map payment received sheet to merchant spend transaction

### DIFF
--- a/cardstack/src/components/Transactions/Merchant/MerchantEarnedSpendTransaction.tsx
+++ b/cardstack/src/components/Transactions/Merchant/MerchantEarnedSpendTransaction.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+
+import { useNavigation } from '@react-navigation/core';
 import { Icon } from '../../Icon';
 import {
   TransactionBase,
   TransactionBaseCustomizationProps,
+  TransactionBaseProps,
 } from '../TransactionBase';
 import { MerchantEarnedSpendTransactionType } from '@cardstack/types';
+import Routes from '@rainbow-me/routes';
 
 export interface MerchantEarnSpendTransactionProps
   extends TransactionBaseCustomizationProps {
@@ -15,6 +19,16 @@ export const MerchantEarnedSpendTransaction = ({
   item,
   ...props
 }: MerchantEarnSpendTransactionProps) => {
+  const { navigate } = useNavigation();
+
+  const onPressTransaction = useCallback(
+    (transaction: TransactionBaseProps) =>
+      navigate(Routes.PAYMENT_RECEIVED_SHEET, {
+        transaction: { ...transaction, ...item },
+      }),
+    [item, navigate]
+  );
+
   return (
     <TransactionBase
       {...props}
@@ -24,6 +38,7 @@ export const MerchantEarnedSpendTransaction = ({
       statusText="Earned"
       subText={item.nativeBalanceDisplay}
       transactionHash={item.transactionHash}
+      onPressTransaction={onPressTransaction}
     />
   );
 };

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/merchant-earned-spend-strategy.test.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/merchant-earned-spend-strategy.test.ts
@@ -44,12 +44,42 @@ describe('MerchantEarnedSpendStrategy', () => {
     const value = await strategy.mapTransaction();
     expect(value).toEqual({
       address: '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
+      balance: {
+        amount: '1.497005988023952095',
+        display: '1.497 DAI',
+      },
+      fromAddress: '0x72DB39da38fa313A004770E8C4d9416428068024',
+      native: {
+        amount: '0',
+        display: '$0.00 USD',
+      },
+      netEarned: {
+        amount: '1.489520958083832335',
+        display: '1.49 DAI',
+      },
       infoDid: '3a13a41e-e44a-4b0f-b079-2d3d53571870',
       nativeBalanceDisplay: '$1.50 USD',
       spendBalanceDisplay: '§150 SPEND',
       timestamp: '1629156260',
       transactionHash:
         '0x5293d95a240c231852724fd31ff6df119e5b5cf7661a7aec38f7cf10893dc2eb',
+      token: {
+        address: '0xFeDc0c803390bbdA5C4C296776f4b574eC4F30D1',
+        name: 'Dai Stablecoin.CPXD',
+        symbol: 'DAI',
+      },
+      transaction: {
+        customerSpend: '150',
+        customerSpendNative: '$0.00 USD',
+        netEarned: {
+          amount: '1.489520958083832335',
+          display: '1.49 DAI',
+        },
+        netEarnedNativeDisplay: '$1.49 USD',
+        protocolFee: '0.00749 DAI',
+        revenueCollected: '1.497 DAI',
+        spendConversionRate: '$0.01 USD',
+      },
       type: 'merchantEarnedSpend',
     });
   });

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/merchant-earned-spend-strategy.test.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/merchant-earned-spend-strategy.test.ts
@@ -1,6 +1,13 @@
 import { MerchantEarnedSpendStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-spend-strategy';
 import { MERCHANT_EARNED_SPEND_MOCK_DATA } from '@cardstack/utils/__mocks__/merchant-strategies';
 
+const mockServices = jest.requireActual('../../../services');
+jest.mock('../../../services', () => ({
+  ...mockServices,
+  fetchHistoricalPrice: jest.fn().mockReturnValue(Promise.resolve(0)),
+  getNativeBalanceFromOracle: jest.fn().mockReturnValue(0.0000974),
+}));
+
 describe('MerchantEarnedSpendStrategy', () => {
   const contructorParams = {
     accountAddress: '0x64Fbf34FaC77696112F1Abaa69D28211214d76c7',
@@ -75,7 +82,7 @@ describe('MerchantEarnedSpendStrategy', () => {
           amount: '1.489520958083832335',
           display: '1.49 DAI',
         },
-        netEarnedNativeDisplay: '$1.49 USD',
+        netEarnedNativeDisplay: '$0.0000974 USD',
         protocolFee: '0.00749 DAI',
         revenueCollected: '1.497 DAI',
         spendConversionRate: '$0.01 USD',

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-revenue-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/merchant-earned-revenue-strategy.ts
@@ -72,13 +72,7 @@ export class MerchantEarnedRevenueStrategy extends BaseStrategy {
       timestamp: prepaidCardPaymentTransaction.timestamp,
       type: TransactionTypes.MERCHANT_EARNED_REVENUE,
       transactionHash: this.transaction.id,
-      transaction: await getMerchantEarnedTransactionDetails(
-        prepaidCardPaymentTransaction,
-        this.nativeCurrency,
-        convertStringToNumber(nativeBalance.amount),
-        this.currencyConversionRates,
-        symbol
-      ),
+      transaction: transactionDetails,
       infoDid: prepaidCardPaymentTransaction.merchantSafe?.infoDid || undefined,
     };
   }

--- a/cardstack/src/types/transaction-types.ts
+++ b/cardstack/src/types/transaction-types.ts
@@ -192,12 +192,22 @@ export interface MerchantEarnedRevenueTransactionType {
 
 export interface MerchantEarnedSpendTransactionType {
   address: string;
+  fromAddress: string;
+  balance: BalanceType;
+  native: BalanceType;
+  netEarned: BalanceType;
   spendBalanceDisplay: string;
   nativeBalanceDisplay: string;
   timestamp: number;
   type: TransactionTypes.MERCHANT_EARNED_SPEND;
   transactionHash: string;
   infoDid?: string;
+  token: {
+    address: string;
+    name?: string | null;
+    symbol?: string | null;
+  };
+  transaction: MerchantEarnedRevenueTransactionTypeTxn;
 }
 
 export interface MerchantWithdrawType {


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Mapped existing merchant spend transactions to new Payment Received sheet.

just fyi, Payment received sheet overlaps payment history sheet now and I think we can fix it later by converting payment history sheet to new sheet component when update Payment History design as discussed.

<!-- Include a summary of the changes. -->

- [x] Completes #CS-2694

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Jan-28-2022 01-32-08](https://user-images.githubusercontent.com/16714648/151412534-44887172-559c-4865-80ff-e3623efcc4d8.gif)

