### PR TITLE
[CS-3308]: Show buy PrepaidCard btn on section header

### DIFF
--- a/cardstack/src/components/AssetList/components/AssetSectionHeader.tsx
+++ b/cardstack/src/components/AssetList/components/AssetSectionHeader.tsx
@@ -25,17 +25,19 @@ const AssetSectionHeader = ({ section, onBuyCardPress }: AssetSectionProps) => {
     data,
   } = section;
 
-  const isEmptyPrepaidCard =
-    type === PinnedHiddenSectionOption.PREPAID_CARDS && data.length === 0;
+  const isPrepaidCardSection = useMemo(
+    () => type === PinnedHiddenSectionOption.PREPAID_CARDS,
+    [type]
+  );
 
-  const renderNewCardButton = useMemo(
-    () =>
-      Device.supportsFiatOnRamp && (
-        <Button variant="tinyOpacity" onPress={onBuyCardPress}>
-          {strings.newCardLabel}
-        </Button>
-      ),
-    [onBuyCardPress]
+  const isEmptyPrepaidCard = useMemo(
+    () => isPrepaidCardSection && data.length === 0,
+    [data.length, isPrepaidCardSection]
+  );
+
+  const backgroundColor = useMemo(
+    () => (isTabBarEnabled ? 'backgroundDarkPurple' : 'backgroundBlue'),
+    [isTabBarEnabled]
   );
 
   return (
@@ -45,9 +47,7 @@ const AssetSectionHeader = ({ section, onBuyCardPress }: AssetSectionProps) => {
         flexDirection="row"
         justifyContent="space-between"
         padding={4}
-        backgroundColor={
-          isTabBarEnabled ? 'backgroundDarkPurple' : 'backgroundBlue'
-        }
+        backgroundColor={backgroundColor}
       >
         <Container flexDirection="row">
           <Text color="white" size="medium">
@@ -70,11 +70,20 @@ const AssetSectionHeader = ({ section, onBuyCardPress }: AssetSectionProps) => {
               {total}
             </Text>
           ) : null}
-          {isEmptyPrepaidCard
-            ? renderNewCardButton
-            : showContextMenu && <PinnedHiddenSectionMenu type={type} />}
+          {showContextMenu && <PinnedHiddenSectionMenu type={type} />}
         </Container>
       </Container>
+      {isPrepaidCardSection && (
+        <Container
+          paddingBottom={4}
+          alignItems="center"
+          backgroundColor={backgroundColor}
+        >
+          {Device.supportsFiatOnRamp && (
+            <Button onPress={onBuyCardPress}>{strings.buyCardLabel}</Button>
+          )}
+        </Container>
+      )}
       {isEmptyPrepaidCard && (
         <Container marginHorizontal={4} alignItems="center">
           <ListEmptyComponent
@@ -83,11 +92,6 @@ const AssetSectionHeader = ({ section, onBuyCardPress }: AssetSectionProps) => {
             hasRoundBox
             textColor="blueText"
           />
-          {Device.supportsFiatOnRamp && (
-            <Button onPress={onBuyCardPress} marginTop={4}>
-              {strings.buyCardLabel}
-            </Button>
-          )}
         </Container>
       )}
     </>

--- a/src/hooks/useAssetListData.tsx
+++ b/src/hooks/useAssetListData.tsx
@@ -52,7 +52,7 @@ const usePrepaidCardSection = (
       title: 'Prepaid Cards',
       count,
       type: PinnedHiddenSectionOption.PREPAID_CARDS,
-      showContextMenu: true,
+      showContextMenu: !!count,
     },
     data: prepaidCards,
     timestamp,


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds the buy prepaid card button on the section header of prepaidcards, also removes the `New card` pill on empty state, since we already the buy prepaid as default we don't need it anymore.

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

Empty State:
<img width="299" alt="image" src="https://user-images.githubusercontent.com/20520102/158649026-318813d0-1c5f-469d-800c-68caa2d14dd6.png">

The section wasn't reordered yet when I recorded the video, but the behavior is the same
![Simulator Screen Recording - iPhone 12 - 2022-03-16 at 11 49 50](https://user-images.githubusercontent.com/20520102/158649147-24878782-ddda-4858-ab8c-0323ac37cc1e.gif)

