### PR TITLE
[CS-2818]: Fix "random" PIN screen on fresh account

### DIFF
--- a/cardstack/src/components/Sheet/Sheet.tsx
+++ b/cardstack/src/components/Sheet/Sheet.tsx
@@ -15,7 +15,7 @@ const styles = StyleSheet.create({
   wrapperBase: {
     justifyContent: 'flex-end',
     backgroundColor: 'white',
-    minHeight: '30%',
+    minHeight: '40%',
   },
 });
 

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -48,8 +48,14 @@ export interface ScreenNavigation {
 // Native iOS custom option, should be removed after deleting NativeStack
 const nativeStackiOSLoadingConfig = {
   customStack: true,
-  // onAppear: null,
+  onAppear: null,
+  allowsDragToDismiss: false,
+  allowsTapToDismiss: false,
+  onTouchTop: null,
   transitionDuration: 0,
+  onWillDismiss: null,
+  dismissable: false,
+  gesturedEnabled: false,
 };
 
 // Shareable component,

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -59,7 +59,9 @@ const nativeStackiOSLoadingConfig = {
 };
 
 // Shareable component,
-// for now android needs on MainStack and iOS on GlobalStack
+// for now android/ios needs on MainStack
+// and iOS only on GlobalStack
+// the navigator looks for the nearest route
 const LoadingOverlayComponent = {
   LOADING_OVERLAY: {
     component: LoadingOverlayScreen,

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -48,20 +48,12 @@ export interface ScreenNavigation {
 // Native iOS custom option, should be removed after deleting NativeStack
 const nativeStackiOSLoadingConfig = {
   customStack: true,
-  onAppear: null,
-  allowsDragToDismiss: false,
-  allowsTapToDismiss: false,
-  onTouchTop: null,
+  // onAppear: null,
   transitionDuration: 0,
-  onWillDismiss: null,
-  dismissable: false,
-  gesturedEnabled: false,
 };
 
 // Shareable component,
-// for now android/ios needs on MainStack
-// and iOS only on GlobalStack
-// the navigator looks for the nearest route
+// for now android needs on MainStack and iOS on GlobalStack
 const LoadingOverlayComponent = {
   LOADING_OVERLAY: {
     component: LoadingOverlayScreen,

--- a/src/handlers/authentication.js
+++ b/src/handlers/authentication.js
@@ -37,7 +37,7 @@ export async function savePIN(pin) {
   }
 }
 
-export async function authenticateWithPIN() {
+export async function authenticateWithPIN(promptMessage) {
   let validPin;
   try {
     validPin = await getExistingPIN();
@@ -58,6 +58,7 @@ export async function authenticateWithPIN() {
         resolve(pin);
       },
       validPin,
+      promptMessage,
     });
   });
 }

--- a/src/helpers/walletLoadingStates.ts
+++ b/src/helpers/walletLoadingStates.ts
@@ -5,4 +5,5 @@ export default {
   FETCHING_PASSWORD: 'Fetching Password...',
   IMPORTING_WALLET: 'Importing...',
   RESTORING_WALLET: 'Restoring...',
+  SWITCHING_ACCOUNT: 'Switching account...',
 };

--- a/src/hooks/useInitializeWallet.js
+++ b/src/hooks/useInitializeWallet.js
@@ -110,17 +110,13 @@ export default function useInitializeWallet() {
 
         hideSplashScreen();
         logger.sentry('Hide splash screen');
-        initializeAccountData();
+        await initializeAccountData();
+
+        logger.log('💰 Wallet initialized');
+        await checkPushPermissionAndRegisterToken(walletAddress, seedPhrase);
 
         dispatch(appStateUpdate({ walletReady: true }));
 
-        logger.log('💰 Wallet initialized');
-        setTimeout(
-          () => {
-            checkPushPermissionAndRegisterToken(walletAddress, seedPhrase);
-          },
-          isNew ? 1000 : 0 // hub auth fails if we try too soon after wallet created
-        );
         return walletAddress;
       } catch (error) {
         logger.sentry('Error while initializing wallet', error);

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -385,13 +385,6 @@ export const signTypedDataMessage = async (
   }
 };
 
-export const oldLoadSeedPhrase = async (): Promise<null | EthereumWalletSeed> => {
-  const seedPhrase = await keychain.loadString(seedPhraseKey, {
-    authenticationPrompt,
-  });
-  return seedPhrase as string | null;
-};
-
 export const loadAddress = (): Promise<null | EthereumAddress> =>
   keychain.loadString(addressKey) as Promise<string | null>;
 
@@ -1032,7 +1025,7 @@ export const loadSeedPhrase = async (
       // Fallback to custom PIN
       if (!hasBiometricsEnabled) {
         try {
-          const userPIN = await authenticateWithPIN();
+          const userPIN = await authenticateWithPIN(promptMessage);
           if (userPIN) {
             const decryptedSeed = await encryptor.decrypt(userPIN, seedPhrase);
             return decryptedSeed;

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -103,6 +103,7 @@ export default function ChangeWalletSheet() {
       if (editMode && !fromDeletion) return;
       if (address === currentAddress) return;
       try {
+        showLoadingOverlay({ title: WalletLoadingStates.SWITCHING_ACCOUNT });
         // Nuke apollo data to refetch after changing account
         await apolloClient.clearStore();
         const wallet = wallets[walletId];
@@ -112,19 +113,23 @@ export default function ChangeWalletSheet() {
         const p2 = dispatch(addressSetSelected(address));
         await Promise.all([p1, p2]);
 
-        initializeWallet();
+        await initializeWallet();
         !fromDeletion && goBack();
       } catch (e) {
         logger.log('error while switching account', e);
+      } finally {
+        dismissLoadingOverlay();
       }
     },
     [
       apolloClient,
       currentAddress,
+      dismissLoadingOverlay,
       dispatch,
       editMode,
       goBack,
       initializeWallet,
+      showLoadingOverlay,
       wallets,
     ]
   );

--- a/src/screens/PinAuthenticationScreen.js
+++ b/src/screens/PinAuthenticationScreen.js
@@ -186,6 +186,15 @@ const PinAuthenticationScreen = () => {
     [actionType, attemptsLeft, dismissPinScreen, initialPin, onShake, params]
   );
 
+  const titleMap = useMemo(
+    () => ({
+      authentication: params?.promptMessage || 'Type your PIN',
+      creation: 'Choose your PIN',
+      confirmation: 'Confirm your PIN',
+    }),
+    [params]
+  );
+
   return (
     <Column
       backgroundColor={colors.backgroundBlue}
@@ -206,13 +215,7 @@ const PinAuthenticationScreen = () => {
               CARD WALLET
             </Text>
           </CenteredContainer>
-          <SheetTitle color="white">
-            {actionType === 'authentication'
-              ? 'Type your PIN'
-              : actionType === 'creation'
-              ? 'Choose your PIN'
-              : 'Confirm your PIN'}
-          </SheetTitle>
+          <SheetTitle color="white">{titleMap[actionType]}</SheetTitle>
           <PinValue translateX={errorAnimation} value={value} />
         </ColumnWithMargins>
       </Centered>


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

The issue was cause by not waiting all the setup before checking the notifications,  so the loading was dismissed and the user would get a random PIN screen that seemed related to the backup but it was not. it depends on #632, because the previous PR already handles the dismiss of the PIN screen. This PR: 

- Adds a custom message to the PIN screen so the user knows why it needs to authenticate.
- Waits all the setup to keep the loading and ask for the PIN after
- Fixes the sheet minHeight (the import sheet was to small), as its a global component, the current implementation has more priority than the WC sheet, since it will be redesigned 
- Adds different messages for each hub authentication step 
- Adds a loading while switching accounts 
- Removes the setTimeout from check notifications, because now we are waiting for the account to be initialized.
- Adds HD.reset on finally block to also reset in case of an error


### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

Part-1 :
![android-creating-acc1](https://user-images.githubusercontent.com/20520102/153217318-2149ef01-7d9e-4c78-a64c-ba03b2e4fe19.gif)
Part-2:
![android-creating-acc2](https://user-images.githubusercontent.com/20520102/153217334-fdb3a525-6d8e-4acb-bfad-14a390d8436b.gif)


