### PR TITLE
[CS-3111] Enforce decimal limit on prepaid card

### DIFF
--- a/cardstack/src/components/PrepaidCard/components/CustomizableBackground.tsx
+++ b/cardstack/src/components/PrepaidCard/components/CustomizableBackground.tsx
@@ -145,14 +145,14 @@ const PatternUri = ({
 
     async function getPattern() {
       try {
-        const response = await (
-          await fetch(
-            uri.startsWith('http') ? uri : `https://app.cardstack.com${uri}`
-          )
-        ).text();
+        const response = await fetch(
+          uri.startsWith('http') ? uri : `https://app.cardstack.com${uri}`
+        );
 
-        const viewBox = response
-          ? (/viewBox="([^"]+)"/.exec(response) || '')[1].trim().split(' ')
+        const svgContent = await response.text();
+
+        const viewBox = svgContent
+          ? (/viewBox="([^"]+)"/.exec(svgContent) || '')[1].trim().split(' ')
           : [];
 
         // mapping svg pattern width
@@ -168,7 +168,7 @@ const PatternUri = ({
             : Number(viewBox[3]) || cardType.normal.height;
 
         setPattern({
-          pattern: response,
+          pattern: svgContent,
           width,
           height,
         });

--- a/cardstack/src/components/PrepaidCard/components/PrepaidCardInnerBottom.tsx
+++ b/cardstack/src/components/PrepaidCard/components/PrepaidCardInnerBottom.tsx
@@ -66,6 +66,7 @@ const cardType: Record<CardVariants, VariantType> = {
 
 const styles = StyleSheet.create({
   logo: { height: '100%', resizeMode: 'contain', width: '100%' },
+  currencySufix: { paddingBottom: 5 },
 });
 
 const PrepaidCardInnerBottom = ({
@@ -104,13 +105,13 @@ const PrepaidCardInnerBottom = ({
           </Text>
           <Container flexDirection="row" alignItems="flex-end">
             <Text fontSize={cardType[variant].tokenFontSize} fontWeight="700">
-              {`${nativeCurrencyInfo.symbol}${nativeBalance}`}
+              {`${nativeCurrencyInfo.symbol}${nativeBalance.toFixed(2)}`}
             </Text>
             <Text
               fontSize={cardType[variant].currencyFontSize}
               fontWeight="bold"
               letterSpacing={0}
-              paddingBottom={2}
+              style={styles.currencySufix}
             >
               {` ${nativeCurrencyInfo.currency}`}
             </Text>

--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -164,7 +164,7 @@ export const estimateTransferNFTGas = async (
     const contract = new Contract(params.to, erc721ABI, provider);
     const contractEstGas = await contract.estimateGas.transferFrom(
       params.from,
-      params.to, // LOOK IT UP
+      params.to,
       params.id
     );
     if (!addPadding) {


### PR DESCRIPTION

### Description

Improves the layout of prepaid card currency suffix to be better aligned with value and sets currency value to show two decimals maximal.

- [x] Completes #(CS-3111)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/153668360-c0cbcf27-10eb-43b7-9d5d-d81ab8c75d34.jpeg">
