### PR TITLE
[CS-3210]: Adds ability to transfer a prepaid card 

### DIFF
--- a/cardstack/src/components/PrepaidCard/PrepaidCard.tsx
+++ b/cardstack/src/components/PrepaidCard/PrepaidCard.tsx
@@ -17,6 +17,7 @@ import {
   Icon,
   ScrollView,
 } from '@cardstack/components';
+import { Alert } from '@rainbow-me/components/alerts';
 
 export interface PrepaidCardProps extends PrepaidCardType, ContainerProps {
   networkName: string;
@@ -86,8 +87,16 @@ export const PrepaidCard = (props: PrepaidCardProps) => {
   ]);
 
   const onLongPress = useCallback(() => {
-    navigate(Routes.TRANSFER_CARD, { prepaidCardAddress: props.address });
-  }, [navigate, props.address]);
+    if (props.transferrable) {
+      navigate(Routes.TRANSFER_CARD, {
+        prepaidCardAddress: props.address,
+      });
+
+      return;
+    }
+
+    Alert({ title: 'Oops!', message: 'Prepaid card not transferrable.' });
+  }, [navigate, props.address, props.transferrable]);
 
   if (!isEditing && isHidden) {
     return null;

--- a/cardstack/src/components/PrepaidCard/PrepaidCard.tsx
+++ b/cardstack/src/components/PrepaidCard/PrepaidCard.tsx
@@ -86,8 +86,8 @@ export const PrepaidCard = (props: PrepaidCardProps) => {
   ]);
 
   const onLongPress = useCallback(() => {
-    navigate(Routes.TRANSFER_CARD);
-  }, [navigate]);
+    navigate(Routes.TRANSFER_CARD, { prepaidCardAddress: props.address });
+  }, [navigate, props.address]);
 
   if (!isEditing && isHidden) {
     return null;

--- a/cardstack/src/hooks/index.ts
+++ b/cardstack/src/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './transactions';
 export * from './use-lifetime-earnings-data';
 export * from './prepaid-card/useAuthToken';
 export * from './notifications-preferences/useUpdateNotificationPreferences';
+export * from './useMutationEffects';

--- a/cardstack/src/hooks/useMutationEffects.ts
+++ b/cardstack/src/hooks/useMutationEffects.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+
+type EffectParams = {
+  status: boolean;
+  callback: () => void;
+};
+
+type MutationStatus = 'loading' | 'success' | 'error';
+
+type useMutationEffectsParams = Partial<Record<MutationStatus, EffectParams>>;
+
+export const useMutationEffects = ({
+  loading,
+  success,
+  error,
+}: useMutationEffectsParams) => {
+  useEffect(() => {
+    if (loading?.status) {
+      loading?.callback();
+    }
+  }, [loading]);
+
+  useEffect(() => {
+    if (success?.status) {
+      success?.callback();
+    }
+  }, [success]);
+
+  useEffect(() => {
+    if (error?.status) {
+      error?.callback();
+    }
+  }, [error]);
+};

--- a/cardstack/src/screens/PayMerchant/usePayMerchant.ts
+++ b/cardstack/src/screens/PayMerchant/usePayMerchant.ts
@@ -21,6 +21,7 @@ import { useAccountSettings, useWallets } from '@rainbow-me/hooks';
 import logger from 'logger';
 import { usePayMerchantMutation } from '@cardstack/services';
 import { useLoadingOverlay } from '@cardstack/navigation';
+import { Network } from '@rainbow-me/helpers/networkTypes';
 
 export const PAY_STEP = {
   EDIT_AMOUNT: 'EDIT_AMOUNT',
@@ -79,8 +80,8 @@ const usePayMerchantRequest = ({
     });
 
     payMerchant({
-      selectedWallet,
-      network: qrCodeNetwork,
+      walletId: selectedWallet.id,
+      network: qrCodeNetwork as Network,
       merchantAddress,
       prepaidCardAddress: selectedPrepaidCard?.address || '',
       spendAmount,
@@ -98,6 +99,10 @@ const usePayMerchantRequest = ({
   ]);
 
   const onPayMerchantSuccess = useCallback(async () => {
+    if (!receipt) {
+      return;
+    }
+
     const { nativeBalanceDisplay } = convertSpendForBalanceDisplay(
       String(spendAmount),
       accountCurrency,
@@ -139,17 +144,10 @@ const usePayMerchantRequest = ({
   ]);
 
   useEffect(() => {
-    if (isSuccess && receipt) {
+    if (isSuccess) {
       onPayMerchantSuccess();
     }
-  }, [
-    dismissLoadingOverlay,
-    error,
-    isError,
-    isSuccess,
-    onPayMerchantSuccess,
-    receipt,
-  ]);
+  }, [isSuccess, onPayMerchantSuccess]);
 
   useEffect(() => {
     if (isError) {

--- a/cardstack/src/screens/TransferCardScreen/TransferCardScreen.tsx
+++ b/cardstack/src/screens/TransferCardScreen/TransferCardScreen.tsx
@@ -46,7 +46,12 @@ const TransferCardScreen = () => {
           multiline
         />
       </Container>
-      <Button marginVertical={5} variant="primary" onPress={onScanPress}>
+      <Button
+        marginVertical={5}
+        variant="primary"
+        onPress={onScanPress}
+        disabled
+      >
         {strings.scanQrBtn}
       </Button>
       <Button disabled={!isValidAddress} onPress={onTransferPress}>

--- a/cardstack/src/screens/TransferCardScreen/TransferCardScreen.tsx
+++ b/cardstack/src/screens/TransferCardScreen/TransferCardScreen.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { useTransferCardScreen } from './useTransferCardScreen';
+import { strings } from './strings';
 import { Button, Container, Icon, Input, Text } from '@cardstack/components';
 
 const TransferCardScreen = () => {
@@ -28,15 +29,15 @@ const TransferCardScreen = () => {
         alignSelf="flex-end"
       />
       <Text color="white" weight="bold" textAlign="center" size="medium">
-        Transfer Card
+        {strings.title}
       </Text>
       <Text color="blueText" size="body" padding={10} textAlign="center">
-        You can enter an EOA address or Scan it to transfer this PrepaidCard
+        {strings.subtitle}
       </Text>
       <Container paddingVertical={5}>
         <Input
           paddingVertical={2}
-          placeholder="Enter address (0x...)"
+          placeholder={strings.inputPlaceholder}
           color="white"
           placeholderTextColor="gray"
           borderBottomColor="teal"
@@ -46,10 +47,10 @@ const TransferCardScreen = () => {
         />
       </Container>
       <Button marginVertical={5} variant="primary" onPress={onScanPress}>
-        Scan QR code
+        {strings.scanQrBtn}
       </Button>
       <Button disabled={!isValidAddress} onPress={onTransferPress}>
-        Transfer
+        {strings.transferBtn}
       </Button>
     </Container>
   );

--- a/cardstack/src/screens/TransferCardScreen/TransferCardScreen.tsx
+++ b/cardstack/src/screens/TransferCardScreen/TransferCardScreen.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
 
-import { useNavigation } from '@react-navigation/core';
 import { useTransferCardScreen } from './useTransferCardScreen';
 import { Button, Container, Icon, Input, Text } from '@cardstack/components';
 
 const TransferCardScreen = () => {
-  const { goBack } = useNavigation();
-
   const {
     isValidAddress,
     onChangeText,
     onTransferPress,
     onScanPress,
+    goBack,
   } = useTransferCardScreen();
 
   return (

--- a/cardstack/src/screens/TransferCardScreen/__tests__/TransferCardScreen.test.tsx
+++ b/cardstack/src/screens/TransferCardScreen/__tests__/TransferCardScreen.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, fireEvent, act } from '../../../../src/test-utils';
+import TransferCardScreen from '../TransferCardScreen';
+import { useTransferCardScreen } from '../useTransferCardScreen';
+
+jest.mock('../useTransferCardScreen', () => ({
+  useTransferCardScreen: jest.fn(),
+}));
+
+describe('TransferCardScreen', () => {
+  const onTransferPress = jest.fn();
+  const onScanPress = jest.fn();
+  const goBack = jest.fn();
+
+  const mockUseTransferCardScreenHelper = (
+    overwriteProps?: Partial<ReturnType<typeof useTransferCardScreen>>
+  ) =>
+    (useTransferCardScreen as jest.Mock).mockImplementation(() => ({
+      isValidAddress: true,
+      onTransferPress,
+      onScanPress,
+      goBack,
+      ...overwriteProps,
+    }));
+
+  beforeEach(() => {
+    mockUseTransferCardScreenHelper();
+  });
+
+  it('should go back on X icon press', () => {
+    const { getByTestId } = render(<TransferCardScreen />);
+
+    const closeBtn = getByTestId('icon-x');
+
+    act(() => {
+      fireEvent.press(closeBtn);
+    });
+
+    expect(goBack).toBeCalledTimes(1);
+  });
+
+  it('should call onScanPress', () => {
+    const { getByText } = render(<TransferCardScreen />);
+
+    const scanBtn = getByText('Scan QR code');
+
+    act(() => {
+      fireEvent.press(scanBtn);
+    });
+
+    expect(onScanPress).toBeCalledTimes(1);
+  });
+
+  it('should disable transfer btn if address is not valid', () => {
+    mockUseTransferCardScreenHelper({ isValidAddress: false });
+
+    const { getByText } = render(<TransferCardScreen />);
+
+    const transferBtn = getByText('Transfer');
+
+    expect(transferBtn).toBeDisabled();
+  });
+
+  it('should enable transfer btn if address is valid', () => {
+    mockUseTransferCardScreenHelper({ isValidAddress: true });
+
+    const { getByText } = render(<TransferCardScreen />);
+
+    const transferBtn = getByText('Transfer');
+
+    expect(transferBtn).toBeEnabled();
+  });
+
+  it('should call onTrasferPress', () => {
+    const { getByText } = render(<TransferCardScreen />);
+
+    const transferBtn = getByText('Transfer');
+
+    act(() => {
+      fireEvent.press(transferBtn);
+    });
+
+    expect(onTransferPress).toBeCalledTimes(1);
+  });
+});

--- a/cardstack/src/screens/TransferCardScreen/__tests__/TransferCardScreen.test.tsx
+++ b/cardstack/src/screens/TransferCardScreen/__tests__/TransferCardScreen.test.tsx
@@ -40,7 +40,7 @@ describe('TransferCardScreen', () => {
     expect(goBack).toBeCalledTimes(1);
   });
 
-  it('should call onScanPress', () => {
+  it('should not call onScanPress', () => {
     const { getByText } = render(<TransferCardScreen />);
 
     const scanBtn = getByText(strings.scanQrBtn);
@@ -49,7 +49,8 @@ describe('TransferCardScreen', () => {
       fireEvent.press(scanBtn);
     });
 
-    expect(onScanPress).toBeCalledTimes(1);
+    expect(scanBtn).toBeDisabled();
+    expect(onScanPress).not.toBeCalled();
   });
 
   it('should disable transfer btn if address is not valid', () => {

--- a/cardstack/src/screens/TransferCardScreen/__tests__/TransferCardScreen.test.tsx
+++ b/cardstack/src/screens/TransferCardScreen/__tests__/TransferCardScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent, act } from '../../../../src/test-utils';
+import { strings } from '../strings';
 import TransferCardScreen from '../TransferCardScreen';
 import { useTransferCardScreen } from '../useTransferCardScreen';
 
@@ -42,7 +43,7 @@ describe('TransferCardScreen', () => {
   it('should call onScanPress', () => {
     const { getByText } = render(<TransferCardScreen />);
 
-    const scanBtn = getByText('Scan QR code');
+    const scanBtn = getByText(strings.scanQrBtn);
 
     act(() => {
       fireEvent.press(scanBtn);
@@ -56,7 +57,7 @@ describe('TransferCardScreen', () => {
 
     const { getByText } = render(<TransferCardScreen />);
 
-    const transferBtn = getByText('Transfer');
+    const transferBtn = getByText(strings.transferBtn);
 
     expect(transferBtn).toBeDisabled();
   });
@@ -66,7 +67,7 @@ describe('TransferCardScreen', () => {
 
     const { getByText } = render(<TransferCardScreen />);
 
-    const transferBtn = getByText('Transfer');
+    const transferBtn = getByText(strings.transferBtn);
 
     expect(transferBtn).toBeEnabled();
   });
@@ -74,7 +75,7 @@ describe('TransferCardScreen', () => {
   it('should call onTrasferPress', () => {
     const { getByText } = render(<TransferCardScreen />);
 
-    const transferBtn = getByText('Transfer');
+    const transferBtn = getByText(strings.transferBtn);
 
     act(() => {
       fireEvent.press(transferBtn);

--- a/cardstack/src/screens/TransferCardScreen/__tests__/useTransferCardScreen.test.ts
+++ b/cardstack/src/screens/TransferCardScreen/__tests__/useTransferCardScreen.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react-hooks';
 
 import { Alert } from 'react-native';
 import { useTransferCardScreen } from '../useTransferCardScreen';
+import { strings } from '../strings';
 import { useTransferPrepaidCardMutation } from '@cardstack/services';
 
 const validAddress = '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13';
@@ -83,7 +84,7 @@ describe('useTransferCardScreen', () => {
     });
 
     expect(mockedShowOverlay).toBeCalledWith({
-      title: 'Transferring Prepaid Card...',
+      title: strings.loadingTitle,
     });
 
     expect(mockedTransferPrepaidCard).toBeCalledWith({
@@ -107,9 +108,9 @@ describe('useTransferCardScreen', () => {
     });
 
     expect(spyAlert).toBeCalledWith(
-      'Success',
-      'Your Prepaid Card has been transferred!',
-      [{ text: 'Okay', onPress: mockedGoBack }],
+      strings.alert.success.title,
+      strings.alert.success.message,
+      [{ text: strings.alert.btnLabel, onPress: mockedGoBack }],
       undefined
     );
   });
@@ -131,9 +132,9 @@ describe('useTransferCardScreen', () => {
     });
 
     expect(spyAlert).toBeCalledWith(
-      'Oops!',
-      'Something went wrong',
-      [{ text: 'Okay', onPress: mockedGoBack }],
+      strings.alert.error.title,
+      strings.alert.error.message,
+      [{ text: strings.alert.btnLabel, onPress: mockedGoBack }],
       undefined
     );
   });

--- a/cardstack/src/screens/TransferCardScreen/strings.ts
+++ b/cardstack/src/screens/TransferCardScreen/strings.ts
@@ -5,4 +5,16 @@ export const strings = {
   inputPlaceholder: 'Enter address (0x...)',
   scanQrBtn: 'Scan QR Code',
   transferBtn: 'Transfer',
+  loadingTitle: 'Transferring Prepaid Card...',
+  alert: {
+    btnLabel: 'Okay',
+    success: {
+      title: 'Success',
+      message: 'Your Prepaid Card has been transferred!',
+    },
+    error: {
+      title: 'Oops!',
+      message: 'Something went wrong',
+    },
+  },
 };

--- a/cardstack/src/screens/TransferCardScreen/strings.ts
+++ b/cardstack/src/screens/TransferCardScreen/strings.ts
@@ -1,0 +1,8 @@
+export const strings = {
+  title: 'Transfer Card',
+  subtitle:
+    'You can enter an EOA address or Scan it to transfer this PrepaidCard',
+  inputPlaceholder: 'Enter address (0x...)',
+  scanQrBtn: 'Scan QR Code',
+  transferBtn: 'Transfer',
+};

--- a/cardstack/src/screens/TransferCardScreen/useTransferCardScreen.ts
+++ b/cardstack/src/screens/TransferCardScreen/useTransferCardScreen.ts
@@ -1,19 +1,97 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
+import { useNavigation, useRoute } from '@react-navigation/core';
 import { useSendAddressValidation } from '@rainbow-me/components/send/SendSheet';
+import { useAccountSettings, useWallets } from '@rainbow-me/hooks';
+import { RouteType } from '@cardstack/navigation/types';
+import { useTransferPrepaidCardMutation } from '@cardstack/services';
+import { useLoadingOverlay } from '@cardstack/navigation';
+import { Alert } from '@rainbow-me/components/alerts';
+import { useMutationEffects } from '@cardstack/hooks';
+
+interface NavParams {
+  prepaidCardAddress: string;
+}
 
 export const useTransferCardScreen = () => {
-  const [address, setAddress] = useState();
+  const {
+    params: { prepaidCardAddress },
+  } = useRoute<RouteType<NavParams>>();
 
-  const isValidAddress = useSendAddressValidation(address);
+  const { goBack } = useNavigation();
+
+  const [newOwnerAddress, setNewOwnerAddress] = useState('');
+
+  const isValidAddress = useSendAddressValidation(newOwnerAddress);
+
+  const { accountAddress, network } = useAccountSettings();
+  const { selectedWallet } = useWallets();
+
+  const { showLoadingOverlay, dismissLoadingOverlay } = useLoadingOverlay();
 
   const onChangeText = useCallback(text => {
-    setAddress(text);
+    setNewOwnerAddress(text);
   }, []);
 
-  const onTransferPress = useCallback(() => {
-    // TODO: handle transfer
-  }, []);
+  const [
+    transferPrepaidCard,
+    { isSuccess, isError },
+  ] = useTransferPrepaidCardMutation();
+
+  const onTransferFinishedAlert = useCallback(
+    ({ title, message }) => () => {
+      dismissLoadingOverlay();
+
+      Alert({
+        message,
+        title,
+        buttons: [{ text: 'Okay', onPress: goBack }],
+      });
+    },
+    [dismissLoadingOverlay, goBack]
+  );
+
+  useMutationEffects(
+    useMemo(
+      () => ({
+        success: {
+          status: isSuccess,
+          callback: onTransferFinishedAlert({
+            title: 'Success',
+            message: 'Your Prepaid Card has been transferred!',
+          }),
+        },
+        error: {
+          status: isError,
+          callback: onTransferFinishedAlert({
+            title: 'Ops!',
+            message: 'Something went wrong',
+          }),
+        },
+      }),
+      [isError, isSuccess, onTransferFinishedAlert]
+    )
+  );
+
+  const onTransferPress = useCallback(async () => {
+    showLoadingOverlay({ title: 'Transferring Prepaid Card...' });
+
+    transferPrepaidCard({
+      accountAddress,
+      network,
+      prepaidCardAddress,
+      newOwner: newOwnerAddress,
+      walletId: selectedWallet.id,
+    });
+  }, [
+    accountAddress,
+    network,
+    newOwnerAddress,
+    prepaidCardAddress,
+    selectedWallet.id,
+    showLoadingOverlay,
+    transferPrepaidCard,
+  ]);
 
   const onScanPress = useCallback(() => {
     // TODO: handle scan qr code
@@ -24,5 +102,6 @@ export const useTransferCardScreen = () => {
     onChangeText,
     onTransferPress,
     onScanPress,
+    goBack,
   };
 };

--- a/cardstack/src/screens/TransferCardScreen/useTransferCardScreen.ts
+++ b/cardstack/src/screens/TransferCardScreen/useTransferCardScreen.ts
@@ -64,7 +64,7 @@ export const useTransferCardScreen = () => {
         error: {
           status: isError,
           callback: onTransferFinishedAlert({
-            title: 'Ops!',
+            title: 'Oops!',
             message: 'Something went wrong',
           }),
         },

--- a/cardstack/src/screens/TransferCardScreen/useTransferCardScreen.ts
+++ b/cardstack/src/screens/TransferCardScreen/useTransferCardScreen.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 
 import { useNavigation, useRoute } from '@react-navigation/core';
+import { strings } from './strings';
 import { useSendAddressValidation } from '@rainbow-me/components/send/SendSheet';
 import { useAccountSettings, useWallets } from '@rainbow-me/hooks';
 import { RouteType } from '@cardstack/navigation/types';
@@ -45,7 +46,7 @@ export const useTransferCardScreen = () => {
       Alert({
         message,
         title,
-        buttons: [{ text: 'Okay', onPress: goBack }],
+        buttons: [{ text: strings.alert.btnLabel, onPress: goBack }],
       });
     },
     [dismissLoadingOverlay, goBack]
@@ -57,15 +58,15 @@ export const useTransferCardScreen = () => {
         success: {
           status: isSuccess,
           callback: onTransferFinishedAlert({
-            title: 'Success',
-            message: 'Your Prepaid Card has been transferred!',
+            title: strings.alert.success.title,
+            message: strings.alert.success.message,
           }),
         },
         error: {
           status: isError,
           callback: onTransferFinishedAlert({
-            title: 'Oops!',
-            message: 'Something went wrong',
+            title: strings.alert.error.title,
+            message: strings.alert.error.message,
           }),
         },
       }),
@@ -74,7 +75,7 @@ export const useTransferCardScreen = () => {
   );
 
   const onTransferPress = useCallback(async () => {
-    showLoadingOverlay({ title: 'Transferring Prepaid Card...' });
+    showLoadingOverlay({ title: strings.loadingTitle });
 
     transferPrepaidCard({
       accountAddress,

--- a/cardstack/src/services/merchant/merchant-api.ts
+++ b/cardstack/src/services/merchant/merchant-api.ts
@@ -12,6 +12,7 @@ const merchantApi = safesApi.injectEndpoints({
           params,
           {
             errorLogMessage: 'Error claiming merchant revenue',
+            resetHdProvider: true,
           }
         );
       },

--- a/cardstack/src/services/merchant/merchant-service.ts
+++ b/cardstack/src/services/merchant/merchant-service.ts
@@ -4,7 +4,6 @@ import BigNumber from 'bignumber.js';
 import { ClaimRevenueQueryParams } from './merchant-types';
 import { TokenType } from '@cardstack/types';
 import Web3Instance from '@cardstack/models/web3-instance';
-import HDProvider from '@cardstack/models/hd-provider';
 
 // Mutations
 
@@ -49,7 +48,4 @@ export const claimMerchantRevenue = async ({
   });
 
   await Promise.all(promises);
-
-  // resets signed provider and web3 instance to kill poller
-  await HDProvider.reset();
 };

--- a/cardstack/src/services/prepaid-cards/prepaid-card-api.ts
+++ b/cardstack/src/services/prepaid-cards/prepaid-card-api.ts
@@ -5,8 +5,13 @@ import {
   PrepaidCardPayMerchantQueryParams,
   PrepaidCardSafeQueryParams,
   PrepaidCardsQueryResult,
+  PrepaidCardTransferQueryParams,
 } from './prepaid-card-types';
-import { fetchPrepaidCards, payMerchant } from './prepaid-card-service';
+import {
+  fetchPrepaidCards,
+  payMerchant,
+  transferPrepaidCard,
+} from './prepaid-card-service';
 
 const prepaidCardApi = safesApi.injectEndpoints({
   endpoints: builder => ({
@@ -24,7 +29,6 @@ const prepaidCardApi = safesApi.injectEndpoints({
       },
       providesTags: [CacheTags.PREPAID_CARDS],
     }),
-
     payMerchant: builder.mutation<
       TransactionReceipt,
       PrepaidCardPayMerchantQueryParams
@@ -40,10 +44,26 @@ const prepaidCardApi = safesApi.injectEndpoints({
       },
       invalidatesTags: [CacheTags.SAFES],
     }),
+    transferPrepaidCard: builder.mutation<
+      TransactionReceipt,
+      PrepaidCardTransferQueryParams
+    >({
+      async queryFn(params) {
+        return queryPromiseWrapper<
+          TransactionReceipt,
+          PrepaidCardTransferQueryParams
+        >(transferPrepaidCard, params, {
+          errorLogMessage: 'Error while transferring prepaid card',
+          resetHdProvider: true,
+        });
+      },
+      invalidatesTags: [CacheTags.SAFES],
+    }),
   }),
 });
 
 export const {
   usePayMerchantMutation,
   useGetPrepaidCardsQuery,
+  useTransferPrepaidCardMutation,
 } = prepaidCardApi;

--- a/cardstack/src/services/prepaid-cards/prepaid-card-service.ts
+++ b/cardstack/src/services/prepaid-cards/prepaid-card-service.ts
@@ -1,11 +1,15 @@
-import { PrepaidCardSafe } from '@cardstack/cardpay-sdk';
+import { getSDK, PrepaidCardSafe } from '@cardstack/cardpay-sdk';
 import { updateSafeWithTokenPrices } from '../gnosis-service';
-import { PrepaidCardSafeQueryParams } from './prepaid-card-types';
+import {
+  PrepaidCardSafeQueryParams,
+  PrepaidCardTransferQueryParams,
+} from './prepaid-card-types';
 import { getSafeData } from '@cardstack/services';
 import logger from 'logger';
 import { fetchCardCustomizationFromDID } from '@cardstack/utils';
 import { getSafesInstance } from '@cardstack/models';
 import { PrepaidCardType } from '@cardstack/types';
+import Web3Instance from '@cardstack/models/web3-instance';
 
 export const addPrepaidCardCustomization = async (card: PrepaidCardSafe) => {
   try {
@@ -74,4 +78,30 @@ export const fetchPrepaidCards = async ({
   return {
     prepaidCards: extendedPrepaidCards,
   };
+};
+
+// Mutations
+
+export const transferPrepaidCard = async ({
+  prepaidCardAddress,
+  newOwner,
+  walletId,
+  network,
+  accountAddress,
+}: PrepaidCardTransferQueryParams) => {
+  const web3 = await Web3Instance.get({
+    walletId,
+    network,
+  });
+
+  const prepaidCardInstance = await getSDK('PrepaidCard', web3);
+
+  const transfer = await prepaidCardInstance.transfer(
+    prepaidCardAddress,
+    newOwner,
+    undefined,
+    { from: accountAddress }
+  );
+
+  return transfer;
 };

--- a/cardstack/src/services/prepaid-cards/prepaid-card-types.ts
+++ b/cardstack/src/services/prepaid-cards/prepaid-card-types.ts
@@ -1,4 +1,5 @@
 import { NativeCurrency } from '@cardstack/cardpay-sdk';
+import { SignedProviderParams } from '@cardstack/models/hd-provider';
 import { PrepaidCardType } from '@cardstack/types';
 
 export interface PrepaidCardsQueryResult {
@@ -8,4 +9,10 @@ export interface PrepaidCardsQueryResult {
 export interface PrepaidCardSafeQueryParams {
   accountAddress: string;
   nativeCurrency: NativeCurrency;
+}
+
+export interface PrepaidCardTransferQueryParams extends SignedProviderParams {
+  accountAddress: string;
+  prepaidCardAddress: string;
+  newOwner: string;
 }

--- a/cardstack/src/services/prepaid-cards/prepaid-card-types.ts
+++ b/cardstack/src/services/prepaid-cards/prepaid-card-types.ts
@@ -2,6 +2,11 @@ import { NativeCurrency } from '@cardstack/cardpay-sdk';
 import { SignedProviderParams } from '@cardstack/models/hd-provider';
 import { PrepaidCardType } from '@cardstack/types';
 
+interface SignedPrepaidCardBaseParams extends SignedProviderParams {
+  accountAddress: string;
+  prepaidCardAddress: string;
+}
+
 export interface PrepaidCardsQueryResult {
   prepaidCards: PrepaidCardType[];
 }
@@ -11,8 +16,13 @@ export interface PrepaidCardSafeQueryParams {
   nativeCurrency: NativeCurrency;
 }
 
-export interface PrepaidCardTransferQueryParams extends SignedProviderParams {
-  accountAddress: string;
-  prepaidCardAddress: string;
+export interface PrepaidCardTransferQueryParams
+  extends SignedPrepaidCardBaseParams {
   newOwner: string;
+}
+
+export interface PrepaidCardPayMerchantQueryParams
+  extends SignedPrepaidCardBaseParams {
+  spendAmount: number;
+  merchantAddress: string;
 }

--- a/cardstack/src/services/utils/query-promise-wrapper.ts
+++ b/cardstack/src/services/utils/query-promise-wrapper.ts
@@ -1,4 +1,5 @@
 import { captureException } from '@sentry/minimal';
+import HDProvider from '@cardstack/models/hd-provider';
 import logger from 'logger';
 
 type QueryError = {
@@ -17,6 +18,7 @@ type QuerySuccess<TResult> = {
 interface Options {
   errorStatus?: number;
   errorLogMessage?: string;
+  resetHdProvider?: boolean;
 }
 
 export const queryPromiseWrapper = async <TResult, TArgs>(
@@ -40,5 +42,7 @@ export const queryPromiseWrapper = async <TResult, TArgs>(
         data: error,
       },
     };
+  } finally {
+    options?.resetHdProvider && (await HDProvider.reset());
   }
 };


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
This PR:

- Adds the mutation to transfer a prepaid card 
- Adds a new hook `useMutationEffects`, which can be reused across useMutation hooks to handle loading, success and error status 
- Resolves a TODO, to move payMerchant from api creation to prepaidcard services 
- Adds the ability to disable HDProvider on the finally block of `queryWrapper`
- Adds UI and logic test for transfer screen 
- Disables Scan QR Code until feature is built 

As I mentioned on the meeting, we can use this screen as a model for new screens where the structure/pattern is like this:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/20520102/155540202-e65c0fa7-df3c-4511-8d55-03609a9681f7.png">
~~We could move even further if we want to extract the strings into it's own file too, the gain would be already having the strings out for i18n and for testing, we don't need to rely on the text itself, because in need to change one copy we are able 
 to just update the strings file without needing to mess with the tests and the screen file, but I'll leave it open to discussion.~~ (Moved to their own file, after team's discussion)

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

The flow [GIF](https://linear.app/cardstack/issue/CS-3210#comment-fd95cd30) is on Linear bc it was too big for gtb.

Here I'll leave the test coverage: 

<img width="500" alt="image" src="https://user-images.githubusercontent.com/20520102/155538846-d99dd561-fe62-46ef-9fdb-ae134f5cdfae.png">

it's missing just the onScan function, which hasn’t been implemented yet.

