### PR TITLE
[CS-2693]: Setup github actions for android release

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   release-android:
     name: Release Android
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     env:
       CRYPTEX_GIT_URL: https://${{ secrets.CI_GITHUB_PERSONAL_ACCESS_TOKEN }}@github.com/${{ secrets.CRYPTEX_GIT_REPOSITORY }}.git
       CRYPTEX_PASSWORD: ${{ secrets.CRYPTEX_PASSWORD }}
@@ -49,10 +49,12 @@ jobs:
         run: yarn postinstall
       - name: Sync google_services
         run: yarn contexts:sync:google_services
+      - name: Sync app_vars
+        run: yarn contexts:app:sync
       - name: Sync google_play_credentials
         run: bundle exec fastlane sync_google_play_credentials
       - name: Run fastlane (android)
-        run: yarn android:publish:internal
+        run: cd android && bundle install && bundle exec fastlane internal
       - uses: actions/upload-artifact@v2
         with:
           name: Android bundle

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -53,6 +53,8 @@ jobs:
         run: yarn contexts:app:sync
       - name: Sync google_play_credentials
         run: bundle exec fastlane sync_google_play_credentials
+      - name: Install NDK
+        run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;20.1.5948944" --sdk_root=${ANDROID_SDK_ROOT}
       - name: Run fastlane (android)
         run: cd android && bundle install && bundle exec fastlane internal
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Sync android_keystore
         run: bundle exec fastlane sync_android_keystore
       - name: Run fastlane (android)
-        run: cd android && bundle install && bundle exec fastlane internal
+        run: cd android && bundle install && bash -c 'set -a && source ../.env && set +a && bundle exec fastlane internal'
       - uses: actions/upload-artifact@v2
         with:
           name: Android bundle

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -50,6 +50,8 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
+      - name: Install NDK
+        run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;20.1.5948944" --sdk_root=${ANDROID_SDK_ROOT}
       - name: Yarn Install
         run: yarn install --network-timeout 300000 --network-concurrency 1
       - name: Yarn Setup
@@ -60,8 +62,6 @@ jobs:
         run: yarn contexts:app:sync
       - name: Sync google_play_credentials
         run: bundle exec fastlane sync_google_play_credentials
-      - name: Install NDK
-        run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;20.1.5948944" --sdk_root=${ANDROID_SDK_ROOT}
       - name: Run fastlane (android)
         run: cd android && bundle install && bundle exec fastlane internal
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -43,6 +43,13 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
       - name: Yarn Install
         run: yarn install --network-timeout 300000 --network-concurrency 1
       - name: Yarn Setup

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -66,6 +66,8 @@ jobs:
         run: yarn contexts:app:sync
       - name: Sync google_play_credentials
         run: bundle exec fastlane sync_google_play_credentials
+      - name: Sync android_keystore
+        run: bundle exec fastlane sync_android_keystore
       - name: Run fastlane (android)
         run: cd android && bundle install && bundle exec fastlane internal
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -50,6 +50,10 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
       - name: Install NDK
         run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;20.1.5948944" --sdk_root=${ANDROID_SDK_ROOT}
       - name: Yarn Install

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,7 +11,10 @@ end
 
 desc "Download encrypted android release keystore"
 lane :sync_android_keystore do
-  if (UI.confirm("This will overwrite your remote release.keystore version at #{'./android/keystores/upload-keystore.jks'} with the file stored in #{ENV['CRYPTEX_GIT_URL']}. Proceed?"))
+  
+  promptMessage = "This will overwrite your remote release.keystore version at #{'./android/keystores/upload-keystore.jks'} with the file stored in #{ENV['CRYPTEX_GIT_URL']}. Proceed?"
+
+  if (is_ci || UI.confirm(promptMessage))
     cryptex(
       type: "export",
       out: './android/keystores/upload-keystore.jks',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,10 @@ end
 
 desc "Download encrypted base app vars"
 lane :sync_app_vars do
-  if (UI.confirm("This will overwrite your local <root>/.env with the file stored in #{ENV['CRYPTEX_GIT_URL']}. Proceed?"))
+  
+  promptMessage = "This will overwrite your local <root>/.env with the file stored in #{ENV['CRYPTEX_GIT_URL']}. Proceed?"
+
+  if (is_ci || UI.confirm(promptMessage))
     app_vars = cryptex(
       type: "export_env",
       key: "app_vars"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "android:clean": "adb uninstall com.cardstack.cardpay || true && yarn android",
     "android:apk": "./scripts/check-env.sh && cd android && bash -c 'set -a && source ../.env && set +a && ./gradlew assembleRelease && (adb uninstall com.cardstack.cardpay || true) && adb install app/build/outputs/apk/release/app-release.apk'",
     "android:bundle": "./scripts/check-env.sh && cd android && bash -c 'set -a && source ../.env && set +a && ./gradlew bundleRelease && open app/build/outputs/bundle/release/'",
-    "android:publish:internal": "./scripts/check-env.sh && cd android && bash -c 'set -a && source ../.env && set +a && bundle exec fastlane internal'",
+    "android:release:internal": "./scripts/check-env.sh && cd android && bash -c 'set -a && source ../.env && set +a && bundle exec fastlane internal'",
     "contexts:app:sync": "bundle exec fastlane sync_app_vars",
     "contexts:app:publish": "bundle exec fastlane publish_app_vars",
     "contexts:app:alpha:sync": "bundle exec fastlane sync_alpha_app_vars",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "android:clean": "adb uninstall com.cardstack.cardpay || true && yarn android",
     "android:apk": "./scripts/check-env.sh && cd android && bash -c 'set -a && source ../.env && set +a && ./gradlew assembleRelease && (adb uninstall com.cardstack.cardpay || true) && adb install app/build/outputs/apk/release/app-release.apk'",
     "android:bundle": "./scripts/check-env.sh && cd android && bash -c 'set -a && source ../.env && set +a && ./gradlew bundleRelease && open app/build/outputs/bundle/release/'",
-    "android:release:internal": "./scripts/check-env.sh && cd android && bash -c 'set -a && source ../.env && set +a && bundle exec fastlane internal'",
+    "android:publish:internal": "./scripts/check-env.sh && cd android && bash -c 'set -a && source ../.env && set +a && bundle exec fastlane internal'",
     "contexts:app:sync": "bundle exec fastlane sync_app_vars",
     "contexts:app:publish": "bundle exec fastlane publish_app_vars",
     "contexts:app:alpha:sync": "bundle exec fastlane sync_alpha_app_vars",


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
This PR fixes the build script to build and release Android to Play Store, for some weird reason Cryptex only works on macOS, and we also need to skip some prompts if we are running in the CI. 

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->


<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/20520102/151615906-8b414fb2-499d-449d-89f2-937e980e048d.png"> 


<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/20520102/151615942-97000035-37ea-4f29-8d31-30326d5e73f9.png"> 


