### PR TITLE
[CS-3211]: Transfer prepaid card using QR code 

### DIFF
--- a/cardstack/src/hooks/index.ts
+++ b/cardstack/src/hooks/index.ts
@@ -5,3 +5,4 @@ export * from './prepaid-card/useAuthToken';
 export * from './notifications-preferences/useUpdateNotificationPreferences';
 export * from './useMutationEffects';
 export * from './useCopyToast';
+export * from './useBooleanState';

--- a/cardstack/src/hooks/useBooleanState.ts
+++ b/cardstack/src/hooks/useBooleanState.ts
@@ -1,12 +1,12 @@
 import { useCallback, useState } from 'react';
 
-export default function useBooleanState(
+export const useBooleanState = (
   initialStateBoolean = false
-): [boolean, () => void, () => void] {
+): [boolean, () => void, () => void] => {
   const [bool, setBool] = useState(initialStateBoolean);
 
   const setTrue = useCallback(() => setBool(true), []);
   const setFalse = useCallback(() => setBool(false), []);
 
   return [bool, setTrue, setFalse];
-}
+};

--- a/cardstack/src/hooks/useCopyToast.tsx
+++ b/cardstack/src/hooks/useCopyToast.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
+import { useBooleanState } from './useBooleanState';
 import { Container, ContainerProps } from '@cardstack/components';
-import { useBooleanState, useClipboard, useTimeout } from '@rainbow-me/hooks';
+import { useClipboard, useTimeout } from '@rainbow-me/hooks';
 import { screenHeight } from '@cardstack/utils';
 import Toast from '@rainbow-me/components/toasts/Toast';
 

--- a/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/QRCodeScannerPage.tsx
+++ b/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/QRCodeScannerPage.tsx
@@ -12,7 +12,7 @@ import {
   CROSSHAIR_SIZE,
 } from './components';
 import { strings } from './strings';
-import { useScanner } from './useScanner';
+import { useScanner, useScannerParams } from './useScanner';
 import {
   Container,
   Text,
@@ -29,12 +29,14 @@ const styles = StyleSheet.create({
   },
 });
 
