### PR TITLE
[CS-3364] Fixes primary reassignment issue

### DIFF
--- a/cardstack/src/components/MerchantSafe/MerchantSafe.tsx
+++ b/cardstack/src/components/MerchantSafe/MerchantSafe.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { strings } from './strings';
-import usePrimarySafe from '@cardstack/redux/hooks/usePrimarySafe';
+import { usePrimarySafe } from '@cardstack/redux/hooks/usePrimarySafe';
 import { ContactAvatar } from '@rainbow-me/components/contacts';
 import {
   CardPressable,

--- a/cardstack/src/redux/hooks/usePrimarySafe.ts
+++ b/cardstack/src/redux/hooks/usePrimarySafe.ts
@@ -13,7 +13,7 @@ const safesInitialState = {
   merchantSafes: [],
 };
 
-export default function usePrimarySafe() {
+export const usePrimarySafe = () => {
   const dispatch = useDispatch();
   const [nativeCurrency] = useNativeCurrencyAndConversionRates();
   const { accountAddress, network } = useAccountSettings();
@@ -37,10 +37,10 @@ export default function usePrimarySafe() {
 
   // Ensures primary will always be valid if theres at least one merchant safe.
   useEffect(() => {
-    if (merchantSafes?.length > 0 && !primarySafe) {
+    if (!isFetching && merchantSafes?.length > 0 && !primarySafe) {
       changePrimarySafe(merchantSafes[merchantSafes.length - 1]);
     }
-  }, [changePrimarySafe, primarySafe, merchantSafes]);
+  }, [changePrimarySafe, primarySafe, merchantSafes, isFetching]);
 
   return {
     error,
@@ -50,4 +50,4 @@ export default function usePrimarySafe() {
     changePrimarySafe,
     safesCount: merchantSafes?.length || 1,
   };
-}
+};

--- a/cardstack/src/screens/MerchantScreen/useMerchantScreen.tsx
+++ b/cardstack/src/screens/MerchantScreen/useMerchantScreen.tsx
@@ -6,7 +6,7 @@ import { MerchantSafeType } from '@cardstack/types';
 import { useAccountSettings } from '@rainbow-me/hooks';
 import { useGetSafesDataQuery } from '@cardstack/services';
 import { RouteType } from '@cardstack/navigation/types';
-import usePrimarySafe from '@cardstack/redux/hooks/usePrimarySafe';
+import { usePrimarySafe } from '@cardstack/redux/hooks/usePrimarySafe';
 import { MerchantContentProps } from '@cardstack/components';
 
 export const useMerchantScreen = () => {

--- a/cardstack/src/screens/ProfileScreen/ProfileScreen.tsx
+++ b/cardstack/src/screens/ProfileScreen/ProfileScreen.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { CreateProfile, strings } from './components';
 import { Container, MainHeader, MerchantContent } from '@cardstack/components';
-import usePrimarySafe from '@cardstack/redux/hooks/usePrimarySafe';
+import { usePrimarySafe } from '@cardstack/redux/hooks/usePrimarySafe';
 
 const ProfileScreen = () => {
   const { primarySafe, isFetching, safesCount } = usePrimarySafe();

--- a/cardstack/src/screens/QRScannerScreen/pages/RequestQRCode/__tests__/useRequestCodePage.test.ts
+++ b/cardstack/src/screens/QRScannerScreen/pages/RequestQRCode/__tests__/useRequestCodePage.test.ts
@@ -2,7 +2,7 @@ import { act, renderHook } from '@testing-library/react-hooks';
 
 import { useRequestCodePage } from '../useRequestCodePage';
 import Routes from '@rainbow-me/routes';
-import usePrimarySafe from '@cardstack/redux/hooks/usePrimarySafe';
+import { usePrimarySafe } from '@cardstack/redux/hooks/usePrimarySafe';
 
 const mockedNavigate = jest.fn();
 jest.mock('@react-navigation/core', () => ({

--- a/cardstack/src/screens/QRScannerScreen/pages/RequestQRCode/__tests__/useRequestCodePage.test.ts
+++ b/cardstack/src/screens/QRScannerScreen/pages/RequestQRCode/__tests__/useRequestCodePage.test.ts
@@ -18,7 +18,9 @@ jest.mock('@cardstack/hooks/merchant/usePaymentLinks', () => ({
   }),
 }));
 
-jest.mock('@cardstack/redux/hooks/usePrimarySafe', () => jest.fn());
+jest.mock('@cardstack/redux/hooks/usePrimarySafe', () => ({
+  usePrimarySafe: jest.fn(),
+}));
 
 const primarySafeMock = {
   address: 'merchantAddress',

--- a/cardstack/src/screens/QRScannerScreen/pages/RequestQRCode/useRequestCodePage.ts
+++ b/cardstack/src/screens/QRScannerScreen/pages/RequestQRCode/useRequestCodePage.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useNavigation } from '@react-navigation/core';
 import Routes from '@rainbow-me/routes';
-import usePrimarySafe from '@cardstack/redux/hooks/usePrimarySafe';
+import { usePrimarySafe } from '@cardstack/redux/hooks/usePrimarySafe';
 import { usePaymentLinks } from '@cardstack/hooks/merchant/usePaymentLinks';
 
 export const useRequestCodePage = () => {


### PR DESCRIPTION
Refactors usePrimarySafe hook to app function standard.

<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

On changing EOA, the primary safe was reset to null but `merchantSafes` array was still dirty from the last EOA. Using flag `isFetching` also as an update dependency resolves the issue. 

- [x] Completes #(CS-3364)

### Checklist

- [x] All UI changes have been tested on a small device
