### PR TITLE
[CS-3010] Handle maintenance notices in card-wallet

### DIFF
--- a/cardstack/src/components/Notice/Notice.tsx
+++ b/cardstack/src/components/Notice/Notice.tsx
@@ -59,7 +59,7 @@ export const Notice = ({
             paddingHorizontal={2}
             marginHorizontal={4}
             marginVertical={2}
-            borderRadius={50}
+            borderRadius={10}
             testID="notice-container"
             backgroundColor={noticeColorConfig[type].backgroundColor}
           >

--- a/cardstack/src/services/hub-service.ts
+++ b/cardstack/src/services/hub-service.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { HUB_URL, HUB_URL_STAGING } from 'react-native-dotenv';
 import { fromWei, getSDK } from '@cardstack/cardpay-sdk';
 import Web3 from 'web3';
 import { getAllWallets, loadAddress } from '@rainbow-me/model/wallet';
@@ -16,18 +17,15 @@ import { Network } from '@rainbow-me/helpers/networkTypes';
 import HDProvider from '@cardstack/models/hd-provider';
 import { getFCMToken } from '@cardstack/models/firebase';
 
-const HUB_URL_STAGING = 'https://hub-staging.stack.cards';
-const HUB_URL_PROD = 'https://hub.cardstack.com';
-
 const HUBAUTH_PROMPT_MESSAGE =
   'To enable notifications, please authenticate your ownership of this account with the Cardstack Hub server';
 
 export const getHubUrl = (network: Network): string =>
-  network === Network.xdai ? HUB_URL_PROD : HUB_URL_STAGING;
+  network === Network.xdai ? HUB_URL : HUB_URL_STAGING;
 
 const axiosConfig = (authToken: string) => {
   return {
-    baseURL: HUB_URL_PROD,
+    baseURL: HUB_URL,
     headers: {
       'Content-Type': 'application/vnd.api+json',
       Authorization: `Bearer: ${authToken}`,

--- a/cardstack/src/services/service-status-api.ts
+++ b/cardstack/src/services/service-status-api.ts
@@ -1,9 +1,7 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { STATUS_API_BASE_URL } from 'react-native-dotenv';
 import { filterIncident } from './utils/filter-incident';
 import { IncidentType } from '@cardstack/types';
-
-// TODO: Move to .env
-const STATUS_PAGE_URL = 'https://status.cardstack.com/api/v2/';
 
 export enum ServiceStatusTags {
   SERVICE_STATUS = 'SERVICE_STATUS',
@@ -11,13 +9,17 @@ export enum ServiceStatusTags {
 
 export const serviceStatusApi = createApi({
   reducerPath: 'serviceStatusApi',
-  baseQuery: fetchBaseQuery({ baseUrl: STATUS_PAGE_URL }),
+  baseQuery: fetchBaseQuery({ baseUrl: STATUS_API_BASE_URL }),
   tagTypes: [...Object.values(ServiceStatusTags)],
   endpoints: builder => ({
     getServiceStatus: builder.query<IncidentType | null, void>({
-      query: () => '/incidents/unresolved.json',
+      query: () => '/summary.json',
       providesTags: [ServiceStatusTags.SERVICE_STATUS],
-      transformResponse: (response: any) => filterIncident(response.incidents),
+      transformResponse: (response: any) =>
+        filterIncident([
+          ...response.incidents,
+          ...response.scheduled_maintenances,
+        ]),
     }),
   }),
 });

--- a/cardstack/src/services/utils/__tests__/services-utils.test.ts
+++ b/cardstack/src/services/utils/__tests__/services-utils.test.ts
@@ -101,6 +101,11 @@ describe('service utils', () => {
           impact: 'critical',
           started_at: '2021-10-10T10:10:00.001Z',
         },
+        {
+          name: 'Upgrade RPC node',
+          impact: 'maintenance',
+          started_at: '2022-01-25T19:33:29.478Z',
+        },
       ];
 
       expect(filterIncident(incidents)).toStrictEqual({
@@ -126,6 +131,27 @@ describe('service utils', () => {
       ];
 
       expect(filterIncident(incidents)).toBeNull();
+    });
+
+    it('it should return valid incident given list has one or more invalid impact type', async () => {
+      const incidents: IncidentType[] = [
+        {
+          name: 'Internet down.',
+          impact: 'critical',
+          started_at: '2021-10-10T10:10:00.001Z',
+        },
+        {
+          name: 'Not defined',
+          impact: 'not-defined',
+          started_at: '2021-10-10T10:10:00.000Z',
+        },
+      ];
+
+      expect(filterIncident(incidents)).toStrictEqual({
+        name: 'Internet down.',
+        impact: 'critical',
+        started_at: '2021-10-10T10:10:00.001Z',
+      });
     });
   });
 });

--- a/cardstack/src/services/utils/filter-incident.ts
+++ b/cardstack/src/services/utils/filter-incident.ts
@@ -1,20 +1,24 @@
 import { orderBy, filter, includes, indexOf } from 'lodash';
 import { IncidentType } from '@cardstack/types';
 
-const order = ['critical', 'major', 'minor', 'none'];
+const order = ['critical', 'major', 'minor', 'maintenance', 'none'];
 
 export const filterIncident = (
   incidents: IncidentType[]
 ): IncidentType | null => {
-  if (incidents?.length === 0) {
+  const validIncidents = filter(incidents, incident =>
+    includes(order, incident.impact)
+  );
+
+  if (validIncidents?.length === 0) {
     return null;
   }
 
-  const highestImpactPresent = orderBy(incidents, ({ impact }) =>
+  const highestImpactPresent = orderBy(validIncidents, ({ impact }) =>
     indexOf(order, impact)
   )[0].impact;
 
-  const filtered = filter(incidents, ['impact', highestImpactPresent]);
+  const filtered = filter(validIncidents, ['impact', highestImpactPresent]);
 
   const incident = orderBy(filtered, 'started_at', 'desc')[0];
   if (!includes(order, incident.impact)) return null;

--- a/cardstack/src/types/react-native-dotenv.d.ts
+++ b/cardstack/src/types/react-native-dotenv.d.ts
@@ -18,4 +18,7 @@ declare module 'react-native-dotenv' {
   export const WYRE_SECRET_KEY: string;
   export const WYRE_SECRET_KEY_TEST: string;
   export const FIXER_API_KEY: string;
+  export const HUB_URL: string;
+  export const HUB_URL_STAGING: string;
+  export const STATUS_API_BASE_URL: string;
 }


### PR DESCRIPTION
### Description

This PR adds support for Service Maintainance Messages and also improves handling when `impact` is not on our order/showing list.

Important: I moved HUB and service STATUS URLs to .env. So after merging this, everyone needs to sync context.

- [x] Completes #(CS-3010)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/151556098-53ed2434-176f-4e3b-adfb-2af172d57589.jpg">

