### PR TITLE
[CS-3328] Modals not opening

### DIFF
--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -26,6 +26,7 @@ import { TabBarIcon } from '@cardstack/components';
 import { colors } from '@cardstack/theme';
 import { Device, screenHeight } from '@cardstack/utils';
 import ExpandedAssetSheet from '@rainbow-me/screens/ExpandedAssetSheet';
+import ModalScreen from '@rainbow-me/screens/ModalScreen';
 import { expandedPreset, sheetPreset } from '@rainbow-me/navigation/effects';
 
 const Tab = createBottomTabNavigator();
@@ -103,11 +104,16 @@ const StackNavigator = () => {
 
   // TODO: Create a navigator for each flow and split auth/non-auth
 
-  // Remove last item aka LoadingOverlay, to avoid dupe
-  cardstackGlobalScreens.pop();
+  // Remove last item aka LoadingOverlay, to avoid dupe (on iOS)
+  Device.isIOS && cardstackGlobalScreens.pop();
 
   return (
-    <Stack.Navigator headerMode="none" initialRouteName={initialRoute}>
+    <Stack.Navigator
+      headerMode="none"
+      mode="modal"
+      screenOptions={{ gestureEnabled: true }}
+      initialRouteName={initialRoute}
+    >
       <Stack.Screen
         component={TabNavigator}
         name={RainbowRoutes.SWIPE_LAYOUT}
@@ -129,6 +135,12 @@ const StackNavigator = () => {
         listeners={dismissAndroidKeyboardOnClose}
         name={RainbowRoutes.EXPANDED_ASSET_SHEET_DRILL}
         options={sheetPreset as StackNavigationOptions}
+      />
+      <Stack.Screen
+        component={ModalScreen}
+        listeners={dismissAndroidKeyboardOnClose}
+        name={RainbowRoutes.MODAL_SCREEN}
+        options={expandedPreset as StackNavigationOptions}
       />
     </Stack.Navigator>
   );


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

- Screen options on main Stack Navigator to be modal;
- Adds `ModalScreen` to Modal Navigator;
- Fixes removing last global screen added to stack on Android.

Fixes modals on Android with less-risky changes, by just setting the main Stack Navigator mode to 'modal' and setting navigation `screenOptions` `gesturesEnabled` to be true on Android too (it defaults to true on ios and false on android).

https://reactnavigation.org/docs/5.x/stack-navigator/#mode
https://reactnavigation.org/docs/5.x/stack-navigator/#gestureenabled

- Adds ModalScreen to Modal Navigator;
- Fixes removing last global screen added to stack on Android.

- [x] Completes #(CS-3328)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

https://user-images.githubusercontent.com/129619/157885978-61c65aba-ed86-4a5b-bde9-63b7f9961f5e.mp4


