### PR TITLE
[CS-3178]: Add profile tab and screen "placeholder"

### DIFF
--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -7,9 +7,13 @@ import React, {
   useState,
 } from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { createStackNavigator } from '@react-navigation/stack';
+import {
+  createStackNavigator,
+  StackNavigationOptions,
+} from '@react-navigation/stack';
 import { InitialRouteContext } from '../../../src/context/initialRoute';
 import { useCardstackGlobalScreens, useCardstackMainScreens } from './hooks';
+import { dismissAndroidKeyboardOnClose } from '.';
 import { HomeScreen, WalletScreen, ProfileScreen } from '@cardstack/screens';
 import RainbowRoutes from '@rainbow-me/navigation/routesNames';
 
@@ -17,6 +21,8 @@ import QRScannerScreen from '@rainbow-me/screens/QRScannerScreen';
 import { TabBarIcon } from '@cardstack/components';
 import { colors } from '@cardstack/theme';
 import { Device, screenHeight } from '@cardstack/utils';
+import ExpandedAssetSheet from '@rainbow-me/screens/ExpandedAssetSheet';
+import { expandedPreset, sheetPreset } from '@rainbow-me/navigation/effects';
 
 const Tab = createBottomTabNavigator();
 
@@ -104,6 +110,22 @@ const StackNavigator = () => {
       />
       {cardstackMainScreens}
       {cardstackGlobalScreens}
+
+      {
+        // Temp rainbow components until migration
+      }
+      <Stack.Screen
+        component={ExpandedAssetSheet}
+        listeners={dismissAndroidKeyboardOnClose}
+        name={RainbowRoutes.EXPANDED_ASSET_SHEET}
+        options={expandedPreset as StackNavigationOptions}
+      />
+      <Stack.Screen
+        component={ExpandedAssetSheet}
+        listeners={dismissAndroidKeyboardOnClose}
+        name={RainbowRoutes.EXPANDED_ASSET_SHEET_DRILL}
+        options={sheetPreset as StackNavigationOptions}
+      />
     </Stack.Navigator>
   );
 };

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -10,7 +10,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
 import { InitialRouteContext } from '../../../src/context/initialRoute';
 import { useCardstackGlobalScreens, useCardstackMainScreens } from './hooks';
-import { HomeScreen, WalletScreen } from '@cardstack/screens';
+import { HomeScreen, WalletScreen, ProfileScreen } from '@cardstack/screens';
 import RainbowRoutes from '@rainbow-me/navigation/routesNames';
 
 import QRScannerScreen from '@rainbow-me/screens/QRScannerScreen';
@@ -54,11 +54,11 @@ const TabNavigator = () => (
       }}
     />
     <Tab.Screen
-      component={QRScannerScreen}
-      name={RainbowRoutes.QR_SCANNER_SCREEN}
+      component={ProfileScreen}
+      name="Profile"
       options={{
         tabBarIcon: ({ focused }) => (
-          <TabBarIcon iconName="qr-code" label="SCAN" focused={focused} />
+          <TabBarIcon iconName="user" label="PROFILE" focused={focused} />
         ),
       }}
     />
