### PR TITLE
[CS-2813] Android assets cards blend mode

### DIFF
--- a/cardstack/src/components/BalanceCoinRow/BalanceCoinRow.tsx
+++ b/cardstack/src/components/BalanceCoinRow/BalanceCoinRow.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { AssetWithNativeType } from '../../types';
 import {
+  BetterOpacityContainer,
   CenteredContainer,
   Container,
   Icon,
@@ -37,14 +38,12 @@ export const BalanceCoinRow = ({
 
   return (
     <Touchable onPress={onPress}>
-      <Container
+      <BetterOpacityContainer
         alignItems="center"
         width="100%"
         paddingHorizontal={5}
         paddingVertical={2}
         flexDirection="row"
-        needsOffscreenAlphaCompositing
-        renderToHardwareTextureAndroid
       >
         <EditingSelectIcon isEditing={isEditing} selected={selected} />
         <PinnedOrHiddenIcon
@@ -68,7 +67,7 @@ export const BalanceCoinRow = ({
           />
         </Container>
         <HiddenOverlay isEditing={isEditing} hidden={hidden} />
-      </Container>
+      </BetterOpacityContainer>
     </Touchable>
   );
 };

--- a/cardstack/src/components/BalanceCoinRow/BalanceCoinRow.tsx
+++ b/cardstack/src/components/BalanceCoinRow/BalanceCoinRow.tsx
@@ -43,6 +43,8 @@ export const BalanceCoinRow = ({
         paddingHorizontal={5}
         paddingVertical={2}
         flexDirection="row"
+        needsOffscreenAlphaCompositing
+        renderToHardwareTextureAndroid
       >
         <EditingSelectIcon isEditing={isEditing} selected={selected} />
         <PinnedOrHiddenIcon

--- a/cardstack/src/components/BetterOpacityContainer/BetterOpacityContainer.tsx
+++ b/cardstack/src/components/BetterOpacityContainer/BetterOpacityContainer.tsx
@@ -1,3 +1,10 @@
+/**
+ * This Wrap is specificly to solve an Android issue where opacity of several stacked
+ * views blend badly together, which in our case, was occuring on all list row components.
+ * It only wraps a simple Container component and adds props `needsOffscreenAlphaCompositing`
+ * and `renderToHardwareTextureAndroid`.
+ */
+
 import React, { ReactNode } from 'react';
 import { ViewProps } from 'react-native';
 

--- a/cardstack/src/components/BetterOpacityContainer/BetterOpacityContainer.tsx
+++ b/cardstack/src/components/BetterOpacityContainer/BetterOpacityContainer.tsx
@@ -1,0 +1,37 @@
+import React, { ReactNode } from 'react';
+import { ViewProps } from 'react-native';
+
+import {
+  LayoutProps,
+  SpacingProps,
+  PositionProps,
+  BorderProps,
+  BackgroundColorProps,
+} from '@shopify/restyle';
+
+import { Theme } from '../../theme';
+import { Container } from '@cardstack/components';
+
+type RestyleProps = ViewProps &
+  LayoutProps<Theme> &
+  SpacingProps<Theme> &
+  PositionProps<Theme> &
+  BackgroundColorProps<Theme> &
+  BorderProps<Theme>;
+
+interface BetterOpacityContainerProps {
+  children: ReactNode;
+}
+
+export const BetterOpacityContainer = ({
+  children,
+  ...rest
+}: BetterOpacityContainerProps & RestyleProps) => (
+  <Container
+    needsOffscreenAlphaCompositing
+    renderToHardwareTextureAndroid
+    {...rest}
+  >
+    {children}
+  </Container>
+);

--- a/cardstack/src/components/BetterOpacityContainer/index.ts
+++ b/cardstack/src/components/BetterOpacityContainer/index.ts
@@ -1,0 +1,1 @@
+export * from './BetterOpacityContainer';

--- a/cardstack/src/components/CollectibleRow/CollectibleRow.tsx
+++ b/cardstack/src/components/CollectibleRow/CollectibleRow.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { CollectibleImage } from '../../../../src/components/collectible';
 import { CollectibleType } from '@cardstack/types';
-import { Touchable, Container, Text } from '@cardstack/components';
+import {
+  BetterOpacityContainer,
+  Touchable,
+  Container,
+  Text,
+} from '@cardstack/components';
 import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
 import { buildCollectibleName } from '@rainbow-me/helpers/assets';
@@ -17,15 +22,13 @@ export const CollectibleRow = (collectible: CollectibleType) => {
 
   return (
     <Touchable onPress={onPress} marginHorizontal={5} marginVertical={2}>
-      <Container
+      <BetterOpacityContainer
         alignItems="center"
         backgroundColor="white"
         borderRadius={10}
         padding={4}
         width="100%"
         flexDirection="row"
-        renderToHardwareTextureAndroid
-        needsOffscreenAlphaCompositing
       >
         <Container
           width={130}
@@ -45,7 +48,7 @@ export const CollectibleRow = (collectible: CollectibleType) => {
           </Text>
           <Text variant="subText">{collectible.asset_contract?.name}</Text>
         </Container>
-      </Container>
+      </BetterOpacityContainer>
     </Touchable>
   );
 };

--- a/cardstack/src/components/CollectibleRow/CollectibleRow.tsx
+++ b/cardstack/src/components/CollectibleRow/CollectibleRow.tsx
@@ -24,6 +24,8 @@ export const CollectibleRow = (collectible: CollectibleType) => {
         padding={4}
         width="100%"
         flexDirection="row"
+        renderToHardwareTextureAndroid
+        needsOffscreenAlphaCompositing
       >
         <Container
           width={130}

--- a/cardstack/src/components/Depot/Depot.tsx
+++ b/cardstack/src/components/Depot/Depot.tsx
@@ -32,6 +32,8 @@ export const Depot = (depot: DepotProps) => {
           overflow="hidden"
           borderColor="buttonPrimaryBorder"
           width="100%"
+          needsOffscreenAlphaCompositing
+          renderToHardwareTextureAndroid
         >
           <SafeHeader {...depot} onPress={onPress} />
           <Bottom {...depot} />

--- a/cardstack/src/components/Depot/Depot.tsx
+++ b/cardstack/src/components/Depot/Depot.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { HorizontalDivider } from '../HorizontalDivider';
 import { MoreItemsFooter } from '../MoreItemsFooter';
 import {
+  BetterOpacityContainer,
   Container,
   SafeHeader,
   TokenBalance,
@@ -26,18 +27,16 @@ export const Depot = (depot: DepotProps) => {
   return (
     <Container width="100%" paddingHorizontal={4} marginBottom={4}>
       <Touchable width="100%" testID="inventory-card" onPress={onPress}>
-        <Container
+        <BetterOpacityContainer
           backgroundColor="white"
           borderRadius={10}
           overflow="hidden"
           borderColor="buttonPrimaryBorder"
           width="100%"
-          needsOffscreenAlphaCompositing
-          renderToHardwareTextureAndroid
         >
           <SafeHeader {...depot} onPress={onPress} />
           <Bottom {...depot} />
-        </Container>
+        </BetterOpacityContainer>
       </Touchable>
     </Container>
   );

--- a/cardstack/src/components/MerchantSafe/MerchantSafe.tsx
+++ b/cardstack/src/components/MerchantSafe/MerchantSafe.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { ContactAvatar } from '@rainbow-me/components/contacts';
 import {
+  BetterOpacityContainer,
   Container,
   Icon,
   SafeHeader,
@@ -32,13 +33,11 @@ export const MerchantSafe = ({ merchantInfo, ...props }: MerchantSafeProps) => {
   return (
     <Container paddingHorizontal={4} marginBottom={4}>
       <Touchable testID="inventory-card" onPress={onPress}>
-        <Container
+        <BetterOpacityContainer
           backgroundColor="white"
           borderRadius={10}
           overflow="hidden"
           borderColor="buttonPrimaryBorder"
-          renderToHardwareTextureAndroid
-          needsOffscreenAlphaCompositing
         >
           <SafeHeader
             {...props}
@@ -54,7 +53,7 @@ export const MerchantSafe = ({ merchantInfo, ...props }: MerchantSafeProps) => {
             />
             <Bottom slug={merchantInfo?.slug} />
           </Container>
-        </Container>
+        </BetterOpacityContainer>
       </Touchable>
     </Container>
   );

--- a/cardstack/src/components/MerchantSafe/MerchantSafe.tsx
+++ b/cardstack/src/components/MerchantSafe/MerchantSafe.tsx
@@ -37,6 +37,8 @@ export const MerchantSafe = ({ merchantInfo, ...props }: MerchantSafeProps) => {
           borderRadius={10}
           overflow="hidden"
           borderColor="buttonPrimaryBorder"
+          renderToHardwareTextureAndroid
+          needsOffscreenAlphaCompositing
         >
           <SafeHeader
             {...props}

--- a/cardstack/src/components/PrepaidCard/PrepaidCard.tsx
+++ b/cardstack/src/components/PrepaidCard/PrepaidCard.tsx
@@ -126,6 +126,8 @@ export const PrepaidCard = (props: PrepaidCardProps) => {
           borderRadius={20}
           overflow="hidden"
           width={isEditing ? EDITING_COIN_ROW_WIDTH : '100%'}
+          needsOffscreenAlphaCompositing
+          renderToHardwareTextureAndroid
         >
           <CustomizableBackground
             cardCustomization={prepaidCard.cardCustomization}

--- a/cardstack/src/components/PrepaidCard/PrepaidCard.tsx
+++ b/cardstack/src/components/PrepaidCard/PrepaidCard.tsx
@@ -12,7 +12,12 @@ import {
   PinnedHiddenSectionOption,
   usePinnedAndHiddenItemOptions,
 } from '@rainbow-me/hooks';
-import { Container, Icon, ScrollView } from '@cardstack/components';
+import {
+  BetterOpacityContainer,
+  Container,
+  Icon,
+  ScrollView,
+} from '@cardstack/components';
 
 export interface PrepaidCardProps extends PrepaidCardType, ContainerProps {
   networkName: string;
@@ -121,13 +126,11 @@ export const PrepaidCard = (props: PrepaidCardProps) => {
             </CenteredContainer>
           </Container>
         )}
-        <Container
+        <BetterOpacityContainer
           backgroundColor="white"
           borderRadius={20}
           overflow="hidden"
           width={isEditing ? EDITING_COIN_ROW_WIDTH : '100%'}
-          needsOffscreenAlphaCompositing
-          renderToHardwareTextureAndroid
         >
           <CustomizableBackground
             cardCustomization={prepaidCard.cardCustomization}
@@ -140,7 +143,7 @@ export const PrepaidCard = (props: PrepaidCardProps) => {
             networkName={networkName}
           />
           <PrepaidCardInnerBottom {...props} />
-        </Container>
+        </BetterOpacityContainer>
         {isEditing && isHidden && (
           <Container
             backgroundColor="black"

--- a/cardstack/src/components/PrepaidCard/SmallPrepaidCard.tsx
+++ b/cardstack/src/components/PrepaidCard/SmallPrepaidCard.tsx
@@ -6,7 +6,7 @@ import {
   NativeCurrency,
 } from '@cardstack/cardpay-sdk';
 import SVG, { Defs, LinearGradient, Rect, Stop } from 'react-native-svg';
-import { Container, Text } from '@cardstack/components';
+import { BetterOpacityContainer, Container, Text } from '@cardstack/components';
 
 interface SmallPrepaidCardProps {
   /** unique identifier, displayed in top right corner of card */
@@ -21,13 +21,11 @@ interface SmallPrepaidCardProps {
 export const SmallPrepaidCard = (props: SmallPrepaidCardProps) => {
   const { id, spendableBalance } = props;
   return (
-    <Container
+    <BetterOpacityContainer
       width="100%"
       borderWidth={1}
       borderRadius={10}
       borderColor="borderGray"
-      needsOffscreenAlphaCompositing
-      renderToHardwareTextureAndroid
     >
       <Container
         backgroundColor="white"
@@ -40,7 +38,7 @@ export const SmallPrepaidCard = (props: SmallPrepaidCardProps) => {
         <Top id={id} />
         <Bottom spendableBalance={spendableBalance} />
       </Container>
-    </Container>
+    </BetterOpacityContainer>
   );
 };
 

--- a/cardstack/src/components/PrepaidCard/SmallPrepaidCard.tsx
+++ b/cardstack/src/components/PrepaidCard/SmallPrepaidCard.tsx
@@ -26,6 +26,8 @@ export const SmallPrepaidCard = (props: SmallPrepaidCardProps) => {
       borderWidth={1}
       borderRadius={10}
       borderColor="borderGray"
+      needsOffscreenAlphaCompositing
+      renderToHardwareTextureAndroid
     >
       <Container
         backgroundColor="white"

--- a/cardstack/src/components/Transactions/TransactionBase.tsx
+++ b/cardstack/src/components/Transactions/TransactionBase.tsx
@@ -4,6 +4,7 @@ import { Linking } from 'react-native';
 import { Icon, IconName, IconProps } from '../Icon';
 import { ContainerProps } from '../Container';
 import {
+  BetterOpacityContainer,
   Container,
   HorizontalDivider,
   Text,
@@ -93,7 +94,7 @@ export const TransactionBase = (props: TransactionBaseProps) => {
         onPress={handleOnPressTransaction}
         disabled={disabled}
       >
-        <Container
+        <BetterOpacityContainer
           backgroundColor="white"
           borderWidth={includeBorder ? 1 : 0}
           borderRadius={10}
@@ -110,7 +111,7 @@ export const TransactionBase = (props: TransactionBaseProps) => {
               {Footer}
             </>
           )}
-        </Container>
+        </BetterOpacityContainer>
       </Touchable>
     </Container>
   );

--- a/cardstack/src/components/index.ts
+++ b/cardstack/src/components/index.ts
@@ -40,3 +40,4 @@ export * from './BalanceSection';
 export * from './AnimatedPressable';
 export * from './Notice';
 export * from './TabBarIcon';
+export * from './BetterOpacityContainer';


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Android default blend mode for opacity makes some views weird when using `TouchableOpacity`. This PR adds two props to favor compositing "offscreen", to all affected container views under a Touchable, in all components listed in the AssetList screen.

~~I tried creating a wrapper view for both the touchable and container, but I was getting more complex than necessary, especially to use it in the `PrepaidCard` component so I scrapped it.~~ Added wrap specifically for the container with the opacity props, so we don't forget why they are there.

- [x] Completes #(CS-2813)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

Now:

https://user-images.githubusercontent.com/129619/152837008-076aeeca-d28c-439d-8f97-00fbeae02bee.mp4

Before:

https://user-images.githubusercontent.com/129619/152837034-3877bea7-aa51-44b3-a48e-f0cb467012b8.mp4

