### PR TITLE
[CS-3341] Enable camera options from settings

### DIFF
--- a/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/components/CameraNotAuthorizedView.tsx
+++ b/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/components/CameraNotAuthorizedView.tsx
@@ -10,10 +10,7 @@ import {
 
 const CameraNotAuthorizedView = () => {
   const handlePressSettings = useCallback(() => {
-    // TODO: Handle android
-    Linking.canOpenURL('app-settings:').then(() =>
-      Linking.openURL('app-settings:')
-    );
+    Linking.openSettings();
   }, []);
 
   return (


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR uses the new `Linking.openSettings` call for the simplest way of opening the app settings in both ios and android.

`openSettings` already check if valid. Also, unfortunately, there isn't a safe way to open the camera setting screens specifically.

- [x] Completes #(CS-3341)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

https://user-images.githubusercontent.com/129619/158389316-c2ccd0c7-6227-4911-b093-ba1dba84ad2d.MOV

https://user-images.githubusercontent.com/129619/158395240-2eb9f69b-6dfa-4d39-a3a0-645fc9baff0c.mp4