### PR TITLE
[CS-3277]: Add QrCode overlay on ScannerScreen

### DIFF
--- a/cardstack/src/screens/QRScannerScreen/components/QRCodeOverlay.tsx
+++ b/cardstack/src/screens/QRScannerScreen/components/QRCodeOverlay.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import Svg, { Defs, ClipPath, Path, Rect, Mask } from 'react-native-svg';
+import { screenHeight, screenWidth } from '@cardstack/utils';
+import { colors } from '@cardstack/theme';
+
+const halfScreen = screenWidth / 2;
+
+const fullScreenSizeProps = {
+  height: '100%',
+  width: '100%',
+};
+
+// CrossHair
+const CROSSHAIR_SIZE = screenWidth * 0.72;
+
+const crosshair = {
+  radius: CROSSHAIR_SIZE * 0.1,
+  position: {
+    x: halfScreen - CROSSHAIR_SIZE / 2,
+    y: screenHeight * 0.18,
+  },
+  stroke: { color: colors.teal, width: 5 },
+};
+
+// HollowSquare
+const HOLLOW_SQUARE_SIZE = CROSSHAIR_SIZE * 0.94;
+
+const hollowSquare = {
+  radius: HOLLOW_SQUARE_SIZE * 0.09,
+  position: {
+    x: halfScreen - HOLLOW_SQUARE_SIZE / 2,
+    y: crosshair.position.y + 8,
+  },
+};
+
+// Path Clip Drawing
+const LINE_SIZE = CROSSHAIR_SIZE / 5.5;
+
+const path = {
+  position: {
+    x: screenWidth - crosshair.position.x,
+    y: crosshair.position.y + CROSSHAIR_SIZE,
+  },
+  distance: CROSSHAIR_SIZE - LINE_SIZE / 2,
+  drawSquare: `h-${LINE_SIZE}v-${LINE_SIZE}h${LINE_SIZE}v${LINE_SIZE}z`,
+  translate: 12,
+};
+
+export const QRCodeOverlay = () => (
+  <Svg {...fullScreenSizeProps}>
+    <Defs>
+      <ClipPath id="a">
+        <Path
+          d={`m${path.position.x} ${path.position.y}${path.drawSquare}m-${path.distance} 0${path.drawSquare}m${path.distance}-${path.distance}${path.drawSquare}m-${path.distance} 0${path.drawSquare}`}
+          translate={path.translate}
+        />
+      </ClipPath>
+      <Mask id="mask" x="0" y="0" {...fullScreenSizeProps}>
+        <Rect {...fullScreenSizeProps} fill="white" />
+        <Rect
+          x={hollowSquare.position.x}
+          y={hollowSquare.position.y}
+          rx={hollowSquare.radius}
+          width={HOLLOW_SQUARE_SIZE}
+          height={HOLLOW_SQUARE_SIZE}
+          fill="black"
+        />
+      </Mask>
+    </Defs>
+    <Rect
+      {...fullScreenSizeProps}
+      mask="url(#mask)"
+      fill="#272330"
+      stroke="black"
+      opacity={0.8}
+    />
+    <Rect
+      clipPath="url(#a)"
+      x={crosshair.position.x}
+      y={crosshair.position.y}
+      width={CROSSHAIR_SIZE}
+      height={CROSSHAIR_SIZE}
+      rx={crosshair.radius}
+      fill="none"
+      stroke={crosshair.stroke.color}
+      strokeWidth={crosshair.stroke.width}
+    />
+  </Svg>
+);

--- a/cardstack/src/screens/QRScannerScreen/components/QRCodeScanner.tsx
+++ b/cardstack/src/screens/QRScannerScreen/components/QRCodeScanner.tsx
@@ -11,6 +11,7 @@ import {
   CROSS_HAIR_TOP,
   EmulatorPasteUriButton,
   SWITCH_SELECTOR_TOP,
+  QRCodeOverlay,
 } from './';
 import {
   CenteredContainer,
@@ -28,7 +29,7 @@ const styles = StyleSheet.create({
     height: '100%',
     width: '100%',
     backgroundColor: '#777',
-    zIndex: 1,
+    zIndex: 0,
   },
 });
 
@@ -81,6 +82,7 @@ export const QRCodeScanner = memo(() => {
           style={styles.camera}
         />
       ) : null}
+      <QRCodeOverlay />
       {isCameraAuthorized ? (
         <CenteredContainer
           position="absolute"
@@ -137,7 +139,12 @@ export const QRCodeScanner = memo(() => {
           )}
         </CenteredContainer>
       ) : null}
-      <Container position="absolute" right={0} top={SWITCH_SELECTOR_TOP + 10}>
+      <Container
+        position="absolute"
+        right={0}
+        top={SWITCH_SELECTOR_TOP + 10}
+        zIndex={2}
+      >
         <EmulatorPasteUriButton />
       </Container>
     </CenteredContainer>

--- a/cardstack/src/screens/QRScannerScreen/components/QRCodeScannerCrosshair.tsx
+++ b/cardstack/src/screens/QRScannerScreen/components/QRCodeScannerCrosshair.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ActivityIndicator } from 'react-native';
 import { useIsEmulator } from 'react-native-device-info';
-import { CenteredContainer, Icon, Text } from '@cardstack/components';
+import { CenteredContainer, Text } from '@cardstack/components';
 
 import { useDimensions } from '@rainbow-me/hooks';
 
@@ -17,8 +17,7 @@ export function QRCodeScannerCrosshair({
   const size = deviceWidth * CrossHairAspectRatio;
 
   return (
-    <CenteredContainer height={size} marginBottom={10} width={size} zIndex={1}>
-      <Icon color="teal" name="crosshair" position="absolute" size={size} />
+    <CenteredContainer height={size} marginBottom={10} width={size} zIndex={10}>
       {isScanningEnabled ? (
         <Text color="white" size="small" textAlign="center" weight="bold">
           {isEmulator ? `Simulator Mode\n (Paste in URI Code)` : 'Scan QR Code'}

--- a/cardstack/src/screens/QRScannerScreen/components/RequestQRCode.tsx
+++ b/cardstack/src/screens/QRScannerScreen/components/RequestQRCode.tsx
@@ -84,7 +84,7 @@ export const RequestQRCode = () => {
   return (
     <Container
       paddingHorizontal={10}
-      paddingTop={isSmallPhone ? 20 : 30}
+      paddingTop={isSmallPhone ? 22 : 30}
       flex={1}
       justifyContent="center"
       alignItems="center"

--- a/cardstack/src/screens/QRScannerScreen/components/index.ts
+++ b/cardstack/src/screens/QRScannerScreen/components/index.ts
@@ -5,3 +5,4 @@ export * from './QRCodeScannerNeedsAuthorization';
 export * from './RequestQRCode';
 export * from './QRScannerContainer';
 export * from './fixture';
+export * from './QRCodeOverlay';


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

<!-- Include a summary of the changes. -->

Creates and adds the QRCode overlay in the ScannerScreen, I've build a custom svg scalable based on the devices dimensions, there are of course some magical numbers, which were chosen based on try and errors to match the design, but I  tested on multiple devices and it looks good. 


### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

<img width="700" alt="image" src="https://user-images.githubusercontent.com/20520102/157084169-8fb6bae1-5b83-4c61-99b8-61696d4469a7.png">

Iphone 12 mini:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/20520102/157084431-6e7980d9-ea67-4d8a-8ea2-43ec65c37ffc.jpeg">

![QROverlay ](https://user-images.githubusercontent.com/20520102/157083681-2de65051-1353-41b0-8c56-a2b1ff534f16.gif)







