### PR TITLE
[CS-3057]: Fix restore multiple google drive backups

### DIFF
--- a/cardstack/src/types/react-native-cloud-fs.d.ts
+++ b/cardstack/src/types/react-native-cloud-fs.d.ts
@@ -6,7 +6,7 @@ declare module 'react-native-cloud-fs' {
     lastModified: string;
   }
 
-  interface ListFilesResult {
+  export interface ListFilesResult {
     files: BackupFile[];
   }
 


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

On android we were adding `${REMOTE_BACKUP_WALLET_DIR}` before the file name, and this is only needed for the UserData.json, after a generated backup the filename already contains  the `REMOTE_BACKUP_WALLET_DIR`, so the path was duplicated and it was never being matched,  now with the filenameMatcher we check all possible matches to make sure the document is found. 

<!-- Include a summary of the changes. -->

- [x] Completes #(CS-3057)

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![android-backup](https://user-images.githubusercontent.com/20520102/152416427-a3aa646c-c589-4dad-9c02-e81cf58aa241.gif)

