### PR TITLE
[CS-2985]: Add UI loadingOverlay instead of using global state

### DIFF
--- a/cardstack/src/navigation/hooks.tsx
+++ b/cardstack/src/navigation/hooks.tsx
@@ -26,6 +26,19 @@ export const useCardstackMainScreens = (Stack: any) =>
 export const useCardstackGlobalScreens = (Stack: any) =>
   getScreens(GlobalRoutes, GlobalScreens, Stack);
 
+// Once we merge the routes, we can type it better
+export const useDismissCurrentRoute = (routeName: string) => {
+  const { goBack } = useNavigation();
+
+  const checkAndDismissCurrentRoute = useCallback(() => {
+    if (Navigation.getActiveRouteName() === routeName) {
+      goBack();
+    }
+  }, [goBack, routeName]);
+
+  return checkAndDismissCurrentRoute;
+};
+
 const defaulLoadingtMessage = {
   title: 'Processing Transaction',
 };
@@ -36,7 +49,11 @@ interface ShowOverlayParams {
 }
 
 export const useLoadingOverlay = () => {
-  const { navigate, goBack } = useNavigation();
+  const { navigate } = useNavigation();
+
+  const dismissLoadingOverlay = useDismissCurrentRoute(
+    MainRoutes.LOADING_OVERLAY
+  );
 
   const showLoadingOverlay = useCallback(
     ({ title, subTitle }: ShowOverlayParams = defaulLoadingtMessage) => {
@@ -47,12 +64,6 @@ export const useLoadingOverlay = () => {
     },
     [navigate]
   );
-
-  const dismissLoadingOverlay = useCallback(() => {
-    if (Navigation.getActiveRouteName() === MainRoutes.LOADING_OVERLAY) {
-      goBack();
-    }
-  }, [goBack]);
 
   return { showLoadingOverlay, dismissLoadingOverlay };
 };

--- a/cardstack/src/navigation/hooks.tsx
+++ b/cardstack/src/navigation/hooks.tsx
@@ -30,11 +30,16 @@ const defaulLoadingtMessage = {
   title: 'Processing Transaction',
 };
 
+interface ShowOverlayParams {
+  title: string;
+  subTitle?: string;
+}
+
 export const useLoadingOverlay = () => {
   const { navigate, goBack } = useNavigation();
 
   const showLoadingOverlay = useCallback(
-    ({ title, subTitle } = defaulLoadingtMessage) => {
+    ({ title, subTitle }: ShowOverlayParams = defaulLoadingtMessage) => {
       navigate(MainRoutes.LOADING_OVERLAY, {
         title,
         subTitle,

--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -22,4 +22,5 @@ export const GlobalRoutes = {
   CONFIRM_REQUEST: 'ConfirmRequest',
   SHOW_QRCODE_MODAL: 'ShowQRCodeModal',
   CURRENCY_SELECTION_MODAL: 'CurrencySelectionModal',
+  LOADING_OVERLAY: 'LoadingOverlay',
 } as const;

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -48,8 +48,14 @@ export interface ScreenNavigation {
 // Native iOS custom option, should be removed after deleting NativeStack
 const nativeStackiOSLoadingConfig = {
   customStack: true,
-  // onAppear: null,
+  onAppear: null,
+  allowsDragToDismiss: false,
+  allowsTapToDismiss: false,
+  onTouchTop: null,
   transitionDuration: 0,
+  onWillDismiss: null,
+  dismissable: false,
+  gesturedEnabled: false,
 };
 
 // Shareable component,

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -45,6 +45,27 @@ export interface ScreenNavigation {
   listeners?: ScreenListeners<NavigationState, StackNavigationEventMap>;
 }
 
+// Native iOS custom option, should be removed after deleting NativeStack
+const nativeStackiOSLoadingConfig = {
+  customStack: true,
+  // onAppear: null,
+  transitionDuration: 0,
+};
+
+// Shareable component,
+// for now android needs on MainStack and iOS on GlobalStack
+const LoadingOverlayComponent = {
+  LOADING_OVERLAY: {
+    component: LoadingOverlayScreen,
+    options: {
+      ...overlayPreset,
+      gestureEnabled: false,
+
+      ...(Device.isIOS ? nativeStackiOSLoadingConfig : {}),
+    } as StackNavigationOptions,
+  },
+};
+
 export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
   DEPOT_SCREEN: { component: DepotScreen, options: horizontalInterpolator },
   MERCHANT_SCREEN: {
@@ -80,10 +101,6 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
     component: ErrorFallbackScreen,
     options: { ...overlayPreset, gestureEnabled: false },
   },
-  LOADING_OVERLAY: {
-    component: LoadingOverlayScreen,
-    options: { ...overlayPreset, gestureEnabled: false },
-  },
   WELCOME_SCREEN: {
     component: WelcomeScreen,
   },
@@ -116,8 +133,10 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
       ? bottomSheetPreset
       : wcPromptPreset) as StackNavigationOptions,
   },
+  ...LoadingOverlayComponent,
 };
 
+// @ts-expect-error it alows undefined for temp solution on loadingOverlay, will be removed on nav redesign
 export const GlobalScreens: Record<
   keyof typeof GlobalRoutes,
   ScreenNavigation
@@ -138,6 +157,7 @@ export const GlobalScreens: Record<
       interactWithScrollView: false,
     } as StackNavigationOptions,
   },
+  ...(Device.isIOS ? LoadingOverlayComponent : {}),
 };
 
 // TODO: Merge paths once, navigation redesign happens

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -59,7 +59,9 @@ const nativeStackiOSLoadingConfig = {
 };
 
 // Shareable component,
-// for now android needs on MainStack and iOS on GlobalStack
+// for now android/ios needs on MainStack
+// and iOS only on GlobalStack
+// the navigator looks for the nearest route
 const LoadingOverlayComponent = {
   LOADING_OVERLAY: {
     component: LoadingOverlayScreen,

--- a/cardstack/src/screens/sheets/UnclaimedRevenue/useClaimAllRevenue.ts
+++ b/cardstack/src/screens/sheets/UnclaimedRevenue/useClaimAllRevenue.ts
@@ -25,8 +25,6 @@ export const useClaimAllRevenue = ({
   ] = useClaimRevenueMutation();
 
   const onClaimAllPress = useCallback(() => {
-    goBack();
-
     showLoadingOverlay({ title: 'Claiming Revenue' });
 
     claimRevenue({
@@ -39,7 +37,6 @@ export const useClaimAllRevenue = ({
   }, [
     accountAddress,
     claimRevenue,
-    goBack,
     merchantSafe.address,
     merchantSafe.revenueBalances,
     network,
@@ -54,6 +51,8 @@ export const useClaimAllRevenue = ({
   useEffect(() => {
     if (isSuccess && hasUpdated) {
       dismissLoadingOverlay();
+
+      goBack();
     }
   }, [
     dismissLoadingOverlay,

--- a/cardstack/src/test-utils/jest-setup.js
+++ b/cardstack/src/test-utils/jest-setup.js
@@ -164,6 +164,11 @@ jest.mock('@rainbow-me/redux/uniswap', () => ({
   default: jest.fn(),
 }));
 
+jest.mock('@rainbow-me/utils', () => ({
+  magicMemo: jest.fn(),
+  neverRerender: jest.fn(),
+}));
+
 jest.mock('@rainbow-me/utils/safeAreaInsetValues', () => ({
   default: jest.fn(),
 }));

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -21,7 +21,7 @@ import {
 } from '@rainbow-me/helpers/emojiHandler';
 import { useAccountProfile, useBiometryIconName } from '@rainbow-me/hooks';
 
-import { useNavigation } from '@rainbow-me/navigation';
+import { Navigation, useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
 import { padding } from '@rainbow-me/styles';
 
@@ -67,32 +67,41 @@ export default function WalletProfileState({
   );
   const inputRef = useRef(null);
 
-  const handleCancel = useCallback(() => {
-    goBack();
+  const dismissProfileModal = useCallback(() => {
+    if (Navigation.getActiveRouteName() === Routes.MODAL_SCREEN) {
+      goBack();
+    }
+  }, [goBack]);
+
+  const goToChangeWalletOnCreate = useCallback(() => {
     if (actionType === 'Create') {
       navigate(Routes.CHANGE_WALLET_SHEET);
     }
-  }, [actionType, goBack, navigate]);
+  }, [actionType, navigate]);
 
-  const handleSubmit = useCallback(() => {
-    onCloseModal({
+  const handleCancel = useCallback(() => {
+    dismissProfileModal();
+
+    goToChangeWalletOnCreate();
+  }, [dismissProfileModal, goToChangeWalletOnCreate]);
+
+  const handleSubmit = useCallback(async () => {
+    dismissProfileModal();
+
+    await onCloseModal({
       color,
       name: nameEmoji ? `${nameEmoji} ${value}` : value,
     });
 
-    // Dismiss WalletProfileModal
-    goBack();
-
-    if (actionType === 'Create' && isNewProfile) {
-      navigate(Routes.CHANGE_WALLET_SHEET);
+    if (isNewProfile) {
+      goToChangeWalletOnCreate();
     }
   }, [
-    actionType,
     color,
-    goBack,
+    dismissProfileModal,
     isNewProfile,
     nameEmoji,
-    navigate,
+    goToChangeWalletOnCreate,
     onCloseModal,
     value,
   ]);

--- a/src/components/expanded-state/WalletProfileState.js
+++ b/src/components/expanded-state/WalletProfileState.js
@@ -14,6 +14,7 @@ import {
   Text,
   TruncatedAddress,
 } from '@cardstack/components';
+import { useDismissCurrentRoute } from '@cardstack/navigation';
 import theme from '@cardstack/theme';
 import {
   removeFirstEmojiFromString,
@@ -21,7 +22,7 @@ import {
 } from '@rainbow-me/helpers/emojiHandler';
 import { useAccountProfile, useBiometryIconName } from '@rainbow-me/hooks';
 
-import { Navigation, useNavigation } from '@rainbow-me/navigation';
+import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
 import { padding } from '@rainbow-me/styles';
 
@@ -54,8 +55,10 @@ export default function WalletProfileState({
   profile,
 }) {
   const nameEmoji = returnStringFirstEmoji(profile?.name);
-  const { goBack, navigate } = useNavigation();
+  const { navigate } = useNavigation();
   const { accountImage } = useAccountProfile();
+
+  const dismissProfileModal = useDismissCurrentRoute(Routes.MODAL_SCREEN);
 
   const { colors } = useTheme();
   const [color, setColor] = useState(
@@ -66,12 +69,6 @@ export default function WalletProfileState({
     profile?.name ? removeFirstEmojiFromString(profile.name).join('') : ''
   );
   const inputRef = useRef(null);
-
-  const dismissProfileModal = useCallback(() => {
-    if (Navigation.getActiveRouteName() === Routes.MODAL_SCREEN) {
-      goBack();
-    }
-  }, [goBack]);
 
   const goToChangeWalletOnCreate = useCallback(() => {
     if (actionType === 'Create') {

--- a/src/hooks/useInitializeWallet.js
+++ b/src/hooks/useInitializeWallet.js
@@ -17,6 +17,7 @@ import useLoadCoingeckoCoins from './useLoadCoingeckoCoins';
 import useLoadGlobalData from './useLoadGlobalData';
 import useResetAccountState from './useResetAccountState';
 import { checkPushPermissionAndRegisterToken } from '@cardstack/models/firebase';
+import { useLoadingOverlay } from '@cardstack/navigation';
 import { appStateUpdate } from '@cardstack/redux/appState';
 import { getCurrencyConversionsRates } from '@cardstack/services';
 import { setCurrencyConversionRates } from '@rainbow-me/redux/currencyConversion';
@@ -24,14 +25,16 @@ import logger from 'logger';
 
 export default function useInitializeWallet() {
   const dispatch = useDispatch();
+
   const resetAccountState = useResetAccountState();
   const loadAccountData = useLoadAccountData();
   const loadCoingeckoCoins = useLoadCoingeckoCoins();
   const loadGlobalData = useLoadGlobalData();
   const initializeAccountData = useInitializeAccountData();
+  const hideSplashScreen = useHideSplashScreen();
 
   const { network } = useAccountSettings();
-  const hideSplashScreen = useHideSplashScreen();
+  const { dismissLoadingOverlay } = useLoadingOverlay();
 
   const initializeWallet = useCallback(
     async ({
@@ -127,17 +130,20 @@ export default function useInitializeWallet() {
         Alert.alert('Something went wrong while importing. Please try again!');
         dispatch(appStateUpdate({ walletReady: true }));
         return null;
+      } finally {
+        dismissLoadingOverlay();
       }
     },
     [
       resetAccountState,
+      dispatch,
       loadCoingeckoCoins,
       network,
-      dispatch,
       hideSplashScreen,
       initializeAccountData,
       loadGlobalData,
       loadAccountData,
+      dismissLoadingOverlay,
     ]
   );
 

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -39,7 +39,6 @@ import {
   isValidMnemonic,
 } from '../handlers/web3';
 import showWalletErrorAlert from '../helpers/support';
-import WalletLoadingStates from '../helpers/walletLoadingStates';
 import { EthereumWalletType } from '../helpers/walletTypes';
 import store from '../redux/store';
 import { setIsWalletLoading } from '../redux/wallets';
@@ -671,16 +670,7 @@ export const createWallet = async (
         try {
           userPIN = await getExistingPIN();
           if (!userPIN) {
-            // We gotta dismiss the modal before showing the PIN screen
-            dispatch(setIsWalletLoading(null));
             userPIN = await authenticateWithPIN();
-            dispatch(
-              setIsWalletLoading(
-                seed
-                  ? WalletLoadingStates.IMPORTING_WALLET
-                  : WalletLoadingStates.CREATING_WALLET
-              )
-            );
           }
         } catch (e) {
           return null;

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -943,11 +943,7 @@ export const generateAccount = async (
       // Fallback to custom PIN
       if (!hasBiometricsEnabled) {
         try {
-          const { dispatch } = store;
-          // Hide the loading overlay while showing the pin auth screen
-          dispatch(setIsWalletLoading(null));
           userPIN = await authenticateWithPIN();
-          dispatch(setIsWalletLoading(WalletLoadingStates.CREATING_WALLET));
         } catch (e) {
           return null;
         }

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -40,8 +40,6 @@ import {
 } from '../handlers/web3';
 import showWalletErrorAlert from '../helpers/support';
 import { EthereumWalletType } from '../helpers/walletTypes';
-import store from '../redux/store';
-import { setIsWalletLoading } from '../redux/wallets';
 import { getRandomColor } from '../styles/colors';
 import { ethereumUtils } from '../utils';
 import {
@@ -624,7 +622,6 @@ export const createWallet = async (
   const walletSeed = seed || generateMnemonic();
 
   const addresses: RainbowAccount[] = [];
-  const { dispatch } = store;
 
   try {
     // Wallet can be checked while importing,
@@ -780,8 +777,6 @@ export const createWallet = async (
     logger.sentry('Error in createWallet', error);
     captureException(error);
     return null;
-  } finally {
-    dispatch(setIsWalletLoading(null));
   }
 };
 

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -32,6 +32,7 @@ import {
 import { getRandomColor } from '../styles/colors';
 import { Container, Sheet, Text, Touchable } from '@cardstack/components';
 import { removeFCMToken } from '@cardstack/models/firebase';
+import { useLoadingOverlay } from '@cardstack/navigation';
 import { getAddressPreview } from '@cardstack/utils';
 import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
 import {
@@ -79,6 +80,8 @@ export default function ChangeWalletSheet() {
   const apolloClient = useApolloClient();
 
   const walletRowCount = useMemo(() => getWalletRowCount(wallets), [wallets]);
+
+  const { showLoadingOverlay, dismissLoadingOverlay } = useLoadingOverlay();
 
   const deviceHeight = deviceUtils.dimensions.height;
   const footerHeight = 160;
@@ -318,7 +321,10 @@ export default function ChangeWalletSheet() {
             isNewProfile: true,
             onCloseModal: async args => {
               if (args) {
-                setIsWalletLoading(WalletLoadingStates.CREATING_WALLET);
+                showLoadingOverlay({
+                  title: WalletLoadingStates.CREATING_WALLET,
+                });
+
                 const name = get(args, 'name', '');
                 const color = get(args, 'color', getRandomColor());
                 // Check if the selected wallet is the primary
@@ -397,7 +403,8 @@ export default function ChangeWalletSheet() {
                 }
               }
               creatingWallet.current = false;
-              setIsWalletLoading(null);
+
+              dismissLoadingOverlay();
             },
             profile: {
               color: null,
@@ -408,10 +415,11 @@ export default function ChangeWalletSheet() {
         }, 50);
       });
     } catch (e) {
-      setIsWalletLoading(null);
+      dismissLoadingOverlay();
       logger.log('Error while trying to add account', e);
     }
   }, [
+    dismissLoadingOverlay,
     dispatch,
     goBack,
     initializeWallet,
@@ -419,7 +427,7 @@ export default function ChangeWalletSheet() {
     navigate,
     selectedWallet.id,
     selectedWallet.primary,
-    setIsWalletLoading,
+    showLoadingOverlay,
     wallets,
   ]);
 

--- a/src/screens/PinAuthenticationScreen.js
+++ b/src/screens/PinAuthenticationScreen.js
@@ -12,8 +12,9 @@ import {
 } from '../handlers/localstorage/globalSettings';
 import { useDimensions, useShakeAnimation } from '../hooks';
 import { useBlockBackButton } from '../hooks/useBlockBackButton';
-import Navigation, { useNavigation } from '../navigation/Navigation';
+import { useNavigation } from '../navigation/Navigation';
 import { CenteredContainer, Icon, Text } from '@cardstack/components';
+import { useDismissCurrentRoute } from '@cardstack/navigation';
 import { colors } from '@cardstack/theme';
 import Routes from '@rainbow-me/navigation/routesNames';
 import { padding } from '@rainbow-me/styles';
@@ -28,7 +29,7 @@ const TIMELOCK_INTERVAL_MINUTES = 5;
 const PinAuthenticationScreen = () => {
   useBlockBackButton();
   const { params } = useRoute();
-  const { goBack, setParams } = useNavigation();
+  const { setParams } = useNavigation();
   const [errorAnimation, onShake] = useShakeAnimation();
 
   const { isNarrowPhone, isSmallPhone, isTallPhone } = useDimensions();
@@ -40,11 +41,9 @@ const PinAuthenticationScreen = () => {
     params.validPin ? 'authentication' : 'creation'
   );
 
-  const dismissPinScreen = useCallback(() => {
-    if (Navigation.getActiveRouteName() === Routes.PIN_AUTHENTICATION_SCREEN) {
-      goBack();
-    }
-  }, [goBack]);
+  const dismissPinScreen = useDismissCurrentRoute(
+    Routes.PIN_AUTHENTICATION_SCREEN
+  );
 
   const finished = useRef(false);
 
@@ -100,7 +99,7 @@ const PinAuthenticationScreen = () => {
     };
 
     checkTimelock();
-  }, [dismissPinScreen, goBack, params]);
+  }, [dismissPinScreen, params]);
 
   useEffect(() => {
     if (attemptsLeft === 0) {
@@ -114,7 +113,7 @@ const PinAuthenticationScreen = () => {
       finished.current = true;
       dismissPinScreen();
     }
-  }, [attemptsLeft, dismissPinScreen, goBack, params]);
+  }, [attemptsLeft, dismissPinScreen, params]);
 
   const handleNumpadPress = useCallback(
     newValue => {

--- a/src/screens/PinAuthenticationScreen.js
+++ b/src/screens/PinAuthenticationScreen.js
@@ -12,9 +12,10 @@ import {
 } from '../handlers/localstorage/globalSettings';
 import { useDimensions, useShakeAnimation } from '../hooks';
 import { useBlockBackButton } from '../hooks/useBlockBackButton';
-import { useNavigation } from '../navigation/Navigation';
+import Navigation, { useNavigation } from '../navigation/Navigation';
 import { CenteredContainer, Icon, Text } from '@cardstack/components';
 import { colors } from '@cardstack/theme';
+import Routes from '@rainbow-me/navigation/routesNames';
 import { padding } from '@rainbow-me/styles';
 
 const layouts = {
@@ -38,6 +39,12 @@ const PinAuthenticationScreen = () => {
   const [actionType, setActionType] = useState(
     params.validPin ? 'authentication' : 'creation'
   );
+
+  const dismissPinScreen = useCallback(() => {
+    if (Navigation.getActiveRouteName() === Routes.PIN_AUTHENTICATION_SCREEN) {
+      goBack();
+    }
+  }, [goBack]);
 
   const finished = useRef(false);
 
@@ -84,7 +91,7 @@ const PinAuthenticationScreen = () => {
           );
           params.onCancel();
           finished.current = true;
-          goBack();
+          dismissPinScreen();
         } else {
           await saveAuthTimelock(null);
           await savePinAuthAttemptsLeft(null);
@@ -93,7 +100,7 @@ const PinAuthenticationScreen = () => {
     };
 
     checkTimelock();
-  }, [goBack, params]);
+  }, [dismissPinScreen, goBack, params]);
 
   useEffect(() => {
     if (attemptsLeft === 0) {
@@ -105,9 +112,9 @@ const PinAuthenticationScreen = () => {
       saveAuthTimelock(Date.now() + TIMELOCK_INTERVAL_MINUTES * 60 * 1000);
       params.onCancel();
       finished.current = true;
-      goBack();
+      dismissPinScreen();
     }
-  }, [attemptsLeft, goBack, params]);
+  }, [attemptsLeft, dismissPinScreen, goBack, params]);
 
   const handleNumpadPress = useCallback(
     newValue => {
@@ -146,7 +153,7 @@ const PinAuthenticationScreen = () => {
               params.onSuccess(nextValue);
               finished.current = true;
               setTimeout(() => {
-                goBack();
+                dismissPinScreen();
               }, 300);
             }
           } else if (actionType === 'creation') {
@@ -168,7 +175,7 @@ const PinAuthenticationScreen = () => {
               params.onSuccess(nextValue);
               finished.current = true;
               setTimeout(() => {
-                goBack();
+                dismissPinScreen();
               }, 300);
             }
           }
@@ -177,7 +184,7 @@ const PinAuthenticationScreen = () => {
         return nextValue;
       });
     },
-    [actionType, attemptsLeft, goBack, initialPin, onShake, params]
+    [actionType, attemptsLeft, dismissPinScreen, initialPin, onShake, params]
   );
 
   return (

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -30,8 +30,10 @@ import {
   SystemNotification,
   Text,
 } from '@cardstack/components';
+import { useLoadingOverlay } from '@cardstack/navigation';
 import { colors } from '@cardstack/theme';
 import { isLayer2, NOTIFICATION_KEY } from '@cardstack/utils';
+import walletLoadingStates from '@rainbow-me/helpers/walletLoadingStates';
 import { useNavigation } from '@rainbow-me/navigation';
 import { position } from '@rainbow-me/styles';
 
@@ -62,6 +64,7 @@ export default function WalletScreen() {
 
   const navigation = useNavigation();
   const { editing, toggle } = usePinnedAndHiddenItemOptions();
+  const { showLoadingOverlay } = useLoadingOverlay();
 
   const setNotifications = async () => {
     try {
@@ -91,11 +94,17 @@ export default function WalletScreen() {
 
   useEffect(() => {
     if (!initialized) {
+      const isCreatingWallet = params?.emptyWallet;
+
+      if (isCreatingWallet) {
+        showLoadingOverlay({ title: walletLoadingStates.CREATING_WALLET });
+      }
+
       initializeWallet();
       setInitialized(true);
       setNotifications();
     }
-  }, [initializeWallet, initialized, params]);
+  }, [initializeWallet, initialized, params, showLoadingOverlay]);
 
   // Show the exchange fab only for supported networks
   // (mainnet & rinkeby)


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR fixes the deleting with PIN case, the problem was caused by using the global setIsWalletLoading state, which replaces the whole navigation with a `Portal` component. In order to prevent this issue on other flows I replaced all the possible global states with the loading overlay, unfortunately there's one piece missing, it's the restore/backup icloud flow within the Setting flow.  The settings flow is a complex nested navigator which turns out to be challenging to apply the loading overlay. Since the backup flow is going to be rewritten we can wait until then to remove this last occurrence of the Portal. I recorded just the deleting scenario, but I tested all the other ones but any new tests are welcome! 

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![deleting-pin-acc](https://user-images.githubusercontent.com/20520102/152864657-324bc155-3826-4bec-8018-1039eb47f9d8.gif)

