### PR TITLE
[CS-3411]: Fix tab profile/wallet switching 

### DIFF
--- a/src/components/toasts/Toast.js
+++ b/src/components/toasts/Toast.js
@@ -46,10 +46,10 @@ export default function Toast({
       {
         backgroundColor: colors.blackOpacity50,
         maxWidth: deviceWidth * 0.9,
-        bottom: deviceHeight * 0.1,
+        bottom: isVisible ? deviceHeight * 0.1 : -50,
       },
     ],
-    [colors.blackOpacity50, colors.shadow, deviceWidth, deviceHeight]
+    [colors.shadow, colors.blackOpacity50, deviceWidth, isVisible, deviceHeight]
   );
 
   return (


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

One of the toast positioning was rendering on the tab bar between the two tabs profile/wallet, added a negative bottom to make sure it's positioned outside the screen.

![Simulator Screen Recording - iPhone 12 - 2022-03-17 at 10 58 56](https://user-images.githubusercontent.com/20520102/158827574-4eaa48cc-c328-4522-8b2b-7173d9c7055b.gif)