### PR TITLE
Fix universal deep link

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
     "path-browserify": "0.0.0",
     "prop-types": "^15.7.2",
     "punycode": "^1.4.1",
-    "qs": "^6.9.4",
     "querystring-es3": "^0.2.1",
     "rainbow-token-list": "rainbow-me/token-lists#092bd84fac3b2032b94f05a1a49899252e5eb923",
     "react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17303,11 +17303,6 @@ qs@^6.6.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
   integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
 
-qs@^6.9.4:
-  version "6.9.4"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
-  integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
-
 qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Fixed handling direct universal WC deeplinks like `https://wallet.cardstack.com/wc?uri=wc:xxxx`, `https://wallet-staging.stack.cards/wc?uri=wc:xxxx`

### Checklist

- [x] Tested on both iOS and Android

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Feb-23-2022 20-06-36](https://user-images.githubusercontent.com/16714648/155316424-572a1320-4f40-4089-9737-7fd266bab270.gif)

