### PR TITLE
[CS-3102]: Create new HomeScreen for TabBar

### DIFF
--- a/cardstack/src/components/DiscordPromoBanner/DiscordPromoBanner.tsx
+++ b/cardstack/src/components/DiscordPromoBanner/DiscordPromoBanner.tsx
@@ -5,7 +5,7 @@ import { Image, Touchable } from '@cardstack/components';
 import { screenWidth } from '@cardstack/utils';
 
 const layouts = {
-  maxWidth: screenWidth * 0.92, // magic number but it works good on big and smaller devices
+  maxWidth: screenWidth * 0.91, // magic number but it works good on big and smaller devices
 };
 
 export const DiscordPromoBanner = ({ onPress }: { onPress: () => void }) => (

--- a/cardstack/src/components/Icon/Icon.tsx
+++ b/cardstack/src/components/Icon/Icon.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Feather from 'react-native-vector-icons/Feather';
 import MaterialCommunity from 'react-native-vector-icons/MaterialCommunityIcons';
 
+import { TouchableOpacity } from 'react-native';
 import { CustomIconNames, customIcons } from './custom-icons';
 import { FeatherIconNames } from './feather-icon-names';
 import { MaterialCommunityIconNames } from './material-community-icon-names';
@@ -48,6 +49,7 @@ export const Icon = ({
   name,
   color,
   stroke,
+  onPress,
   ...props
 }: IconProps) => {
   const theme = useTheme<Theme>();
@@ -63,32 +65,36 @@ export const Icon = ({
     const CustomIcon = customIcons[name as CustomIconNames];
 
     return (
-      <Container
-        testID="custom-icon"
-        height={sizeWithDefault}
-        width={sizeWithDefault}
-        {...props}
-      >
-        <CustomIcon
-          color={colorWithDefault}
-          fill={colorWithDefault}
-          stroke={strokeWithDefault}
-          width={sizeWithDefault}
+      <TouchableOpacity disabled={!onPress} onPress={onPress}>
+        <Container
+          testID="custom-icon"
           height={sizeWithDefault}
-        />
-      </Container>
+          width={sizeWithDefault}
+          {...props}
+        >
+          <CustomIcon
+            color={colorWithDefault}
+            fill={colorWithDefault}
+            stroke={strokeWithDefault}
+            width={sizeWithDefault}
+            height={sizeWithDefault}
+          />
+        </Container>
+      </TouchableOpacity>
     );
   }
 
   const IconComponent = IconFamilies[iconFamily];
 
   return (
-    <Container {...props}>
-      <IconComponent
-        color={colorWithDefault || 'transparent'}
-        name={name}
-        size={sizeWithDefault}
-      />
-    </Container>
+    <TouchableOpacity disabled={!onPress} onPress={onPress}>
+      <Container {...props}>
+        <IconComponent
+          color={colorWithDefault || 'transparent'}
+          name={name}
+          size={sizeWithDefault}
+        />
+      </Container>
+    </TouchableOpacity>
   );
 };

--- a/cardstack/src/components/Icon/custom-icons/index.ts
+++ b/cardstack/src/components/Icon/custom-icons/index.ts
@@ -20,7 +20,6 @@ export const customIcons = {
   doubleCaret: require('./doubleCaret').default,
   inventory: require('./inventory').default,
   error: require('./error').default,
-  gift: require('./gift').default,
   more: require('./more').default,
   pay: require('./pay').default,
   refresh: require('./refresh').default,

--- a/cardstack/src/components/ListItem/ListEmptyComponent.tsx
+++ b/cardstack/src/components/ListItem/ListEmptyComponent.tsx
@@ -21,7 +21,7 @@ export const ListEmptyComponent = ({
       borderRadius={10}
       backgroundColor={hasRoundBox ? 'buttonDisabledBackground' : 'transparent'}
       paddingVertical={9}
-      marginHorizontal={5}
+      marginHorizontal={4}
       {...props}
     >
       <Text color={textColor} textAlign="center" size="body">

--- a/cardstack/src/components/MainHeader/MainHeader.tsx
+++ b/cardstack/src/components/MainHeader/MainHeader.tsx
@@ -1,0 +1,55 @@
+import React, { memo, useCallback, useMemo } from 'react';
+
+import { useSafeArea } from 'react-native-safe-area-context';
+import { Alert } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { Container, Icon, Text } from '@cardstack/components';
+import Routes from '@rainbow-me/navigation/routesNames';
+
+const MainHeader = ({ title }: { title: string }) => {
+  const { navigate } = useNavigation();
+
+  const insets = useSafeArea();
+  const style = useMemo(() => ({ paddingTop: insets.top + 10 }), [insets]);
+
+  const onMenuPress = useCallback(() => navigate(Routes.SETTINGS_MODAL), [
+    navigate,
+  ]);
+
+  const onRewardPress = useCallback(() => {
+    Alert.alert('Rewards coming soon...');
+  }, []);
+
+  return (
+    <Container
+      backgroundColor="backgroundBlue"
+      flexDirection="row"
+      justifyContent="space-between"
+      alignItems="center"
+      padding={4}
+      style={style}
+    >
+      <Icon
+        color="teal"
+        iconSize="medium"
+        name="menu"
+        onPress={onMenuPress}
+        size={28}
+      />
+      <Container alignSelf="flex-end">
+        <Text color="white" size="small" fontWeight="bold">
+          {title}
+        </Text>
+      </Container>
+      <Icon
+        color="teal"
+        iconSize="medium"
+        size={22}
+        name="gift"
+        onPress={onRewardPress}
+      />
+    </Container>
+  );
+};
+
+export default memo(MainHeader);

--- a/cardstack/src/components/MainHeader/index.ts
+++ b/cardstack/src/components/MainHeader/index.ts
@@ -1,0 +1,1 @@
+export { default as MainHeader } from './MainHeader';

--- a/cardstack/src/components/TransactionList/TransactionList.tsx
+++ b/cardstack/src/components/TransactionList/TransactionList.tsx
@@ -1,49 +1,23 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
-import {
-  RefreshControl,
-  SectionList,
-  ActivityIndicator,
-  StyleSheet,
-} from 'react-native';
+import { RefreshControl, SectionList, ActivityIndicator } from 'react-native';
 
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { TransactionListLoading } from './TransactionListLoading';
 import { useFullTransactionList } from '@cardstack/hooks';
-import { colors } from '@cardstack/theme';
 import {
   Container,
   ListEmptyComponent,
-  ScrollView,
   Text,
   TransactionItem,
+  TransactionItemProps,
 } from '@cardstack/components';
+import { useTabBarFlag } from '@cardstack/navigation/tabBarNavigator';
 
 interface TransactionListProps {
-  Header: JSX.Element;
+  Header?: JSX.Element;
   accountAddress: string;
 }
-
-const styles = StyleSheet.create({
-  contentContainerStyle: { paddingBottom: 40 },
-  background: { backgroundColor: colors.backgroundBlue },
-});
-
-const renderSectionHeader = ({
-  section: { title },
-}: {
-  section: { title: string };
-}) => (
-  <Container
-    paddingVertical={2}
-    paddingHorizontal={5}
-    width="100%"
-    backgroundColor="backgroundBlue"
-  >
-    <Text size="medium" color="white">
-      {title}
-    </Text>
-  </Container>
-);
 
 export const TransactionList = memo(({ Header }: TransactionListProps) => {
   const {
@@ -55,39 +29,79 @@ export const TransactionList = memo(({ Header }: TransactionListProps) => {
     refetchLoading,
   } = useFullTransactionList();
 
+  const isLoadingFallback = useRef(true);
+
+  useEffect(() => {
+    if (isLoadingTransactions) {
+      // Once tx are loading we don't need to track anymore
+      isLoadingFallback.current = false;
+    }
+  }, [isLoadingTransactions]);
+
+  const { isTabBarEnabled } = useTabBarFlag();
+
+  // TODO: Remove condition after tab is official
+  // useBottomTabBarHeight throws error if it's not inside tabNav
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const tabBarHeight = isTabBarEnabled ? useBottomTabBarHeight() : 0;
+
+  const contentContainerStyle = useMemo(
+    () => ({
+      paddingBottom: 40 + tabBarHeight,
+    }),
+    [tabBarHeight]
+  );
+
+  const renderSectionHeader = useCallback(
+    ({ section: { title } }: { section: { title: string } }) => (
+      <Container
+        paddingVertical={2}
+        paddingHorizontal={5}
+        width="100%"
+        backgroundColor={
+          isTabBarEnabled ? 'backgroundDarkPurple' : 'backgroundBlue'
+        }
+      >
+        <Text size="medium" color="white">
+          {title}
+        </Text>
+      </Container>
+    ),
+    [isTabBarEnabled]
+  );
+
   const onRefresh = useCallback(() => {
     refetch && refetch();
   }, [refetch]);
 
   useFocusEffect(onRefresh);
 
-  if (isLoadingTransactions) {
-    return (
-      <ScrollView
-        backgroundColor="backgroundBlue"
-        contentContainerStyle={styles.contentContainerStyle}
-      >
-        {Header}
-        <TransactionListLoading />
-      </ScrollView>
-    );
-  }
+  const renderItem = useCallback(
+    (props: TransactionItemProps) => <TransactionItem {...props} />,
+    []
+  );
 
   return (
     <SectionList
       ListEmptyComponent={
-        <ListEmptyComponent
-          text={`You don't have any\ntransactions yet`}
-          textColor="blueText"
-          hasRoundBox
-        />
+        // Use fallback to avoid flickering empty component,
+        // when fetching hasn't started yet
+        isLoadingTransactions || isLoadingFallback ? (
+          <TransactionListLoading />
+        ) : (
+          <ListEmptyComponent
+            text={`You don't have any\ntransactions yet`}
+            textColor="blueText"
+            hasRoundBox
+          />
+        )
       }
       ListHeaderComponent={Header}
       ListFooterComponent={
         isFetchingMore ? <ActivityIndicator color="white" /> : null
       }
-      contentContainerStyle={styles.contentContainerStyle}
-      renderItem={props => <TransactionItem {...props} />}
+      contentContainerStyle={contentContainerStyle}
+      renderItem={renderItem}
       sections={sections}
       renderSectionHeader={renderSectionHeader}
       refreshControl={
@@ -99,7 +113,6 @@ export const TransactionList = memo(({ Header }: TransactionListProps) => {
       }
       onEndReached={onEndReached}
       onEndReachedThreshold={1}
-      style={styles.background}
     />
   );
 });

--- a/cardstack/src/components/Transactions/TransactionItem.tsx
+++ b/cardstack/src/components/Transactions/TransactionItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 
 import { DepotBridgedLayer1Transaction } from './DepotBridgedLayer1Transaction';
 import { DepotBridgedLayer2Transaction } from './DepotBridgedLayer2Transaction';
@@ -18,7 +18,8 @@ import { MerchantEarnedSpendTransaction } from './Merchant/MerchantEarnedSpendTr
 import { MerchantEarnedSpendAndRevenueTransaction } from './Merchant/MerchantEarnedSpendAndRevenueTransaction';
 import { TransactionType, TransactionTypes } from '@cardstack/types';
 
-interface TransactionItemProps extends TransactionBaseCustomizationProps {
+export interface TransactionItemProps
+  extends TransactionBaseCustomizationProps {
   item: TransactionType;
   isFullWidth?: boolean;
 }
@@ -49,7 +50,7 @@ const transactionItemMap: Record<
   [TransactionTypes.ERC_20]: ERC20Transaction,
 };
 
-export const TransactionItem = (props: TransactionItemProps) => {
+export const TransactionItem = memo((props: TransactionItemProps) => {
   const { item } = props;
 
   if (!item) {
@@ -60,4 +61,4 @@ export const TransactionItem = (props: TransactionItemProps) => {
     transactionItemMap[item.type as TxTypesWithoutReneveueEvent] || null;
 
   return <Transaction {...props} item={item} />;
-};
+});

--- a/cardstack/src/components/index.ts
+++ b/cardstack/src/components/index.ts
@@ -41,3 +41,4 @@ export * from './AnimatedPressable';
 export * from './Notice';
 export * from './TabBarIcon';
 export * from './BetterOpacityContainer';
+export * from './MainHeader';

--- a/cardstack/src/constants.ts
+++ b/cardstack/src/constants.ts
@@ -1,4 +1,3 @@
-export const ENABLE_PAYMENTS = true;
 export const ENABLE_PIN_ITEMS = false;
 export const TRANSACTION_PAGE_SIZE = 100; // Temp increase the page size
 export const SUPPORT_EMAIL_ADDRESS = 'appfeedback@cardstack.com';

--- a/cardstack/src/hooks/transaction-confirmation/use-close-screen.ts
+++ b/cardstack/src/hooks/transaction-confirmation/use-close-screen.ts
@@ -3,7 +3,7 @@ import { InteractionManager } from 'react-native';
 import { useDispatch } from 'react-redux';
 
 import { useRouteParams } from './use-route-params';
-import { WCRedirectTypes } from '@cardstack/screen/sheets/WalletConnectRedirectSheet';
+import { WCRedirectTypes } from '@cardstack/screens/sheets/WalletConnectRedirectSheet';
 import {
   SEND_TRANSACTION,
   isMessageDisplayType,

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -27,7 +27,7 @@ import {
   UnclaimedRevenueSheet,
   WalletConnectApprovalSheet,
   WalletConnectRedirectSheet,
-} from '@cardstack/screen';
+} from '@cardstack/screens';
 import {
   bottomSheetPreset,
   expandedPreset,

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -9,10 +9,9 @@ import React, {
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
 import { InitialRouteContext } from '../../../src/context/initialRoute';
+import { WelcomeScreen, HomeScreen } from '@cardstack/screens';
 import RainbowRoutes from '@rainbow-me/navigation/routesNames';
 
-import { WelcomeScreen } from '@cardstack/screen';
-import ProfileScreen from '@rainbow-me/screens/ProfileScreen';
 import QRScannerScreen from '@rainbow-me/screens/QRScannerScreen';
 import WalletScreen from '@rainbow-me/screens/WalletScreen';
 import { TabBarIcon } from '@cardstack/components';
@@ -46,11 +45,11 @@ const TabNavigator = () => (
     tabBarOptions={tabBarOptions}
   >
     <Tab.Screen
-      component={ProfileScreen}
+      component={HomeScreen}
       name={RainbowRoutes.PROFILE_SCREEN}
       options={{
         tabBarIcon: ({ focused }) => (
-          <TabBarIcon iconName="user" label="HOME" focused={focused} />
+          <TabBarIcon iconName="home" label="HOME" focused={focused} />
         ),
       }}
     />
@@ -123,3 +122,5 @@ export const TabBarFeatureProvider: React.FC = ({ children }) => {
     </TabBarFeatureContext.Provider>
   );
 };
+
+export const useTabBarFlag = () => useContext(TabBarFeatureContext);

--- a/cardstack/src/screens/HomeScreen/HomeScreen.tsx
+++ b/cardstack/src/screens/HomeScreen/HomeScreen.tsx
@@ -1,0 +1,39 @@
+import React, { useMemo } from 'react';
+
+import { Container, MainHeader, TransactionList } from '@cardstack/components';
+import { useAccountProfile } from '@rainbow-me/hooks';
+import {
+  DiscordPromoBanner,
+  useDiscordPromoBanner,
+} from '@cardstack/components/DiscordPromoBanner';
+
+const HomeScreen = () => {
+  const { accountAddress } = useAccountProfile();
+
+  const {
+    showPromoBanner,
+    onPress: onDiscordPromoPress,
+  } = useDiscordPromoBanner();
+
+  const renderPromoBanner = useMemo(
+    () =>
+      showPromoBanner ? (
+        <DiscordPromoBanner onPress={onDiscordPromoPress} />
+      ) : undefined,
+    [onDiscordPromoPress, showPromoBanner]
+  );
+
+  return (
+    <Container backgroundColor="backgroundDarkPurple" flex={1}>
+      <MainHeader title="ACTIVITY" />
+      <Container paddingTop={6}>
+        <TransactionList
+          Header={renderPromoBanner}
+          accountAddress={accountAddress}
+        />
+      </Container>
+    </Container>
+  );
+};
+
+export default HomeScreen;

--- a/cardstack/src/screens/PayMerchant/PayMerchant.tsx
+++ b/cardstack/src/screens/PayMerchant/PayMerchant.tsx
@@ -7,7 +7,7 @@ import {
   AmountInNativeCurrency,
   MinInvalidAmountText,
   useAmountConvertHelper,
-} from '@cardstack/screen/PaymentRequest/helper';
+} from '@cardstack/screens/PaymentRequest/helper';
 import MerchantSectionCard from '@cardstack/components/TransactionConfirmationSheet/displays/components/sections/MerchantSectionCard';
 import {
   SafeAreaView,

--- a/cardstack/src/screens/index.ts
+++ b/cardstack/src/screens/index.ts
@@ -18,3 +18,4 @@ export { default as PaymentReceivedSheet } from './sheets/PaymentReceived/Paymen
 export { default as UnclaimedRevenueSheet } from './sheets/UnclaimedRevenue/UnclaimedRevenueSheet';
 export { default as WalletConnectApprovalSheet } from './sheets/WalletConnectApprovalSheet';
 export { default as WalletConnectRedirectSheet } from './sheets/WalletConnectRedirectSheet';
+export { default as HomeScreen } from './HomeScreen/HomeScreen';

--- a/cardstack/src/test-utils/jest-setup.js
+++ b/cardstack/src/test-utils/jest-setup.js
@@ -44,6 +44,10 @@ jest.mock('@react-navigation/material-top-tabs', () => ({
   createMaterialTopTabNavigator: jest.fn(),
 }));
 
+jest.mock('@react-navigation/bottom-tabs', () => ({
+  useBottomTabBarHeight: jest.fn(),
+}));
+
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
@@ -242,6 +246,10 @@ jest.mock('@cardstack/navigation', () => ({
 
 jest.mock('@cardstack/navigation/screens', () => ({
   default: jest.fn(),
+}));
+
+jest.mock('@cardstack/navigation/tabBarNavigator', () => ({
+  useTabBarFlag: jest.fn(),
 }));
 
 // Mock to avoid not checksum address console.warn

--- a/cardstack/src/theme/colors.ts
+++ b/cardstack/src/theme/colors.ts
@@ -35,9 +35,11 @@ export const palette = {
   buttonDisabledBackground: '#2e2d38',
   appleBlue: '#0E76FD',
   yellow: '#F9D849',
+  darkPurple: '#272330',
 };
 
 export const colors = {
+  backgroundDarkPurple: palette.darkPurple,
   backgroundGray: palette.grayBackground,
   backgroundLightGray: palette.grayBackgroundLight,
   backgroundBlue: palette.blueDark,

--- a/cardstack/src/types/react-native-dotenv.d.ts
+++ b/cardstack/src/types/react-native-dotenv.d.ts
@@ -2,7 +2,6 @@ declare module 'react-native-dotenv' {
   export const GANACHE_URL: string;
   export const IMGIX_DOMAIN: string;
   export const IMGIX_TOKEN: string;
-  export const ENABLE_PAYMENTS: string;
   export const INFURA_PROJECT_ID: string;
   export const INFURA_PROJECT_ID_DEV: string;
   export const CRYPTOCOMPARE_API_KEY: string;

--- a/src/handlers/deeplinks.js
+++ b/src/handlers/deeplinks.js
@@ -6,7 +6,7 @@ import {
   walletConnectRemovePendingRedirect,
   walletConnectSetPendingRedirect,
 } from '../redux/walletconnect';
-import { WCRedirectTypes } from '@cardstack/screen/sheets/WalletConnectRedirectSheet';
+import { WCRedirectTypes } from '@cardstack/screens/sheets/WalletConnectRedirectSheet';
 import logger from 'logger';
 
 export default function handleDeepLink(url) {

--- a/src/hooks/useScanner.js
+++ b/src/hooks/useScanner.js
@@ -16,7 +16,7 @@ import { useNavigation } from '../navigation/Navigation';
 import usePrevious from './usePrevious';
 import useWallets from './useWallets';
 import useWalletConnectConnections from '@cardstack/hooks/wallet-connect/useWalletConnectConnections';
-import { WCRedirectTypes } from '@cardstack/screen/sheets/WalletConnectRedirectSheet';
+import { WCRedirectTypes } from '@cardstack/screens/sheets/WalletConnectRedirectSheet';
 import { Device } from '@cardstack/utils';
 import { enableActionsOnReadOnlyWallet } from '@rainbow-me/config/debug';
 import Routes from '@rainbow-me/routes';

--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -23,7 +23,7 @@ import { Navigation } from '../navigation';
 import { isSigningMethod } from '../utils/signingMethods';
 import { getFCMToken } from '@cardstack/models/firebase';
 import { addRequestToApprove } from '@cardstack/redux/requests';
-import { WCRedirectTypes } from '@cardstack/screen/sheets/WalletConnectRedirectSheet';
+import { WCRedirectTypes } from '@cardstack/screens/sheets/WalletConnectRedirectSheet';
 import { baseCloudFunctionsUrl } from '@cardstack/services';
 import { enableActionsOnReadOnlyWallet } from '@rainbow-me/config/debug';
 import Routes from '@rainbow-me/routes';

--- a/src/screens/ExpandedAssetSheet.js
+++ b/src/screens/ExpandedAssetSheet.js
@@ -17,7 +17,7 @@ import {
 import { Centered } from '../components/layout';
 import { useAsset, useDimensions } from '../hooks';
 import { useNavigation } from '../navigation/Navigation';
-import { ExpandedMerchantRoutes } from '@cardstack/screen/MerchantScreen';
+import { ExpandedMerchantRoutes } from '@cardstack/screens/MerchantScreen';
 import { position } from '@rainbow-me/styles';
 
 const ScreenTypes = {

--- a/src/screens/ModalScreen.js
+++ b/src/screens/ModalScreen.js
@@ -11,7 +11,7 @@ import {
 } from '../components/expanded-state';
 import { Centered } from '../components/layout';
 import { useNavigation } from '../navigation/Navigation';
-import { CopyAddressSheet } from '@cardstack/screen';
+import { CopyAddressSheet } from '@cardstack/screens';
 import { padding, position } from '@rainbow-me/styles';
 
 const ModalTypes = {

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
-import { ENABLE_PAYMENTS } from '../../cardstack/src/constants';
 
 import { BackButton, Header, HeaderButton } from '../components/header';
 import { Page } from '../components/layout';
@@ -50,7 +49,8 @@ export default function ProfileScreen() {
     navigate(Routes.CHANGE_WALLET_SHEET);
   }, [navigate]);
 
-  const addCashAvailable = network === networkTypes.mainnet && ENABLE_PAYMENTS;
+  const addCashAvailable = network === networkTypes.mainnet;
+
   const [copiedText, setCopiedText] = useState(undefined);
   const [copyCount, setCopyCount] = useState(0);
 

--- a/src/utils/feature-toggle-utils.ts
+++ b/src/utils/feature-toggle-utils.ts
@@ -1,5 +1,0 @@
-import { ENABLE_PAYMENTS } from 'react-native-dotenv';
-
-export const usePaymentsEnabled = () => {
-  return ENABLE_PAYMENTS === 'true';
-};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -62,13 +62,15 @@
       "@cardstack/navigation": ["cardstack/src/navigation"],
       "@cardstack/navigation/*": ["cardstack/src/navigation/*"],
       "@cardstack/notification-handler": ["cardstack/src/notification-handler"],
-      "@cardstack/notification-handler/*": ["cardstack/src/notification-handler/*"],
+      "@cardstack/notification-handler/*": [
+        "cardstack/src/notification-handler/*"
+      ],
       "@cardstack/parsers": ["cardstack/src/parsers"],
       "@cardstack/parsers/*": ["cardstack/src/parsers/*"],
       "@cardstack/redux": ["cardstack/src/redux"],
       "@cardstack/redux/*": ["cardstack/src/redux/*"],
-      "@cardstack/screen": ["cardstack/src/screens"],
-      "@cardstack/screen/*": ["cardstack/src/screens/*"],
+      "@cardstack/screens": ["cardstack/src/screens"],
+      "@cardstack/screens/*": ["cardstack/src/screens/*"],
       "@cardstack/services": ["cardstack/src/services"],
       "@cardstack/services/*": ["cardstack/src/services/*"],
       "@cardstack/theme": ["cardstack/src/theme"],


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds the new HomeScreen with the tabBar design, the address behavior was changed by @kdowlin requests, and the navigate icons doesn't work yet, because there's  other route in the tabNavigator, which will be mapped later. Also removed some unused code and add reusable components for the next screens.

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<img width="300" alt="Screen Shot 2022-02-10 at 19 29 31" src="https://user-images.githubusercontent.com/20520102/153507828-00f7db54-c789-40d1-868a-bb1d9ee44540.png">

<img width="300" alt="Screen Shot 2022-02-10 at 19 29 51" src="https://user-images.githubusercontent.com/20520102/153507841-f070633f-9ff6-4b60-9dbc-a9fdbd128ac9.png">

<img width="300" alt="Screen Shot 2022-02-10 at 19 30 40" src="https://user-images.githubusercontent.com/20520102/153507847-e45fa5d1-3b72-4498-91ec-dea5c69542bf.png">

