### PR TITLE
[CS-3247]: Use ppCard address for receipt header

### DIFF
--- a/cardstack/src/screens/PayMerchant/usePayMerchant.ts
+++ b/cardstack/src/screens/PayMerchant/usePayMerchant.ts
@@ -126,7 +126,7 @@ const usePayMerchantRequest = ({
         timestamp,
         transactionHash: receipt.transactionHash,
         merchantSafeAddress: merchantAddress,
-        address: receipt.from,
+        address: selectedPrepaidCard?.address,
         cardCustomization: selectedPrepaidCard?.cardCustomization,
       });
     });


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

<!-- Include a summary of the changes. -->

The `receipt.from` refers to the relay server, when we actually want to show the selected PrepaidCard address that is from, this PR fixes this issue.

