### PR TITLE
[CS-3201] Using shared Sheet component for show QR code screen

### DIFF
--- a/cardstack/src/components/Sheet/Sheet.tsx
+++ b/cardstack/src/components/Sheet/Sheet.tsx
@@ -14,7 +14,6 @@ import { shadow } from '@rainbow-me/styles';
 const styles = StyleSheet.create({
   wrapperBase: {
     justifyContent: 'flex-end',
-    backgroundColor: 'white',
     minHeight: '40%',
   },
 });
@@ -38,6 +37,7 @@ export interface SheetProps {
   scrollEnabled?: boolean;
   shadowEnabled?: boolean;
   overlayColor?: string;
+  cardBackgroundColor?: string;
   Header?: JSX.Element;
   Footer?: JSX.Element;
 }
@@ -50,6 +50,7 @@ const Sheet = ({
   scrollEnabled = false,
   shadowEnabled = false,
   overlayColor = 'transparent',
+  cardBackgroundColor = 'white',
   Header,
   Footer,
 }: SheetProps) => {
@@ -75,10 +76,11 @@ const Sheet = ({
       ...styles.wrapperBase,
       ...shadowStyle,
       flex,
+      backgroundColor: cardBackgroundColor,
       borderTopStartRadius: borderRadius,
       borderTopEndRadius: borderRadius,
     };
-  }, [borderRadius, isFullScreen, shadowEnabled]);
+  }, [borderRadius, isFullScreen, shadowEnabled, cardBackgroundColor]);
 
   const contentContainerStyle = useMemo(() => {
     const { scrollable, fixed } = layouts.contentPaddingBottom;

--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -16,12 +16,12 @@ export const MainRoutes = {
   UNCLAIMED_REVENUE_SHEET: 'UnclaimedRevenueSheet',
   WALLET_CONNECT_APPROVAL_SHEET: 'WalletConnectApprovalSheet',
   WALLET_CONNECT_REDIRECT_SHEET: 'WalletConnectRedirectSheet',
+  SHOW_QRCODE_MODAL: 'ShowQRCodeModal',
   SETTINGS_MODAL: 'SettingModal',
 } as const;
 
 export const GlobalRoutes = {
   CONFIRM_REQUEST: 'ConfirmRequest',
-  SHOW_QRCODE_MODAL: 'ShowQRCodeModal',
   CURRENCY_SELECTION_MODAL: 'CurrencySelectionModal',
   LOADING_OVERLAY: 'LoadingOverlay',
 } as const;

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -35,7 +35,6 @@ import {
   sheetPreset,
   wcPromptPreset,
 } from '@rainbow-me/navigation/effects';
-import { nativeStackModalConfig } from '@rainbow-me/navigation/config';
 import RainbowRoutes from '@rainbow-me/navigation/routesNames';
 import SendSheetEOA from '@rainbow-me/screens/SendSheetEOA';
 import { Device } from '@cardstack/utils';
@@ -161,7 +160,7 @@ export const GlobalScreens: Record<
   },
   SHOW_QRCODE_MODAL: {
     component: ShowQRCodeModal,
-    options: nativeStackModalConfig as StackNavigationOptions,
+    options: sheetPreset as StackNavigationOptions,
   },
   CURRENCY_SELECTION_MODAL: {
     component: CurrencySelectionGlobalModal,

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -142,6 +142,10 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
       ? bottomSheetPreset
       : wcPromptPreset) as StackNavigationOptions,
   },
