### PR TITLE
[CS-3340]: Hide toast on scan page

### DIFF
--- a/src/navigation/SwipeNavigator.js
+++ b/src/navigation/SwipeNavigator.js
@@ -6,6 +6,7 @@ import { useAccountSettings, useCoinListEdited } from '../hooks';
 import ProfileScreen from '../screens/ProfileScreen';
 import WalletScreen from '../screens/WalletScreen';
 import { deviceUtils } from '../utils';
+import Navigation from './Navigation';
 import ScrollPagerWrapper, { scrollPosition } from './ScrollPagerWrapper';
 import Routes from './routesNames';
 import { QRScannerScreen } from '@cardstack/screens';
@@ -19,6 +20,9 @@ const renderPager = props => <ScrollPagerWrapper {...props} />;
 export function SwipeNavigator() {
   const { isCoinListEdited } = useCoinListEdited();
   const { network } = useAccountSettings();
+
+  const isOnScanPage =
+    Navigation.getActiveRouteName() === Routes.QR_SCANNER_SCREEN;
 
   return (
     <FlexItem>
@@ -37,7 +41,7 @@ export function SwipeNavigator() {
           name={Routes.QR_SCANNER_SCREEN}
         />
       </Swipe.Navigator>
-      <NetworkToast network={network} />
+      {!isOnScanPage && <NetworkToast network={network} />}
     </FlexItem>
   );
 }


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

There's probably some smoother way to hide is maybe within the `NetworkToast` but I don't know if it's because of rainbow navigation,  but sometimes it was not identifying the screen had changed, so the safest bet was to place in the SwipeNavigator itself, and we are going to remove this soon anyways, we cannot memoize the isOnScanPage, because if we do so, it will only store the first value.

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size


<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Simulator Screen Recording - iPhone 12 - 2022-03-15 at 16 42 30](https://user-images.githubusercontent.com/20520102/158458539-9ab88043-cac8-46d6-9b62-c1324052b883.gif)

