### PR TITLE
[CS-3075]: Fix crash on backup flow after failing pass fetch

### DIFF
--- a/src/components/backup/BackupCloudStep.tsx
+++ b/src/components/backup/BackupCloudStep.tsx
@@ -9,29 +9,19 @@ import React, {
   useState,
 } from 'react';
 
-import { Keyboard, TextInputProps } from 'react-native';
+import { Keyboard } from 'react-native';
 import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
 import { saveBackupPassword } from '../../model/backup';
 import { DelayedAlert } from '../alerts';
 import BackupSheetKeyboardLayout from './BackupSheetKeyboardLayout';
 import {
-  BaseInputProps,
-  Button,
-  Container,
-  Icon,
-  IconName,
-  IconProps,
-  Input,
-  InputProps,
-  Text,
-} from '@cardstack/components';
-import {
-  cloudBackupPasswordMinLength,
-  isCloudBackupPasswordValid,
-} from '@rainbow-me/handlers/cloudBackup';
+  BackupPasswordButtonFooter,
+  backupPasswordInputProps,
+} from './backupComponentsUtils';
+import { Container, Icon, IconProps, Input, Text } from '@cardstack/components';
+import { isCloudBackupPasswordValid } from '@rainbow-me/handlers/cloudBackup';
 import showWalletErrorAlert from '@rainbow-me/helpers/support';
 import {
-  useBiometryIconName,
   useMagicAutofocus,
   useRouteExistsInNavigationState,
   useWalletCloudBackup,
@@ -56,7 +46,6 @@ export default function BackupCloudStep() {
   const [passwordFocused, setPasswordFocused] = useState(true);
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const biometryIconName = useBiometryIconName();
 
   useEffect(() => {
     if (isDamaged) {
@@ -163,18 +152,6 @@ export default function BackupCloudStep() {
     validPassword && onConfirmBackup();
   }, [onConfirmBackup, validPassword]);
 
-  const biometryIconProps: IconProps | undefined = useMemo(
-    () =>
-      biometryIconName
-        ? {
-            iconSize: 'medium',
-            marginRight: 3,
-            name: biometryIconName as IconName,
-          }
-        : undefined,
-    [biometryIconName]
-  );
-
   const passwordFieldIconProps: IconProps | undefined = useMemo(
     () =>
       isCloudBackupPasswordValid(password)
@@ -195,30 +172,15 @@ export default function BackupCloudStep() {
     [validPassword]
   );
 
-  const sharedPasswordProps: Partial<
-    TextInputProps & InputProps & BaseInputProps
-  > = {
-    autoCompleteType: 'password',
-    blurOnSubmit: false,
-    border: true,
-    marginVertical: 2,
-    passwordRules: `minlength: ${cloudBackupPasswordMinLength};`,
-    secureTextEntry: true,
-    selectTextOnFocus: true,
-    textContentType: 'password',
-  };
-
   return (
     !isWalletLoading && (
       <BackupSheetKeyboardLayout
         footer={
-          validPassword ? (
-            <Button iconProps={biometryIconProps} onPress={onConfirmBackup}>
-              Confirm
-            </Button>
-          ) : (
-            <Text variant="subText">Minimum 8 characters</Text>
-          )
+          <BackupPasswordButtonFooter
+            buttonLabel="Confirm"
+            isValidPassword={validPassword}
+            onButtonPress={onConfirmBackup}
+          />
         }
       >
         <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
@@ -234,7 +196,7 @@ export default function BackupCloudStep() {
           </Container>
           <Container margin={5}>
             <Input
-              {...sharedPasswordProps}
+              {...backupPasswordInputProps}
               iconProps={passwordFieldIconProps}
               onBlur={onPasswordBlur}
               onChange={onPasswordChange}
@@ -247,7 +209,7 @@ export default function BackupCloudStep() {
               value={password}
             />
             <Input
-              {...sharedPasswordProps}
+              {...backupPasswordInputProps}
               iconProps={confirmPasswordFieldIconProps}
               onChange={onConfirmPasswordChange}
               onFocus={onConfirmPasswordFocus}

--- a/src/components/backup/BackupConfirmPasswordStep.tsx
+++ b/src/components/backup/BackupConfirmPasswordStep.tsx
@@ -1,94 +1,35 @@
 import { useRoute } from '@react-navigation/native';
 import lang from 'i18n-js';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import { Keyboard } from 'react-native';
-import styled from 'styled-components';
-import { isSamsungGalaxy } from '../../helpers/samsung';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { saveBackupPassword } from '../../model/backup';
 import { DelayedAlert } from '../alerts';
-import { PasswordField } from '../fields';
-import { Centered, Column } from '../layout';
-import { GradientText } from '../text';
 import BackupSheetKeyboardLayout from './BackupSheetKeyboardLayout';
-import { Button, IconName, IconProps, Text } from '@cardstack/components';
+import {
+  BackupPasswordButtonFooter,
+  backupPasswordInputProps,
+} from './backupComponentsUtils';
+import { Container, Icon, Input, Text } from '@cardstack/components';
 import { Device } from '@cardstack/utils/device';
+import { isCloudBackupPasswordValid } from '@rainbow-me/handlers/cloudBackup';
 import {
-  cloudBackupPasswordMinLength,
-  isCloudBackupPasswordValid,
-} from '@rainbow-me/handlers/cloudBackup';
-import {
-  useBiometryIconName,
-  useBooleanState,
-  useDimensions,
   useRouteExistsInNavigationState,
   useWalletCloudBackup,
   useWallets,
 } from '@rainbow-me/hooks';
 import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
-import { margin, padding } from '@rainbow-me/styles';
 import logger from 'logger';
 
 const { cloudPlatform } = Device;
 
-const DescriptionText = styled(Text).attrs(({ theme: { colors } }) => ({
-  align: 'center',
-  color: colors.alpha(colors.blueGreyDark, 0.5),
-  lineHeight: 'looser',
-  size: 'large',
-}))`
-  ${padding(0, 50)};
-`;
-
-const Masthead = styled(Centered).attrs({
-  direction: 'column',
-})`
-  ${padding(24, 0, 42)}
-  flex-shrink: 0;
-`;
-
-const MastheadIcon = styled(GradientText).attrs({
-  align: 'center',
-  angle: false,
-  colors: ['#FFB114', '#FF54BB', '#00F0FF'],
-  end: { x: 0, y: 0 },
-  letterSpacing: 'roundedTight',
-  size: 52,
-  start: { x: 1, y: 1 },
-  steps: [0, 0.5, 1],
-  weight: 'bold',
-})``;
-
-const Title = styled(Text).attrs({
-  size: 'large',
-  weight: 'bold',
-})`
-  ${margin(15, 0, 12)};
-`;
-
-const samsungGalaxy = (Device.isAndroid && isSamsungGalaxy()) || false;
-
 export default function BackupConfirmPasswordStep() {
-  const { isTinyPhone } = useDimensions();
   const { params } = useRoute();
   const { goBack } = useNavigation();
   const walletCloudBackup = useWalletCloudBackup();
-  const biometryIconName = useBiometryIconName();
-  const [isKeyboardOpen, setIsKeyboardOpen] = useState(false);
+
   const [validPassword, setValidPassword] = useState(false);
-  const [
-    passwordFocused,
-    setPasswordFocused,
-    setPasswordBlurred,
-  ] = useBooleanState(true);
   const [password, setPassword] = useState('');
-  const [label, setLabel] = useState('􀎽 Confirm Backup');
+  const [label, setLabel] = useState('Confirm Backup');
   const passwordRef = useRef<any>();
   const { selectedWallet, setIsWalletLoading } = useWallets();
   const walletId = (params as any)?.walletId || selectedWallet.id;
@@ -98,50 +39,14 @@ export default function BackupConfirmPasswordStep() {
   );
 
   useEffect(() => {
-    const keyboardDidShow = () => {
-      setIsKeyboardOpen(true);
-    };
-
-    const keyboardDidHide = () => {
-      setIsKeyboardOpen(false);
-    };
-
-    const didShowListener = Keyboard.addListener(
-      'keyboardDidShow',
-      keyboardDidShow
-    );
-
-    const didHideListener = Keyboard.addListener(
-      'keyboardDidHide',
-      keyboardDidHide
-    );
-    return () => {
-      didShowListener.remove();
-      didHideListener.remove();
-    };
-  }, []);
-
-  const biometryIconProps: IconProps | undefined = useMemo(
-    () =>
-      biometryIconName
-        ? {
-            iconSize: 'medium',
-            marginRight: 3,
-            name: biometryIconName as IconName,
-          }
-        : undefined,
-    [biometryIconName]
-  );
-
-  useEffect(() => {
     let passwordIsValid = false;
 
     if (isCloudBackupPasswordValid(password)) {
       passwordIsValid = true;
-      setLabel(`􀑙 Add to ${cloudPlatform} Backup`);
+      setLabel(`Add to ${cloudPlatform} Backup`);
     }
     setValidPassword(passwordIsValid);
-  }, [password, passwordFocused]);
+  }, [password]);
 
   const onPasswordChange = useCallback(
     ({ nativeEvent: { text: inputText } }) => {
@@ -187,46 +92,38 @@ export default function BackupConfirmPasswordStep() {
     walletCloudBackup,
     walletId,
   ]);
-
   return (
     <BackupSheetKeyboardLayout
       footer={
-        validPassword ? (
-          <Button iconProps={biometryIconProps} onPress={onSubmit}>
-            {label}
-          </Button>
-        ) : (
-          <Text variant="subText">Minimum 8 characters</Text>
-        )
+        <BackupPasswordButtonFooter
+          buttonLabel={label}
+          isValidPassword={validPassword}
+          onButtonPress={onSubmit}
+        />
       }
     >
-      <Masthead>
-        {(isTinyPhone || samsungGalaxy) && isKeyboardOpen ? null : (
-          <MastheadIcon>􀙶</MastheadIcon>
-        )}
-        <Title>Enter backup password</Title>
-        <DescriptionText>
-          To add this account to your {cloudPlatform} backup, enter your
-          existing backup password
-        </DescriptionText>
-      </Masthead>
-      <Column align="center" flex={1}>
-        <PasswordField
-          autoFocus
-          isInvalid={
-            password !== '' &&
-            password.length < cloudBackupPasswordMinLength &&
-            !passwordRef?.current?.isFocused?.()
-          }
-          onBlur={setPasswordBlurred}
-          onChange={onPasswordChange}
-          onFocus={setPasswordFocused}
-          onSubmitEditing={onSubmit}
-          password={password}
-          placeholder="Backup Password"
-          ref={passwordRef}
-        />
-      </Column>
+      <Container flex={1}>
+        <Container alignItems="center" padding={9}>
+          <Icon color="settingsTeal" iconSize="xl" name="lock" />
+          <Text fontSize={20} margin={4}>
+            Enter backup password
+          </Text>
+          <Text color="blueText" textAlign="center">
+            To add this account to your {cloudPlatform} backup, enter your
+            existing backup password
+          </Text>
+        </Container>
+        <Container margin={4}>
+          <Input
+            {...backupPasswordInputProps}
+            autoFocus
+            onChange={onPasswordChange}
+            onSubmitEditing={onSubmit}
+            placeholder="Backup Password"
+            ref={passwordRef}
+          />
+        </Container>
+      </Container>
     </BackupSheetKeyboardLayout>
   );
 }

--- a/src/components/backup/backupComponentsUtils.tsx
+++ b/src/components/backup/backupComponentsUtils.tsx
@@ -1,0 +1,59 @@
+import React, { useMemo } from 'react';
+import { TextInputProps } from 'react-native';
+import {
+  BaseInputProps,
+  Button,
+  IconName,
+  IconProps,
+  InputProps,
+  Text,
+} from '@cardstack/components';
+import { cloudBackupPasswordMinLength } from '@rainbow-me/handlers/cloudBackup';
+import { useBiometryIconName } from '@rainbow-me/hooks';
+
+export const backupPasswordInputProps: Partial<
+  TextInputProps & InputProps & BaseInputProps
+> = {
+  autoCompleteType: 'password',
+  blurOnSubmit: false,
+  border: true,
+  marginVertical: 2,
+  passwordRules: `minlength: ${cloudBackupPasswordMinLength};`,
+  secureTextEntry: true,
+  selectTextOnFocus: true,
+  textContentType: 'password',
+};
+
+interface BackupButtonFooterProps {
+  buttonLabel: string;
+  onButtonPress: () => void;
+  isValidPassword: boolean;
+}
+
+export const BackupPasswordButtonFooter = ({
+  buttonLabel,
+  onButtonPress,
+  isValidPassword,
+}: BackupButtonFooterProps) => {
+  const biometryIconName = useBiometryIconName();
+
+  const biometryIconProps: IconProps | undefined = useMemo(
+    () =>
+      biometryIconName
+        ? {
+            iconSize: 'medium',
+            marginRight: 3,
+            name: biometryIconName as IconName,
+          }
+        : undefined,
+    [biometryIconName]
+  );
+
+  return isValidPassword ? (
+    <Button iconProps={biometryIconProps} onPress={onButtonPress}>
+      {buttonLabel}
+    </Button>
+  ) : (
+    <Text variant="subText">Minimum 8 characters</Text>
+  );
+};

--- a/src/components/settings-menu/BackupSection/WalletSelectionView.js
+++ b/src/components/settings-menu/BackupSection/WalletSelectionView.js
@@ -170,7 +170,7 @@ const WalletSelectionView = () => {
         <Footer>
           <ButtonPressAnimation onPress={manageCloudBackups}>
             <Text align="center" color="backgroundBlue">
-              􀍢 Manage {Device.cloudPlatform} Backups
+              Manage {Device.cloudPlatform} Backups
             </Text>
           </ButtonPressAnimation>
         </Footer>


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

`BackupConfirmPasswordStep` was using a Cardstack Text component, but receiving invalid props, thus the crash, but this screen also had an outdated layout, so I refactored it and shared a couple of components.

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots


<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

Before: 
<img width="250" alt="Screenshot" src=https://user-images.githubusercontent.com/20520102/152830941-99300322-f949-44be-afb3-ad70749d91a7.PNG>


After: 
<img width="250" alt="Screenshot" src=https://user-images.githubusercontent.com/20520102/152830460-e083db53-72c2-40cd-9562-3a0fc2d5d6dd.PNG>

PS: The minimum text is hidden bc there's a valid password, we just can't see it filled bc of the device's protected screenshot