### PR TITLE
[CS-3109]: Redesign settings screen and share on both navigator 

### DIFF
--- a/cardstack/src/navigation/presetOptions.ts
+++ b/cardstack/src/navigation/presetOptions.ts
@@ -19,6 +19,30 @@ const forFade = ({ current }: StackCardInterpolationProps) => ({
   },
 });
 
+const forSlideLeftToRight = ({
+  current,
+  layouts: { screen },
+}: StackCardInterpolationProps) => {
+  const translateFocused = current.progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [-screen.width, 0],
+  });
+
+  return {
+    cardStyle: {
+      transform: [
+        {
+          translateX: translateFocused,
+        },
+      ],
+    },
+  };
+};
+
+export const slideLeftToRightPreset: StackNavigationOptions = {
+  cardStyleInterpolator: forSlideLeftToRight,
+};
+
 export const overlayPreset: StackNavigationOptions = {
   cardOverlayEnabled: true,
   cardStyle: { backgroundColor: colors.overlay },

--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -16,6 +16,7 @@ export const MainRoutes = {
   UNCLAIMED_REVENUE_SHEET: 'UnclaimedRevenueSheet',
   WALLET_CONNECT_APPROVAL_SHEET: 'WalletConnectApprovalSheet',
   WALLET_CONNECT_REDIRECT_SHEET: 'WalletConnectRedirectSheet',
+  SETTINGS_MODAL: 'SettingModal',
 } as const;
 
 export const GlobalRoutes = {

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -6,6 +6,7 @@ import {
   dismissAndroidKeyboardOnClose,
   horizontalInterpolator,
   overlayPreset,
+  slideLeftToRightPreset,
 } from './presetOptions';
 import {
   BuyPrepaidCard,
@@ -38,6 +39,7 @@ import { nativeStackModalConfig } from '@rainbow-me/navigation/config';
 import RainbowRoutes from '@rainbow-me/navigation/routesNames';
 import SendSheetEOA from '@rainbow-me/screens/SendSheetEOA';
 import { Device } from '@cardstack/utils';
+import SettingsModal from '@rainbow-me/screens/SettingsModal';
 
 export interface ScreenNavigation {
   component: React.ComponentType<any>;
@@ -142,6 +144,10 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
       : wcPromptPreset) as StackNavigationOptions,
   },
   ...LoadingOverlayComponent,
+  SETTINGS_MODAL: {
+    component: SettingsModal,
+    options: slideLeftToRightPreset,
+  },
 };
 
 // @ts-expect-error it alows undefined for temp solution on loadingOverlay, will be removed on nav redesign

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -171,6 +171,8 @@ export const GlobalScreens: Record<
       interactWithScrollView: false,
     } as StackNavigationOptions,
   },