+  SHOW_QRCODE_MODAL: {
+    component: ShowQRCodeModal,
+    options: expandedPreset as StackNavigationOptions,
+  },
   ...LoadingOverlayComponent,
   SETTINGS_MODAL: {
     component: SettingsModal,
@@ -157,10 +161,6 @@ export const GlobalScreens: Record<
   CONFIRM_REQUEST: {
     component: TransactionConfirmation,
     options: { gestureEnabled: false },
-  },
-  SHOW_QRCODE_MODAL: {
-    component: ShowQRCodeModal,
-    options: sheetPreset as StackNavigationOptions,
   },
   CURRENCY_SELECTION_MODAL: {
     component: CurrencySelectionGlobalModal,

--- a/cardstack/src/screens/ShowQRCodeModal.tsx
+++ b/cardstack/src/screens/ShowQRCodeModal.tsx
@@ -60,7 +60,6 @@ export const AmountQRCode = ({
         justifyContent="space-between"
       >
         <Container alignItems="center">
-          {/* <SheetHandle /> */}
           <Text size="body" color="black" fontWeight="bold" marginTop={4}>
             Scan to Pay
           </Text>

--- a/cardstack/src/screens/ShowQRCodeModal.tsx
+++ b/cardstack/src/screens/ShowQRCodeModal.tsx
@@ -8,8 +8,7 @@ import {
   Touchable,
   Container,
   QRCode,
-  SafeAreaView,
-  SheetHandle,
+  Sheet,
   Text,
 } from '@cardstack/components';
 import { MerchantInformation } from '@cardstack/types';
@@ -53,23 +52,15 @@ export const AmountQRCode = ({
   );
 
   return (
-    <Container
-      flex={1}
-      alignItems="center"
-      backgroundColor="grayCardBackground"
-      borderRadius={20}
-      borderWidth={1}
-      borderColor="whiteOverlay"
-    >
+    <Container flex={1} alignItems="center">
       <Container
         flex={1}
         flexDirection="column"
         alignItems="center"
         justifyContent="space-between"
-        paddingTop={4}
       >
         <Container alignItems="center">
-          <SheetHandle />
+          {/* <SheetHandle /> */}
           <Text size="body" color="black" fontWeight="bold" marginTop={4}>
             Scan to Pay
           </Text>
@@ -158,9 +149,9 @@ const ShowQRCodeModal = () => {
   const { params } = useRoute() as { params: ShowQRCodeModalParamTypes };
 
   return (
-    <SafeAreaView flex={1} width="100%" backgroundColor="transparent">
+    <Sheet isFullScreen cardBackgroundColor={colors.grayCardBackground}>
       <AmountQRCode {...params} />
-    </SafeAreaView>
+    </Sheet>
   );
 };
 

--- a/src/navigation/config.js
+++ b/src/navigation/config.js
@@ -8,7 +8,6 @@ import { Text } from '../components/text';
 import { useTheme } from '../context/ThemeContext';
 import colors from '../context/currentColors';
 import { onWillPop } from './Navigation';
-import { colors as cardstackColors } from '@cardstack/theme';
 import WalletBackupStepTypes from '@rainbow-me/helpers/walletBackupStepTypes';
 import { fonts } from '@rainbow-me/styles';
 import { deviceUtils, safeAreaInsetValues } from '@rainbow-me/utils';
@@ -122,21 +121,6 @@ export const nativeStackDefaultConfig = {
   springDamping: 1,
   topOffset: 0,
   transitionDuration: 0.3,
-};
-
-// react-native-cool-modals options to display screen as a modal like QRCode Screen
-export const nativeStackModalConfig = {
-  allowsDragToDismiss: true,
-  backgroundColor: cardstackColors.overlayGray,
-  backgroundOpacity: 0.95,
-  transparentCard: true,
-  onAppear: null,
-  topOffset: 0,
-  ignoreBottomOffset: true,
-  cornerRadius: 0,
-  customStack: true,
-  springDamping: 1,
-  transitionDuration: 0.2,
 };
 
 export const nativeStackDefaultConfigWithoutStatusBar = {


### PR DESCRIPTION
### Description

Refactors screen ShowQRCodeModal to use navigation options `sheetPreset` and also `Sheet` component for better display on Android, since Sheet already considers StatusBar.currentHeight.

Also, added `cardBackgroundColor` prop to `Sheet` so we can match previous style for ShowQRCodeModal.


- [x] Completes #(CS-3201)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/154702515-9c804283-6e32-4757-a077-23370861309c.jpeg">