-const QRCodeScannerPage = () => {
+type QRCodeScannerProps = useScannerParams;
+
+const QRCodeScannerPage = (props: QRCodeScannerProps) => {
   const [error, showError] = useBooleanState();
 
   const { result: isEmulator } = useIsEmulator();
 
-  const { onScan, isLoading } = useScanner();
+  const { onScan, isLoading } = useScanner(props);
 
   const isFocused = useIsFocused();
 

--- a/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/QRCodeScannerPage.tsx
+++ b/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/QRCodeScannerPage.tsx
@@ -19,8 +19,8 @@ import {
   Image,
   AbsoluteFullScreenContainer,
 } from '@cardstack/components';
-import { useBooleanState } from '@rainbow-me/hooks';
 import { colors } from '@cardstack/theme';
+import { useBooleanState } from '@cardstack/hooks';
 
 const styles = StyleSheet.create({
   loadingContainer: { paddingTop: CROSSHAIR_SIZE * 0.45 },

--- a/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/useScanner.ts
+++ b/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/useScanner.ts
@@ -18,7 +18,9 @@ export interface useScannerParams {
   customScanAddressHandler?: (address: string) => void;
 }
 
-export const useScanner = ({ customScanAddressHandler }: useScannerParams) => {
+export const useScanner = ({
+  customScanAddressHandler,
+}: useScannerParams = {}) => {
   const { navigate } = useNavigation();
   const { walletConnectOnSessionRequest } = useWalletConnectConnections();
 
@@ -134,6 +136,7 @@ export const useScanner = ({ customScanAddressHandler }: useScannerParams) => {
       isScanningEnabled,
       disableScanning,
       handleScanInvalid,
+      customScanAddressHandler,
       handleScanAddress,
       handleScanWalletConnect,
       handleScanPayMerchant,

--- a/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/useScanner.ts
+++ b/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/useScanner.ts
@@ -10,7 +10,7 @@ import { convertDeepLinkToCardWalletProtocol, Device } from '@cardstack/utils';
 import Routes from '@rainbow-me/routes';
 import logger from 'logger';
 import { Alert } from '@rainbow-me/components/alerts';
-import useBooleanState from '@rainbow-me/hooks/useBooleanState';
+import { useBooleanState } from '@cardstack/hooks';
 import { getEthereumAddressFromQRCodeData } from '@rainbow-me/utils/address';
 import haptics from '@rainbow-me/utils/haptics';
 
@@ -114,7 +114,7 @@ export const useScanner = ({
         const address = await getEthereumAddressFromQRCodeData(data);
 
         if (address) {
-          return customScanAddressHandler?.(address)
+          return customScanAddressHandler
             ? customScanAddressHandler(address)
             : handleScanAddress(address);
         }

--- a/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/useScanner.ts
+++ b/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/useScanner.ts
@@ -14,7 +14,11 @@ import useBooleanState from '@rainbow-me/hooks/useBooleanState';
 import { getEthereumAddressFromQRCodeData } from '@rainbow-me/utils/address';
 import haptics from '@rainbow-me/utils/haptics';
 
-export const useScanner = () => {
+export interface useScannerParams {
+  customScanAddressHandler?: (address: string) => void;
+}
+
+export const useScanner = ({ customScanAddressHandler }: useScannerParams) => {
   const { navigate } = useNavigation();
   const { walletConnectOnSessionRequest } = useWalletConnectConnections();
 
@@ -108,7 +112,9 @@ export const useScanner = () => {
         const address = await getEthereumAddressFromQRCodeData(data);
 
         if (address) {
-          return handleScanAddress(address);
+          return customScanAddressHandler?.(address)
+            ? customScanAddressHandler(address)
+            : handleScanAddress(address);
         }
 
         if (deeplink.startsWith('wc:')) {

--- a/cardstack/src/screens/TransferCardScreen/TransferCardScreen.tsx
+++ b/cardstack/src/screens/TransferCardScreen/TransferCardScreen.tsx
@@ -38,6 +38,8 @@ const TransferCardScreen = () => {
     goBack,
     renderScanPage,
     dismissScanPage,
+    onScanHandler,
+    newOwnerAddress,
   } = useTransferCardScreen();
 
   const { isTinyPhone } = useDimensions();
@@ -53,7 +55,7 @@ const TransferCardScreen = () => {
   const scanPage = useMemo(
     () => (
       <Container flex={1} justifyContent="flex-end">
-        <QRCodeScannerPage />
+        <QRCodeScannerPage customScanAddressHandler={onScanHandler} />
         <Container flex={0.4} justifyContent="flex-start" alignItems="center">
           <Button variant="primary" onPress={dismissScanPage}>
             {strings.scanPage.btnLabel}
@@ -61,7 +63,7 @@ const TransferCardScreen = () => {
         </Container>
       </Container>
     ),
-    [dismissScanPage]
+    [dismissScanPage, onScanHandler]
   );
 
   return (
@@ -107,6 +109,7 @@ const TransferCardScreen = () => {
                     borderBottomWidth={1}
                     onChangeText={onChangeText}
                     multiline
+                    value={newOwnerAddress}
                   />
                 </Container>
                 <Container flexGrow={0.6}>

--- a/cardstack/src/screens/TransferCardScreen/TransferCardScreen.tsx
+++ b/cardstack/src/screens/TransferCardScreen/TransferCardScreen.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   TouchableWithoutFeedback,
 } from 'react-native';
+import { QRCodeScannerPage } from '../QRScannerScreen/pages';
 import { useTransferCardScreen } from './useTransferCardScreen';
 import { strings } from './strings';
 import {
@@ -35,6 +36,8 @@ const TransferCardScreen = () => {
     onTransferPress,
     onScanPress,
     goBack,
+    renderScanPage,
+    dismissScanPage,
   } = useTransferCardScreen();
 
   const { isTinyPhone } = useDimensions();
@@ -47,64 +50,83 @@ const TransferCardScreen = () => {
     return negativeOffset;
   }, [isTinyPhone]);
 
+  const scanPage = useMemo(
+    () => (
+      <Container flex={1} justifyContent="flex-end">
+        <QRCodeScannerPage />
+        <Container flex={0.4} justifyContent="flex-start" alignItems="center">
+          <Button variant="primary" onPress={dismissScanPage}>
+            {strings.scanPage.btnLabel}
+          </Button>
+        </Container>
+      </Container>
+    ),
+    [dismissScanPage]
+  );
+
   return (
-    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-      <KeyboardAvoidingView
-        behavior={Device.keyboardBehavior}
-        style={styles.keyboardAvoidView}
-        keyboardVerticalOffset={keyboardOffset}
-        enabled={Device.isIOS}
-      >
-        <SafeAreaView flex={1} margin={2} alignItems="center">
-          <Icon
-            flexDirection="row"
-            name="x"
-            color="teal"
-            onPress={goBack}
-            iconSize="medium"
-            alignSelf="flex-end"
-          />
-          <Container justifyContent="space-evenly" flexGrow={1}>
-            <Container justifyContent="space-between" flexGrow={0.3}>
-              <Text
-                color="white"
-                weight="bold"
-                textAlign="center"
-                size="medium"
-              >
-                {strings.title}
-              </Text>
-              <Text color="blueText" size="body" textAlign="center">
-                {strings.subtitle}
-              </Text>
-              <Input
-                paddingVertical={2}
-                placeholder={strings.inputPlaceholder}
-                color="white"
-                placeholderTextColor="gray"
-                borderBottomColor="teal"
-                borderBottomWidth={1}
-                onChangeText={onChangeText}
-                multiline
+    <Container flex={1} backgroundColor="backgroundDarkPurple">
+      {renderScanPage ? (
+        scanPage
+      ) : (
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+          <KeyboardAvoidingView
+            behavior={Device.keyboardBehavior}
+            style={styles.keyboardAvoidView}
+            keyboardVerticalOffset={keyboardOffset}
+            enabled={Device.isIOS}
+          >
+            <SafeAreaView flex={1} margin={2} alignItems="center">
+              <Icon
+                flexDirection="row"
+                name="x"
+                color="teal"
+                onPress={goBack}
+                iconSize="medium"
+                alignSelf="flex-end"
               />
-            </Container>
-            <Container flexGrow={0.6}>
-              <Button
-                marginVertical={5}
-                variant="primary"
-                onPress={onScanPress}
-                disabled
-              >
-                {strings.scanQrBtn}
-              </Button>
-              <Button disabled={!isValidAddress} onPress={onTransferPress}>
-                {strings.transferBtn}
-              </Button>
-            </Container>
-          </Container>
-        </SafeAreaView>
-      </KeyboardAvoidingView>
-    </TouchableWithoutFeedback>
+              <Container justifyContent="space-evenly" flexGrow={1}>
+                <Container justifyContent="space-between" flexGrow={0.3}>
+                  <Text
+                    color="white"
+                    weight="bold"
+                    textAlign="center"
+                    size="medium"
+                  >
+                    {strings.title}
+                  </Text>
+                  <Text color="blueText" size="body" textAlign="center">
+                    {strings.subtitle}
+                  </Text>
+                  <Input
+                    paddingVertical={2}
+                    placeholder={strings.inputPlaceholder}
+                    color="white"
+                    placeholderTextColor="gray"
+                    borderBottomColor="teal"
+                    borderBottomWidth={1}
+                    onChangeText={onChangeText}
+                    multiline
+                  />
+                </Container>
+                <Container flexGrow={0.6}>
+                  <Button
+                    marginVertical={5}
+                    variant="primary"
+                    onPress={onScanPress}
+                  >
+                    {strings.scanQrBtn}
+                  </Button>
+                  <Button disabled={!isValidAddress} onPress={onTransferPress}>
+                    {strings.transferBtn}
+                  </Button>
+                </Container>
+              </Container>
+            </SafeAreaView>
+          </KeyboardAvoidingView>
+        </TouchableWithoutFeedback>
+      )}
+    </Container>
   );
 };
 

--- a/cardstack/src/screens/TransferCardScreen/__tests__/TransferCardScreen.test.tsx
+++ b/cardstack/src/screens/TransferCardScreen/__tests__/TransferCardScreen.test.tsx
@@ -14,6 +14,10 @@ jest.mock('@rainbow-me/hooks', () => ({
   }),
 }));
 
+jest.mock('../../QRScannerScreen/pages', () => ({
+  QRCodeScannerPage: () => <></>,
+}));
+
 describe('TransferCardScreen', () => {
   const onTransferPress = jest.fn();
   const onScanPress = jest.fn();
@@ -24,6 +28,7 @@ describe('TransferCardScreen', () => {
   ) =>
     (useTransferCardScreen as jest.Mock).mockImplementation(() => ({
       isValidAddress: true,
+      renderScanPage: false,
       onTransferPress,
       onScanPress,
       goBack,
@@ -44,19 +49,6 @@ describe('TransferCardScreen', () => {
     });
 
     expect(goBack).toBeCalledTimes(1);
-  });
-
-  it('should not call onScanPress', () => {
-    const { getByText } = render(<TransferCardScreen />);
-
-    const scanBtn = getByText(strings.scanQrBtn);
-
-    act(() => {
-      fireEvent.press(scanBtn);
-    });
-
-    expect(scanBtn).toBeDisabled();
-    expect(onScanPress).not.toBeCalled();
   });
 
   it('should disable transfer btn if address is not valid', () => {
@@ -89,5 +81,34 @@ describe('TransferCardScreen', () => {
     });
 
     expect(onTransferPress).toBeCalledTimes(1);
+  });
+
+  it('should render scan page if renderScanPage is true', () => {
+    mockUseTransferCardScreenHelper({ renderScanPage: true });
+
+    const { getByText } = render(<TransferCardScreen />);
+
+    const returnToTransferBtn = getByText(strings.scanPage.btnLabel);
+
+    expect(returnToTransferBtn).toBeTruthy();
+  });
+
+  it('should call dismiss when return button is pressed', () => {
+    const mockedDismissScanPage = jest.fn();
+
+    mockUseTransferCardScreenHelper({
+      dismissScanPage: mockedDismissScanPage,
+      renderScanPage: true,
+    });
+
+    const { getByText } = render(<TransferCardScreen />);
+
+    const returnToTransferBtn = getByText(strings.scanPage.btnLabel);
+
+    act(() => {
+      fireEvent.press(returnToTransferBtn);
+    });
+
+    expect(mockedDismissScanPage).toBeCalledTimes(1);
   });
 });

--- a/cardstack/src/screens/TransferCardScreen/__tests__/useTransferCardScreen.test.ts
+++ b/cardstack/src/screens/TransferCardScreen/__tests__/useTransferCardScreen.test.ts
@@ -45,6 +45,10 @@ jest.mock('@rainbow-me/components/send/SendSheet', () => ({
   useSendAddressValidation: jest.fn(() => true),
 }));
 
+jest.mock('@rainbow-me/utils/haptics', () => ({
+  notificationSuccess: jest.fn(),
+}));
+
 describe('useTransferCardScreen', () => {
   const mockedTransferPrepaidCard = jest.fn();
 
@@ -156,5 +160,35 @@ describe('useTransferCardScreen', () => {
     });
 
     expect(mockedGoBack).toBeCalled();
+  });
+
+  it('should set renderScanPage to true onScanPress', async () => {
+    const { result } = renderHook(() => useTransferCardScreen());
+
+    act(() => {
+      result.current.onScanPress();
+    });
+
+    expect(result.current.renderScanPage).toBeTruthy();
+  });
+
+  it('should set renderScanPage to false on dismissScanPage', async () => {
+    const { result } = renderHook(() => useTransferCardScreen());
+
+    act(() => {
+      result.current.dismissScanPage();
+    });
+
+    expect(result.current.renderScanPage).toBeFalsy();
+  });
+
+  it('should set newOwner on ScanHandler read', async () => {
+    const { result } = renderHook(() => useTransferCardScreen());
+
+    act(() => {
+      result.current.onScanHandler(validAddress);
+    });
+
+    expect(result.current.newOwnerAddress).toBe(validAddress);
   });
 });

--- a/cardstack/src/screens/TransferCardScreen/__tests__/useTransferCardScreen.test.ts
+++ b/cardstack/src/screens/TransferCardScreen/__tests__/useTransferCardScreen.test.ts
@@ -4,6 +4,7 @@ import { Alert } from 'react-native';
 import { useTransferCardScreen } from '../useTransferCardScreen';
 import { strings } from '../strings';
 import { useTransferPrepaidCardMutation } from '@cardstack/services';
+import haptics from '@rainbow-me/utils/haptics';
 
 const validAddress = '0x2f58630CA445Ab1a6DE2Bb9892AA2e1d60876C13';
 const prepaidCardAddress = '0x4ba1A50Aecba077Acdf4625BF9aDB3Fe964eEA17';
@@ -45,9 +46,7 @@ jest.mock('@rainbow-me/components/send/SendSheet', () => ({
   useSendAddressValidation: jest.fn(() => true),
 }));
 
-jest.mock('@rainbow-me/utils/haptics', () => ({
-  notificationSuccess: jest.fn(),
-}));
+jest.mock('@rainbow-me/utils/haptics');
 
 describe('useTransferCardScreen', () => {
   const mockedTransferPrepaidCard = jest.fn();
@@ -183,12 +182,15 @@ describe('useTransferCardScreen', () => {
   });
 
   it('should set newOwner on ScanHandler read', async () => {
+    haptics.notificationSuccess = jest.fn();
+
     const { result } = renderHook(() => useTransferCardScreen());
 
     act(() => {
       result.current.onScanHandler(validAddress);
     });
 
+    expect(haptics.notificationSuccess).toBeCalled();
     expect(result.current.newOwnerAddress).toBe(validAddress);
   });
 });

--- a/cardstack/src/screens/TransferCardScreen/strings.ts
+++ b/cardstack/src/screens/TransferCardScreen/strings.ts
@@ -17,4 +17,5 @@ export const strings = {
       message: 'Something went wrong',
     },
   },
+  scanPage: { btnLabel: 'Return to transfer' },
 };

--- a/cardstack/src/screens/TransferCardScreen/useTransferCardScreen.ts
+++ b/cardstack/src/screens/TransferCardScreen/useTransferCardScreen.ts
@@ -16,6 +16,7 @@ import { Alert } from '@rainbow-me/components/alerts';
 import { useMutationEffects } from '@cardstack/hooks';
 
 import { layoutEasingAnimation } from '@cardstack/utils';
+import haptics from '@rainbow-me/utils/haptics';
 
 interface NavParams {
   prepaidCardAddress: string;
@@ -107,6 +108,16 @@ export const useTransferCardScreen = () => {
     transferPrepaidCard,
   ]);
 
+  const onScanHandler = useCallback(
+    (qrCodeAddress: string) => {
+      haptics.notificationSuccess();
+      setNewOwnerAddress(qrCodeAddress);
+
+      dismissScanPage();
+    },
+    [dismissScanPage]
+  );
+
   return {
     renderScanPage,
     isValidAddress,
@@ -115,5 +126,7 @@ export const useTransferCardScreen = () => {
     onScanPress: showScanPage,
     goBack,
     dismissScanPage,
+    onScanHandler,
+    newOwnerAddress,
   };
 };

--- a/cardstack/src/screens/TransferCardScreen/useTransferCardScreen.ts
+++ b/cardstack/src/screens/TransferCardScreen/useTransferCardScreen.ts
@@ -4,16 +4,12 @@ import { useNavigation, useRoute } from '@react-navigation/core';
 
 import { strings } from './strings';
 import { useSendAddressValidation } from '@rainbow-me/components/send/SendSheet';
-import {
-  useAccountSettings,
-  useBooleanState,
-  useWallets,
-} from '@rainbow-me/hooks';
+import { useAccountSettings, useWallets } from '@rainbow-me/hooks';
 import { RouteType } from '@cardstack/navigation/types';
 import { useTransferPrepaidCardMutation } from '@cardstack/services';
 import { useLoadingOverlay } from '@cardstack/navigation';
 import { Alert } from '@rainbow-me/components/alerts';
-import { useMutationEffects } from '@cardstack/hooks';
+import { useBooleanState, useMutationEffects } from '@cardstack/hooks';
 
 import { layoutEasingAnimation } from '@cardstack/utils';
 import haptics from '@rainbow-me/utils/haptics';

--- a/cardstack/src/screens/TransferCardScreen/useTransferCardScreen.ts
+++ b/cardstack/src/screens/TransferCardScreen/useTransferCardScreen.ts
@@ -1,14 +1,21 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 
 import { useNavigation, useRoute } from '@react-navigation/core';
+
 import { strings } from './strings';
 import { useSendAddressValidation } from '@rainbow-me/components/send/SendSheet';
-import { useAccountSettings, useWallets } from '@rainbow-me/hooks';
+import {
+  useAccountSettings,
+  useBooleanState,
+  useWallets,
+} from '@rainbow-me/hooks';
 import { RouteType } from '@cardstack/navigation/types';
 import { useTransferPrepaidCardMutation } from '@cardstack/services';
 import { useLoadingOverlay } from '@cardstack/navigation';
 import { Alert } from '@rainbow-me/components/alerts';
 import { useMutationEffects } from '@cardstack/hooks';
+
+import { layoutEasingAnimation } from '@cardstack/utils';
 
 interface NavParams {
   prepaidCardAddress: string;
@@ -29,6 +36,12 @@ export const useTransferCardScreen = () => {
   const { selectedWallet } = useWallets();
 
   const { showLoadingOverlay, dismissLoadingOverlay } = useLoadingOverlay();
+
+  const [renderScanPage, showScanPage, dismissScanPage] = useBooleanState();
+
+  useLayoutEffect(() => {
+    layoutEasingAnimation();
+  }, [renderScanPage]);
 
   const onChangeText = useCallback(text => {
     setNewOwnerAddress(text);
@@ -94,15 +107,13 @@ export const useTransferCardScreen = () => {
     transferPrepaidCard,
   ]);
 
-  const onScanPress = useCallback(() => {
-    // TODO: handle scan qr code
-  }, []);
-
   return {
+    renderScanPage,
     isValidAddress,
     onChangeText,
     onTransferPress,
-    onScanPress,
+    onScanPress: showScanPage,
     goBack,
+    dismissScanPage,
   };
 };

--- a/src/components/coin-icon/CoinIconFallback.js
+++ b/src/components/coin-icon/CoinIconFallback.js
@@ -4,8 +4,8 @@ import { Image } from 'react-native';
 import styled from 'styled-components';
 import { useTheme } from '../../context/ThemeContext';
 import { Centered } from '../layout';
+import { useBooleanState } from '@cardstack/hooks';
 import { colors } from '@cardstack/theme';
-import { useBooleanState } from '@rainbow-me/hooks';
 import { borders, fonts, position, shadow } from '@rainbow-me/styles';
 import { getUrlForTrustIconFallback, magicMemo } from '@rainbow-me/utils';
 

--- a/src/components/expanded-state/chart/ChartExpandedStateHeader.js
+++ b/src/components/expanded-state/chart/ChartExpandedStateHeader.js
@@ -11,7 +11,8 @@ import {
   ChartPriceLabel,
 } from './chart-data-labels';
 import { CoinIcon, Text } from '@cardstack/components';
-import { useAccountSettings, useBooleanState } from '@rainbow-me/hooks';
+import { useBooleanState } from '@cardstack/hooks';
+import { useAccountSettings } from '@rainbow-me/hooks';
 import { padding } from '@rainbow-me/styles';
 
 const { call, cond, onChange, useCode } = Animated;

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -19,7 +19,6 @@ export {
 } from './useBiometryType';
 export { default as useBlockPolling } from './useBlockPolling';
 export { default as useBuyPrepaidCard } from '@cardstack/hooks/prepaid-card/useBuyPrepaidCard';
-export { default as useBooleanState } from './useBooleanState';
 export { default as useClipboard } from './useClipboard';
 export { default as useCoinListEdited } from './useCoinListEdited';
 export { default as useCoinListEditOptions } from './useCoinListEditOptions';


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Adds the ability to read a QRCode within the transfer flow to auto fill the address. It may be mixing the contexts of Pay/Connect/Transfer, but since it's experimental I guess it's okay.

<!-- Include a summary of the changes. -->

- [x] Completes CS-3211
- [x] Completes CS-3196

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size



<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![scan-transfer](https://user-images.githubusercontent.com/20520102/158258231-2e9ec992-cacb-4e8c-9fac-b085962830cc.gif)

<img width="300" alt="image" src="https://user-images.githubusercontent.com/20520102/158258369-6cbeafc2-3a74-4bf5-9427-9179d239e6b7.png">