+
+  // Needs to be the last item of the object, until we move to a single navigator
   ...(Device.isIOS ? LoadingOverlayComponent : {}),
 };
 

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -9,7 +9,8 @@ import React, {
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
 import { InitialRouteContext } from '../../../src/context/initialRoute';
-import { WelcomeScreen, HomeScreen } from '@cardstack/screens';
+import { useCardstackGlobalScreens, useCardstackMainScreens } from './hooks';
+import { HomeScreen } from '@cardstack/screens';
 import RainbowRoutes from '@rainbow-me/navigation/routesNames';
 
 import QRScannerScreen from '@rainbow-me/screens/QRScannerScreen';
@@ -79,16 +80,22 @@ const Stack = createStackNavigator();
 const StackNavigator = () => {
   const initialRoute = useContext(InitialRouteContext) || '';
 
+  const cardstackMainScreens = useCardstackMainScreens(Stack);
+  const cardstackGlobalScreens = useCardstackGlobalScreens(Stack);
+
+  // TODO: Create a navigator for each flow and split auth/non-auth
+
+  // Remove last item aka LoadingOverlay, to avoid dupe
+  cardstackGlobalScreens.pop();
+
   return (
-    <Stack.Navigator initialRouteName={initialRoute} headerMode="none">
+    <Stack.Navigator headerMode="none" initialRouteName={initialRoute}>
       <Stack.Screen
         component={TabNavigator}
         name={RainbowRoutes.SWIPE_LAYOUT}
       />
-      <Stack.Screen
-        component={WelcomeScreen}
-        name={RainbowRoutes.WELCOME_SCREEN}
-      />
+      {cardstackMainScreens}
+      {cardstackGlobalScreens}
     </Stack.Navigator>
   );
 };

--- a/src/components/radio-list/RadioListItem.js
+++ b/src/components/radio-list/RadioListItem.js
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 
 import { ListItem } from '../list';
-import { Icon } from '@cardstack/components';
+import { CenteredContainer, Icon } from '@cardstack/components';
 
 const RadioListItem = ({ disabled, selected, ...props }) => {
   const onPress = useCallback(() => {
@@ -13,7 +13,9 @@ const RadioListItem = ({ disabled, selected, ...props }) => {
   return (
     <ListItem onPress={onPress} opacity={disabled ? 0.42 : 1} {...props}>
       {selected && (
-        <Icon iconSize="medium" name="success" position="absolute" right={0} />
+        <CenteredContainer alignItems="flex-end" flex={1}>
+          <Icon iconSize="medium" name="success" />
+        </CenteredContainer>
       )}
     </ListItem>
   );

--- a/src/components/settings-menu/BackupSection/AlreadyBackedUpView.js
+++ b/src/components/settings-menu/BackupSection/AlreadyBackedUpView.js
@@ -131,7 +131,7 @@ export default function AlreadyBackedUpView() {
   return (
     <Fragment>
       <Container alignItems="center" width="100%">
-        <Text style={{ marginTop: -10 }} variant="subText">
+        <Text paddingTop={1} variant="subText">
           {(walletStatus === WalletBackupStatus.CLOUD_BACKUP && `Backed up`) ||
             (walletStatus === WalletBackupStatus.MANUAL_BACKUP &&
               `Backed up manually`) ||

--- a/src/components/settings-menu/BackupSection/NeedsBackupView.js
+++ b/src/components/settings-menu/BackupSection/NeedsBackupView.js
@@ -48,7 +48,7 @@ export default function NeedsBackupView() {
   return (
     <Fragment>
       <Container alignItems="center" width="100%">
-        <Text color="red" style={{ marginTop: -10 }} variant="subText">
+        <Text color="red" paddingTop={1} variant="subText">
           Not backed up
         </Text>
       </Container>

--- a/src/components/settings-menu/BackupSection/WalletSelectionView.js
+++ b/src/components/settings-menu/BackupSection/WalletSelectionView.js
@@ -25,6 +25,8 @@ const Footer = styled(Centered)`
   ${padding(19, 15, 30)};
 `;
 
+const style = { paddingTop: 10 };
+
 const WalletSelectionView = () => {
   const { navigate } = useNavigation();
   const { colors } = useTheme();
@@ -54,7 +56,7 @@ const WalletSelectionView = () => {
   let cloudBackedUpWallets = 0;
 
   return (
-    <ScrollView>
+    <ScrollView style={style}>
       {Object.keys(wallets)
         .filter(key => wallets[key].type !== WalletTypes.readOnly)
         .map(key => {
@@ -152,7 +154,6 @@ const WalletSelectionView = () => {
                         name="warning"
                       />
                     )}
-
                     <Icon
                       alignSelf="center"
                       color="settingsGrayChevron"

--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -20,26 +20,15 @@ import networkInfo from '@rainbow-me/helpers/networkInfo';
 import WalletTypes from '@rainbow-me/helpers/walletTypes';
 import {
   useAccountSettings,
-  useDimensions,
   useSendFeedback,
   useWallets,
 } from '@rainbow-me/hooks';
-import { position } from '@rainbow-me/styles';
 import {
   AppleReviewAddress,
   REVIEW_DONE_KEY,
 } from '@rainbow-me/utils/reviewAlert';
 
 const { RainbowRequestReview, RNReview } = NativeModules;
-
-const contentContainerStyle = { flex: 1 };
-const Container = styled(ScrollView).attrs({
-  contentContainerStyle,
-  scrollEventThrottle: 32,
-})`
-  ${position.cover};
-  background-color: ${({ backgroundColor }) => backgroundColor};
-`;
 
 const VersionStampContainer = styled(Column).attrs({
   align: 'center',
@@ -85,7 +74,6 @@ export default function SettingsSection({
 }) {
   const { wallets } = useWallets();
   const { nativeCurrency, network, accountAddress } = useAccountSettings();
-  const { isTinyPhone } = useDimensions();
 
   const { colors } = useTheme();
 
@@ -145,7 +133,7 @@ export default function SettingsSection({
   };
 
   return (
-    <Container backgroundColor={colors.white} scrollEnabled={isTinyPhone}>
+    <ScrollView backgroundColor={colors.white}>
       <ColumnWithDividers dividerRenderer={ListItemDivider} marginTop={7}>
         {canBeBackedUp && (
           <ListItem
@@ -249,6 +237,6 @@ export default function SettingsSection({
       <VersionStampContainer>
         <AppVersionStamp />
       </VersionStampContainer>
-    </Container>
+    </ScrollView>
   );
 }

--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -27,7 +27,6 @@ import {
   exchangePreset,
   expandedPreset,
   overlayExpandedPreset,
-  settingsPreset,
   sheetPreset,
   sheetPresetWithSmallGestureResponseDistance,
   speedUpAndCancelStyleInterpolator,

--- a/src/navigation/Routes.android.js
+++ b/src/navigation/Routes.android.js
@@ -11,7 +11,6 @@ import PinAuthenticationScreen from '../screens/PinAuthenticationScreen';
 import RestoreSheet from '../screens/RestoreSheet';
 import SavingsSheet from '../screens/SavingsSheet';
 import SendSheetEOA from '../screens/SendSheetEOA';
-import SettingsModal from '../screens/SettingsModal';
 import SpeedUpAndCancelSheet from '../screens/SpeedUpAndCancelSheet';
 import WithdrawModal from '../screens/WithdrawModal';
 import WyreWebview from '../screens/WyreWebview';
@@ -178,11 +177,6 @@ function MainOuterNavigator() {
       <OuterStack.Screen
         component={MainNavigator}
         name={Routes.MAIN_NAVIGATOR}
-      />
-      <OuterStack.Screen
-        component={SettingsModal}
-        name={Routes.SETTINGS_MODAL}
-        options={settingsPreset}
       />
       <OuterStack.Screen
         component={PinAuthenticationScreen}

--- a/src/navigation/Routes.ios.js
+++ b/src/navigation/Routes.ios.js
@@ -13,7 +13,6 @@ import ModalScreen from '../screens/ModalScreen';
 import RestoreSheet from '../screens/RestoreSheet';
 import SavingsSheet from '../screens/SavingsSheet';
 import SendSheetEOA from '../screens/SendSheetEOA';
-import SettingsModal from '../screens/SettingsModal';
 import SpeedUpAndCancelSheet from '../screens/SpeedUpAndCancelSheet';
 import SpendSheet from '../screens/SpendSheet';
 import WithdrawModal from '../screens/WithdrawModal';
@@ -126,18 +125,6 @@ function NativeStackNavigator() {
       <NativeStack.Screen
         component={NativeStackFallbackNavigator}
         name={Routes.STACK}
-      />
-      <NativeStack.Screen
-        component={SettingsModal}
-        name={Routes.SETTINGS_MODAL}
-        options={{
-          backgroundColor: '#25292E',
-          backgroundOpacity: 0.7,
-          cornerRadius: 0,
-          customStack: true,
-          ignoreBottomOffset: true,
-          topOffset: 0,
-        }}
       />
       <NativeStack.Screen
         component={ExchangeModalNavigator}

--- a/src/screens/SettingsModal.js
+++ b/src/screens/SettingsModal.js
@@ -1,9 +1,7 @@
 import { useRoute } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { Animated, InteractionManager, View } from 'react-native';
-import styled from 'styled-components';
-import { Modal } from '../components/modal';
 import {
   CurrencySection,
   LanguageSection,
@@ -15,11 +13,11 @@ import SettingsBackupView from '../components/settings-menu/BackupSection/Settin
 import ShowSecretView from '../components/settings-menu/BackupSection/ShowSecretView';
 import WalletSelectionView from '../components/settings-menu/BackupSection/WalletSelectionView';
 import DeveloperSettings from '../components/settings-menu/DeveloperSettings';
-import { useTheme } from '../context/ThemeContext';
 import WalletTypes from '../helpers/walletTypes';
-import { useDimensions, useWallets } from '../hooks';
-import { settingsOptions } from '../navigation/config';
-import { Text, Touchable } from '@cardstack/components';
+import { useWallets } from '../hooks';
+import { Icon, Text, Touchable } from '@cardstack/components';
+import { slideLeftToRightPreset } from '@cardstack/navigation';
+import { palette } from '@cardstack/theme';
 import { useNavigation } from '@rainbow-me/navigation';
 
 function cardStyleInterpolator({
@@ -94,19 +92,34 @@ const SettingsPages = {
   },
 };
 
-const Container = styled.View`
-  flex: 1;
-  overflow: hidden;
-`;
-
 const Stack = createStackNavigator();
+
+const screenOptions = {
+  ...slideLeftToRightPreset,
+  headerStyle: {
+    backgroundColor: palette.blueDark,
+  },
+  headerTitleStyle: {
+    color: 'white',
+  },
+  cardStyle: { backgroundColor: 'white' },
+  headerTitleAlign: 'center',
+};
+
+const HeaderBackBtnLeft = props => (
+  <Icon
+    {...props}
+    color="teal"
+    iconSize="large"
+    name="chevron-left"
+    paddingLeft={3}
+  />
+);
 
 export default function SettingsModal() {
   const { goBack, navigate } = useNavigation();
   const { wallets, selectedWallet } = useWallets();
   const { params } = useRoute();
-  const { isTinyPhone } = useDimensions();
-  const { colors } = useTheme();
 
   const getRealRoute = useCallback(
     key => {
@@ -162,87 +175,73 @@ export default function SettingsModal() {
     }
   }, [getRealRoute, navigate, params]);
 
-  const memoSettingsOptions = useMemo(() => settingsOptions(colors), [colors]);
   return (
-    <Modal
-      minHeight={isTinyPhone ? 500 : 600}
-      onCloseModal={goBack}
-      radius={18}
-      showDoneButton={ios}
-      skipStatusBar={android}
-      testID="settings-modal"
+    <Stack.Navigator
+      screenOptions={{
+        ...screenOptions,
+        headerRight: renderHeaderRight,
+        headerLeft: HeaderBackBtnLeft,
+      }}
     >
-      <Container>
-        <Stack.Navigator
-          screenOptions={{
-            ...memoSettingsOptions,
-            headerRight: renderHeaderRight,
-          }}
-        >
-          <Stack.Screen
-            name="SettingsSection"
-            options={{
-              headerTitle: 'Settings',
-              headerLeft: null,
-            }}
-          >
-            {() => (
-              <SettingsSection
-                onCloseModal={goBack}
-                onPressBackup={onPressSection(SettingsPages.backup)}
-                onPressCurrency={onPressSection(SettingsPages.currency)}
-                onPressDev={onPressSection(SettingsPages.dev)}
-                onPressLanguage={onPressSection(SettingsPages.language)}
-                onPressNetwork={onPressSection(SettingsPages.network)}
-                onPressNotifications={onPressSection(
-                  SettingsPages.notifications
-                )}
-              />
-            )}
-          </Stack.Screen>
-          {Object.values(SettingsPages).map(
-            ({ component, title, key }) =>
-              component && (
-                <Stack.Screen
-                  component={component}
-                  key={key}
-                  name={key}
-                  options={{
-                    cardStyleInterpolator,
-                    title,
-                  }}
-                  title={title}
-                />
-              )
-          )}
+      <Stack.Screen
+        name="SettingsSection"
+        options={{
+          headerTitle: 'Settings',
+          headerLeft: null,
+        }}
+      >
+        {() => (
+          <SettingsSection
+            onCloseModal={goBack}
+            onPressBackup={onPressSection(SettingsPages.backup)}
+            onPressCurrency={onPressSection(SettingsPages.currency)}
+            onPressDev={onPressSection(SettingsPages.dev)}
+            onPressLanguage={onPressSection(SettingsPages.language)}
+            onPressNetwork={onPressSection(SettingsPages.network)}
+            onPressNotifications={onPressSection(SettingsPages.notifications)}
+          />
+        )}
+      </Stack.Screen>
+      {Object.values(SettingsPages).map(
+        ({ component, title, key }) =>
+          component && (
+            <Stack.Screen
+              component={component}
+              key={key}
+              name={key}
+              options={{
+                cardStyleInterpolator,
+                title,
+              }}
+              title={title}
+            />
+          )
+      )}
 
-          <Stack.Screen
-            component={WalletSelectionView}
-            name="WalletSelectionView"
-            options={{
-              cardStyle: { backgroundColor: colors.white, marginTop: 6 },
-              cardStyleInterpolator,
-              headerTitle: 'Backup',
-            }}
-          />
-          <Stack.Screen
-            component={SettingsBackupView}
-            name="SettingsBackupView"
-            options={({ route }) => ({
-              cardStyleInterpolator,
-              title: route.params?.title || 'Backup',
-            })}
-          />
-          <Stack.Screen
-            component={ShowSecretView}
-            name="ShowSecretView"
-            options={({ route }) => ({
-              cardStyleInterpolator,
-              title: route.params?.title || 'Backup',
-            })}
-          />
-        </Stack.Navigator>
-      </Container>
-    </Modal>
+      <Stack.Screen
+        component={WalletSelectionView}
+        name="WalletSelectionView"
+        options={{
+          cardStyleInterpolator,
+          headerTitle: 'Backup',
+        }}
+      />
+      <Stack.Screen
+        component={SettingsBackupView}
+        name="SettingsBackupView"
+        options={({ route }) => ({
+          cardStyleInterpolator,
+          title: route.params?.title || 'Backup',
+        })}
+      />
+      <Stack.Screen
+        component={ShowSecretView}
+        name="ShowSecretView"
+        options={({ route }) => ({
+          cardStyleInterpolator,
+          title: route.params?.title || 'Backup',
+        })}
+      />
+    </Stack.Navigator>
   );
 }


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR enables the scrollview in the settings and restyle it to be a screen from left to right to avoid gestures conflicts with the scroll, also adds the possible shareable routes into the tabBar navigator, which will be refactored soon to specific navigators based on each flow.  This change is applied on the current app and in the tabBar

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Simulator Screen Recording - iPhone 13 mini - 2022-02-11 at 17 05 01](https://user-images.githubusercontent.com/20520102/153662405-5100508a-1cb8-4963-a54e-05bbf06a1025.gif)