@@ -68,6 +68,15 @@ const TabNavigator = () => (
       options={{
         tabBarIcon: ({ focused }) => (
           <TabBarIcon iconName="wallet" label="WALLET" focused={focused} />
+        ),
+      }}
+    />
+    <Tab.Screen
+      component={QRScannerScreen}
+      name={RainbowRoutes.QR_SCANNER_SCREEN}
+      options={{
+        tabBarIcon: ({ focused }) => (
+          <TabBarIcon iconName="dollar-sign" label="SCAN" focused={focused} />
         ),
       }}
     />

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -46,7 +46,7 @@ const TabNavigator = () => (
   >
     <Tab.Screen
       component={HomeScreen}
-      name={RainbowRoutes.PROFILE_SCREEN}
+      name={RainbowRoutes.HOME_SCREEN}
       options={{
         tabBarIcon: ({ focused }) => (
           <TabBarIcon iconName="home" label="HOME" focused={focused} />
@@ -55,7 +55,7 @@ const TabNavigator = () => (
     />
     <Tab.Screen
       component={ProfileScreen}
-      name="Profile"
+      name={RainbowRoutes.PROFILE_SCREEN}
       options={{
         tabBarIcon: ({ focused }) => (
           <TabBarIcon iconName="user" label="PROFILE" focused={focused} />

--- a/cardstack/src/screens/PayMerchant/usePayMerchant.ts
+++ b/cardstack/src/screens/PayMerchant/usePayMerchant.ts
@@ -110,7 +110,7 @@ const usePayMerchantRequest = ({
     dismissLoadingOverlay();
 
     // Navigate to Transaction screen
-    navigate(RainbowRoutes.PROFILE_SCREEN);
+    navigate(RainbowRoutes.HOME_SCREEN);
 
     // Wait goBack action to navigate
     InteractionManager.runAfterInteractions(() => {

--- a/cardstack/src/screens/ProfileScreen/ProfileScreen.tsx
+++ b/cardstack/src/screens/ProfileScreen/ProfileScreen.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { Container, MainHeader } from '@cardstack/components';
+
+const ProfileScreen = () => {
+  return (
+    <Container backgroundColor="backgroundDarkPurple" flex={1}>
+      <MainHeader title="PROFILE" />
+    </Container>
+  );
+};
+
+export default ProfileScreen;

--- a/cardstack/src/screens/index.ts
+++ b/cardstack/src/screens/index.ts
@@ -20,3 +20,4 @@ export { default as WalletConnectApprovalSheet } from './sheets/WalletConnectApp
 export { default as WalletConnectRedirectSheet } from './sheets/WalletConnectRedirectSheet';
 export { default as HomeScreen } from './HomeScreen/HomeScreen';
 export { default as WalletScreen } from './WalletScreen/WalletScreen';
+export { default as ProfileScreen } from './ProfileScreen/ProfileScreen';

--- a/src/components/header/ProfileHeaderButton.js
+++ b/src/components/header/ProfileHeaderButton.js
@@ -11,9 +11,7 @@ export default function ProfileHeaderButton() {
   const { navigate } = useNavigation();
   const { accountSymbol, accountColor, accountImage } = useAccountProfile();
 
-  const onPress = useCallback(() => navigate(Routes.PROFILE_SCREEN), [
-    navigate,
-  ]);
+  const onPress = useCallback(() => navigate(Routes.HOME_SCREEN), [navigate]);
 
   const onLongPress = useCallback(() => navigate(Routes.CHANGE_WALLET_SHEET), [
     navigate,

--- a/src/components/settings-menu/DeveloperSettings.js
+++ b/src/components/settings-menu/DeveloperSettings.js
@@ -29,7 +29,7 @@ const DeveloperSettings = () => {
 
   const connectToGanache = useCallback(async () => {
     GanacheUtils.connect(() => {
-      navigate(Routes.PROFILE_SCREEN);
+      navigate(Routes.HOME_SCREEN);
     });
   }, [navigate]);
 

--- a/src/navigation/SwipeNavigator.js
+++ b/src/navigation/SwipeNavigator.js
@@ -30,7 +30,7 @@ export function SwipeNavigator() {
         swipeEnabled={!isCoinListEdited}
         tabBar={renderTabBar}
       >
-        <Swipe.Screen component={ProfileScreen} name={Routes.PROFILE_SCREEN} />
+        <Swipe.Screen component={ProfileScreen} name={Routes.HOME_SCREEN} />
         <Swipe.Screen component={WalletScreen} name={Routes.WALLET_SCREEN} />
         <Swipe.Screen
           component={QRScannerScreen}

--- a/src/navigation/onNavigationStateChange.js
+++ b/src/navigation/onNavigationStateChange.js
@@ -12,11 +12,9 @@ let memRouteName;
 let action = null;
 
 const isOnSwipeScreen = name =>
-  [
-    Routes.WALLET_SCREEN,
-    Routes.QR_SCANNER_SCREEN,
-    Routes.PROFILE_SCREEN,
-  ].includes(name);
+  [Routes.WALLET_SCREEN, Routes.QR_SCANNER_SCREEN, Routes.HOME_SCREEN].includes(
+    name
+  );
 
 export function triggerOnSwipeLayout(newAction) {
   if (isOnSwipeScreen(Navigation.getActiveRoute()?.name)) {

--- a/src/navigation/routesNames.js
+++ b/src/navigation/routesNames.js
@@ -27,7 +27,6 @@ const Routes = {
   NATIVE_STACK: 'NativeStack',
   NON_MODAL_SCREENS: 'NonModalScreens',
   PIN_AUTHENTICATION_SCREEN: 'PinAuthenticationScreen',
-  PROFILE_SCREEN: 'ProfileScreen',
   QR_SCANNER_SCREEN: 'QRScannerScreen',
   RESTORE_SHEET: 'RestoreSheet',
   SAVINGS_DEPOSIT_MODAL: 'SavingsDepositModal',
@@ -49,6 +48,7 @@ const Routes = {
   // Cardstack Screens
   ...CSMainRoutes,
   ...CSGlobalRoutes,
+  HOME_SCREEN: 'HomeScreen',
 };
 
 export const NATIVE_ROUTES = [

--- a/src/navigation/routesNames.js
+++ b/src/navigation/routesNames.js
@@ -42,13 +42,14 @@ const Routes = {
   SUPPORTED_COUNTRIES_MODAL_SCREEN: 'SupportedCountriesModalScreen',
   SWAP_DETAILS_SCREEN: 'SwapDetailsScreen',
   SWIPE_LAYOUT: 'SwipeLayout',
-  WALLET_SCREEN: 'WalletScreen',
   WYRE_WEBVIEW: 'WyreWebview',
   WYRE_WEBVIEW_NAVIGATOR: 'WyreWebviewNavigator',
   // Cardstack Screens
   ...CSMainRoutes,
   ...CSGlobalRoutes,
   HOME_SCREEN: 'HomeScreen',
+  PROFILE_SCREEN: 'ProfileScreen',
+  WALLET_SCREEN: 'WalletScreen',
 };
 
 export const NATIVE_ROUTES = [

--- a/src/screens/ExchangeModal.js
+++ b/src/screens/ExchangeModal.js
@@ -346,7 +346,7 @@ export default function ExchangeModal({
         setIsAuthorizing(false);
         const callback = () => {
           setParams({ focused: false });
-          navigate(Routes.PROFILE_SCREEN);
+          navigate(Routes.HOME_SCREEN);
         };
         const rap = await createRap({
           callback,


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

- Adds new profile tab with empty screen
- Renames Profile to Home in order to give Profile a different purpose 
- Adds expandedSheet component, although it's rainbows, is still needed on some flows, so we keep it there until we recreate the merchant flows.
- Updates scan icon 

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

<img width="300" alt="image" src="https://user-images.githubusercontent.com/20520102/154749303-b9b4dc5f-75c5-485e-a1d3-f78d5d5fd004.png">

