### PR TITLE
[CS-3185]- Persist connected network across the app

### DIFF
--- a/cardstack/src/components/MainHeader/MainHeader.tsx
+++ b/cardstack/src/components/MainHeader/MainHeader.tsx
@@ -5,9 +5,12 @@ import { Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { Container, Icon, Text } from '@cardstack/components';
 import Routes from '@rainbow-me/navigation/routesNames';
+import { useAccountSettings } from '@rainbow-me/hooks';
+import { networkInfo } from '@rainbow-me/helpers/networkInfo';
 
 const MainHeader = ({ title }: { title: string }) => {
   const { navigate } = useNavigation();
+  const { network } = useAccountSettings();
 
   const insets = useSafeArea();
   const style = useMemo(() => ({ paddingTop: insets.top + 10 }), [insets]);
@@ -36,9 +39,19 @@ const MainHeader = ({ title }: { title: string }) => {
         onPress={onMenuPress}
         size={28}
       />
-      <Container alignSelf="flex-end">
+      <Container
+        flex={1}
+        alignSelf="flex-end"
+        alignItems="center"
+        justifyContent="space-between"
+        flexDirection="column"
+        paddingTop={2}
+      >
         <Text color="white" size="small" fontWeight="bold">
           {title}
+        </Text>
+        <Text color="backgroundLightGray" size="xxs">
+          {networkInfo[network].name}
         </Text>
       </Container>
       <Icon

--- a/src/components/toasts/NetworkToast.js
+++ b/src/components/toasts/NetworkToast.js
@@ -4,7 +4,6 @@ import networkInfo from '../../helpers/networkInfo';
 import { useAccountSettings, useInternetStatus } from '../../hooks';
 import { Nbsp, Text } from '../text';
 import Toast from './Toast';
-import networkTypes from '@rainbow-me/helpers/networkTypes';
 
 const NetworkToast = () => {
   const isConnected = useInternetStatus();
@@ -15,7 +14,7 @@ const NetworkToast = () => {
   const [networkName, setNetworkName] = useState(name);
 
   useEffect(() => {
-    setVisible(isConnected && network !== networkTypes.xdai);
+    setVisible(isConnected);
     setNetworkName(networkInfo[network].shortName);
   }, [name, network, providerUrl, isConnected, isTestnet, networkName]);
 


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
- Always show network pill on current navigation
- Adds the network name in the header on tabBar navigation (Approved)

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

<img width="300" alt="Screen Shot 2022-02-21 at 11 32 48" src="https://user-images.githubusercontent.com/20520102/154975261-070dd33e-27a2-476c-98f2-8713b0240da4.png">
<img width="300" alt="Screen Shot 2022-02-21 at 11 33 00" src="https://user-images.githubusercontent.com/20520102/154975284-1714ae73-3024-4549-8112-a3d72402f942.png">

