### PR TITLE
[CS-3290]: Fix tabHeader size and make it customizable 

### DIFF
--- a/cardstack/src/components/MainHeader/MainHeader.tsx
+++ b/cardstack/src/components/MainHeader/MainHeader.tsx
@@ -1,19 +1,36 @@
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, ReactNode, useCallback } from 'react';
 
-import { useSafeArea } from 'react-native-safe-area-context';
 import { Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import { Container, Icon, Text } from '@cardstack/components';
+import { ContainerProps } from '../Container';
+import {
+  Container,
+  Icon,
+  Text,
+  MainHeaderWrapper,
+} from '@cardstack/components';
 import Routes from '@rainbow-me/navigation/routesNames';
 import { useAccountSettings } from '@rainbow-me/hooks';
 import { networkInfo } from '@rainbow-me/helpers/networkInfo';
 
-const MainHeader = ({ title }: { title: string }) => {
+interface Props extends ContainerProps {
+  title?: string;
+  showNetwork?: boolean;
+  rightIcon?: JSX.Element;
+  leftIcon?: JSX.Element;
+  children?: ReactNode;
+}
+
+const MainHeader = ({
+  title,
+  showNetwork = true,
+  rightIcon,
+  leftIcon,
+  children,
+  ...containerProps
+}: Props) => {
   const { navigate } = useNavigation();
   const { network } = useAccountSettings();
-
-  const insets = useSafeArea();
-  const style = useMemo(() => ({ paddingTop: insets.top + 10 }), [insets]);
 
   const onMenuPress = useCallback(() => navigate(Routes.SETTINGS_MODAL), [
     navigate,
@@ -24,44 +41,46 @@ const MainHeader = ({ title }: { title: string }) => {
   }, []);
 
   return (
-    <Container
-      backgroundColor="backgroundBlue"
-      flexDirection="row"
-      justifyContent="space-between"
-      alignItems="center"
-      padding={4}
-      style={style}
-    >
-      <Icon
-        color="teal"
-        iconSize="medium"
-        name="menu"
-        onPress={onMenuPress}
-        size={28}
-      />
-      <Container
-        flex={1}
-        alignSelf="flex-end"
-        alignItems="center"
-        justifyContent="space-between"
-        flexDirection="column"
-        paddingTop={2}
-      >
-        <Text color="white" size="small" weight="bold">
-          {title}
-        </Text>
-        <Text color="backgroundLightGray" size="xxs">
-          {networkInfo[network].name}
-        </Text>
-      </Container>
-      <Icon
-        color="teal"
-        iconSize="medium"
-        size={22}
-        name="gift"
-        onPress={onRewardPress}
-      />
-    </Container>
+    <MainHeaderWrapper {...containerProps}>
+      {!leftIcon ? (
+        <Icon
+          color="teal"
+          iconSize="medium"
+          name="menu"
+          onPress={onMenuPress}
+          size={28}
+        />
+      ) : (
+        leftIcon
+      )}
+      {!children ? (
+        <Container flex={1} alignItems="center" flexDirection="column">
+          {!!title && (
+            <Text color="white" size="small" weight="bold">
+              {title}
+            </Text>
+          )}
+          {showNetwork && (
+            <Text color="backgroundLightGray" size="xxs">
+              {networkInfo[network].name}
+            </Text>
+          )}
+        </Container>
+      ) : (
+        children
+      )}
+      {!rightIcon ? (
+        <Icon
+          color="teal"
+          iconSize="medium"
+          size={22}
+          name="gift"
+          onPress={onRewardPress}
+        />
+      ) : (
+        rightIcon
+      )}
+    </MainHeaderWrapper>
   );
 };
 

--- a/cardstack/src/components/MainHeader/components/MainHeaderWrapper.tsx
+++ b/cardstack/src/components/MainHeader/components/MainHeaderWrapper.tsx
@@ -1,0 +1,26 @@
+import React, { memo } from 'react';
+
+import { Container, SafeAreaView, ContainerProps } from '@cardstack/components';
+
+import { Device } from '@cardstack/utils';
+
+const MainHeaderWrapper: React.FC<ContainerProps> = ({
+  children,
+  ...props
+}) => (
+  <SafeAreaView backgroundColor="backgroundBlue">
+    <Container
+      flexDirection="row"
+      justifyContent="space-between"
+      alignItems="center"
+      paddingTop={Device.isAndroid ? 3 : 0}
+      paddingBottom={2}
+      paddingHorizontal={5}
+      {...props}
+    >
+      {children}
+    </Container>
+  </SafeAreaView>
+);
+
+export default memo(MainHeaderWrapper);

--- a/cardstack/src/components/MainHeader/index.ts
+++ b/cardstack/src/components/MainHeader/index.ts
@@ -1,1 +1,2 @@
 export { default as MainHeader } from './MainHeader';
+export { default as MainHeaderWrapper } from './components/MainHeaderWrapper';

--- a/cardstack/src/components/SafeAreaView/SafeAreaView.tsx
+++ b/cardstack/src/components/SafeAreaView/SafeAreaView.tsx
@@ -14,6 +14,7 @@ import {
 import { ReactNode } from 'react';
 import {
   SafeAreaView as ReactNativeSafeAreaView,
+  StatusBar,
   ViewProps,
 } from 'react-native';
 
@@ -39,3 +40,7 @@ export const SafeAreaView = createRestyleComponent<SafeAreaViewProps, Theme>(
   [layout, spacing, position, border, backgroundColor],
   ReactNativeSafeAreaView
 );
+
+SafeAreaView.defaultProps = {
+  style: { paddingTop: StatusBar.currentHeight },
+};

--- a/cardstack/src/screens/PrepaidCardModal.tsx
+++ b/cardstack/src/screens/PrepaidCardModal.tsx
@@ -1,6 +1,6 @@
 import { useRoute } from '@react-navigation/core';
 import React, { memo } from 'react';
-import { SectionList, StatusBar, StyleSheet } from 'react-native';
+import { SectionList } from 'react-native';
 import { TransactionListLoading } from '../components/TransactionList/TransactionListLoading';
 import {
   Container,
@@ -14,12 +14,6 @@ import {
 } from '@cardstack/components';
 import { usePrepaidCardTransactions } from '@cardstack/hooks';
 import { sectionStyle } from '@cardstack/utils/layouts';
-
-const styles = StyleSheet.create({
-  container: {
-    paddingTop: StatusBar.currentHeight || 1,
-  },
-});
 
 const PrepaidCardModal = () => {
   const {
@@ -36,7 +30,7 @@ const PrepaidCardModal = () => {
       flex={1}
       width="100%"
       alignItems="center"
-      style={styles.container}
+      paddingTop={1}
     >
       <SheetHandle color="buttonDarkBackground" opacity={1} />
       <PrepaidCard

--- a/cardstack/src/screens/TransactionConfirmation.tsx
+++ b/cardstack/src/screens/TransactionConfirmation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StatusBar, StyleSheet } from 'react-native';
+import { StatusBar } from 'react-native';
 import { GasSpeedButton } from '../../../src/components/gas';
 import { useTransactionConfirmation } from '@cardstack/hooks';
 import {
@@ -7,15 +7,6 @@ import {
   TransactionConfirmationSheet,
   SafeAreaView,
 } from '@cardstack/components';
-
-const styles = StyleSheet.create({
-  safeAreaViewStyle: {
-    backgroundColor: 'black',
-    flex: 1,
-    width: '100%',
-    paddingTop: StatusBar.currentHeight || 0,
-  },
-});
 
 const TransactionConfirmation = () => {
   const {
@@ -31,7 +22,7 @@ const TransactionConfirmation = () => {
   } = useTransactionConfirmation();
 
   return (
-    <SafeAreaView style={styles.safeAreaViewStyle}>
+    <SafeAreaView backgroundColor="black" flex={1} width="100%">
       <StatusBar barStyle="light-content" />
       <TransactionConfirmationSheet
         data={data}

--- a/cardstack/src/screens/TransferCardScreen/TransferCardScreen.tsx
+++ b/cardstack/src/screens/TransferCardScreen/TransferCardScreen.tsx
@@ -5,12 +5,17 @@ import {
   KeyboardAvoidingView,
   StyleSheet,
   TouchableWithoutFeedback,
-  SafeAreaView,
-  StatusBar,
 } from 'react-native';
 import { useTransferCardScreen } from './useTransferCardScreen';
 import { strings } from './strings';
-import { Button, Container, Icon, Input, Text } from '@cardstack/components';
+import {
+  Button,
+  Container,
+  Icon,
+  Input,
+  SafeAreaView,
+  Text,
+} from '@cardstack/components';
 import { Device, screenHeight } from '@cardstack/utils';
 import { colors } from '@cardstack/theme';
 import { useDimensions } from '@rainbow-me/hooks';
@@ -20,12 +25,6 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingHorizontal: 10,
     backgroundColor: colors.backgroundDarkPurple,
-  },
-  safeArea: {
-    paddingTop: StatusBar.currentHeight,
-    flex: 1,
-    margin: 8,
-    alignItems: 'center',
   },
 });
 
@@ -56,7 +55,7 @@ const TransferCardScreen = () => {
         keyboardVerticalOffset={keyboardOffset}
         enabled={Device.isIOS}
       >
-        <SafeAreaView style={styles.safeArea}>
+        <SafeAreaView flex={1} margin={2} alignItems="center">
           <Icon
             flexDirection="row"
             name="x"


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Make mainHeader more dynamic to match or at least get pretty close to the `Settings` header, also it makes the StatusBar.currentHeight as default on SafeArea's paddingTop (Idk why it doesn't work out of box for android anymore, or if it's something on this project). MainHeader now is fully customizable, it may not make much sense right now, but it will definitely be useful on my next task.

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Simulator Screen Recording - iPhone 12 - 2022-03-04 at 16 25 39](https://user-images.githubusercontent.com/20520102/156832554-f1053d9f-6ff2-42cf-b088-76dfa9163b79.gif)


<img width="300" alt="image" src="https://user-images.githubusercontent.com/20520102/156832605-48b4bcff-9ea6-4c4a-938a-77593615caf6.png">
