### PR TITLE
[Bugfix] Restores onPress for CardPressable in MerchantSafe

### DIFF
--- a/cardstack/src/components/MerchantSafe/MerchantSafe.tsx
+++ b/cardstack/src/components/MerchantSafe/MerchantSafe.tsx
@@ -38,6 +38,7 @@ export const MerchantSafe = ({
         overflow="hidden"
         borderColor="buttonPrimaryBorder"
         testID="inventory-card"
+        onPress={onPress}
         disabled={disabled}
       >
         <SafeHeader


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

onPress was mistakenly removed. This PR re-adds it.

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

https://user-images.githubusercontent.com/129619/157738379-271409eb-b6f8-4fcf-ad8b-f8b430512cde.mp4
