### PR TITLE
[CS-3453]: Add reward register mutation 

### DIFF
--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -14,6 +14,7 @@ export const strings = {
       message:
         'Before you can claim, you need to create and register a reward account.  This is an on-chain event and will cost you a small gas fee - you can use any existing prepaid card to pay the transaction fee.',
     },
+    loading: 'Registering Account',
   },
   claim: {
     button: 'Claim',

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -1,18 +1,26 @@
 import { useCallback, useMemo } from 'react';
+import { convertToSpend } from '@cardstack/cardpay-sdk';
+import { useNavigation } from '@react-navigation/core';
+import { strings } from './strings';
 import {
   useGetRewardPoolTokenBalancesQuery,
   useGetRewardsSafeQuery,
+  useRegisterToRewardProgramMutation,
 } from '@cardstack/services/rewards-center/rewards-center-api';
-import { useAccountSettings } from '@rainbow-me/hooks';
+import { useAccountSettings, useWallets } from '@rainbow-me/hooks';
 import { networkTypes } from '@rainbow-me/helpers/networkTypes';
+import { MainRoutes, useLoadingOverlay } from '@cardstack/navigation';
+import { Alert } from '@rainbow-me/components/alerts';
+import { useMutationEffects } from '@cardstack/hooks';
 
 const rewardDefaultProgramId = {
   [networkTypes.sokol]: '0x5E4E148baae93424B969a0Ea67FF54c315248BbA',
-  //TBD
-  [networkTypes.xdai]: '',
+  // TestID
+  [networkTypes.xdai]: '0xf1223b57D5832fc4229c767E9AD4A8FCfab8A6cA',
 };
 
 export const useRewardsCenterScreen = () => {
+  const { navigate } = useNavigation();
   const { accountAddress, nativeCurrency, network } = useAccountSettings();
 
   const query = useMemo(
@@ -37,6 +45,11 @@ export const useRewardsCenterScreen = () => {
     isLoading: isLoadingTokens,
     data: { rewardPoolTokenBalances } = {},
   } = useGetRewardPoolTokenBalancesQuery(query.params, query.options);
+
+  const [
+    registerToRewardProgram,
+    { isSuccess: isRegistrationSuccess, isError: isRegistrationError },
+  ] = useRegisterToRewardProgramMutation();
 
   const registeredPools = useMemo(
     () =>
@@ -68,9 +81,94 @@ export const useRewardsCenterScreen = () => {
     [network, rewardPoolTokenBalances]
   );
 
+  const { showLoadingOverlay, dismissLoadingOverlay } = useLoadingOverlay();
+
+  const { selectedWallet } = useWallets();
+
+  const onRegisterEnd = useCallback(
+    ({ title, message }) => () => {
+      dismissLoadingOverlay();
+
+      Alert({
+        message,
+        title,
+        buttons: [{ text: 'Okay' }],
+      });
+    },
+    [dismissLoadingOverlay]
+  );
+
+  useMutationEffects(
+    useMemo(
+      () => ({
+        success: {
+          status: isRegistrationSuccess,
+          callback: onRegisterEnd({
+            title: 'Success',
+            message: 'Registration successful',
+          }),
+        },
+        error: {
+          status: isRegistrationError,
+          callback: onRegisterEnd({
+            title: 'Error',
+            message: 'Registration failed',
+          }),
+        },
+      }),
+      [isRegistrationError, isRegistrationSuccess, onRegisterEnd]
+    )
+  );
+
+  const onRegisterConfirmPress = useCallback(
+    (prepaidCardAddress, rewardProgramId) => () => {
+      showLoadingOverlay({ title: strings.register.loading });
+
+      registerToRewardProgram({
+        prepaidCardAddress,
+        accountAddress,
+        network,
+        rewardProgramId,
+        walletId: selectedWallet.id,
+      });
+    },
+    [
+      accountAddress,
+      network,
+      registerToRewardProgram,
+      selectedWallet.id,
+      showLoadingOverlay,
+    ]
+  );
+
+  const onPrepaidCardSelection = useCallback(
+    prepaidCard => {
+      // TODO: Replace with confirmation sheet
+      Alert({
+        buttons: [
+          { text: 'Cancel' },
+          {
+            text: 'Confirm',
+            onPress: onRegisterConfirmPress(
+              prepaidCard.address,
+              rewardDefaultProgramId[network]
+            ),
+          },
+        ],
+        title: 'Register Account',
+        message: `Cardstack Rewards\n(${rewardDefaultProgramId[network]})\nPrepaid Card:\n${prepaidCard.address}`,
+      });
+    },
+    [network, onRegisterConfirmPress]
+  );
+
   const onRegisterPress = useCallback(() => {
-    //pass
-  }, []);
+    navigate(MainRoutes.CHOOSE_PREPAIDCARD_SHEET, {
+      // Mocked estimated gas fee until we get from sdk
+      spendAmount: convertToSpend(0.01, 'USD', 1),
+      onConfirmChoosePrepaidCard: onPrepaidCardSelection,
+    });
+  }, [navigate, onPrepaidCardSelection]);
 
   return {
     rewardSafes,

--- a/cardstack/src/screens/sheets/ChoosePrepaidCardSheet/useChoosePrepaidCard.ts
+++ b/cardstack/src/screens/sheets/ChoosePrepaidCardSheet/useChoosePrepaidCard.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Alert } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
+import { orderBy } from 'lodash';
 import { strings } from './strings';
 import { useAccountSettings } from '@rainbow-me/hooks';
 import { isLayer1 } from '@cardstack/utils';
@@ -32,7 +33,8 @@ export const useChoosePrepaidCard = () => {
         isLoading: isLoadingCards,
         isUninitialized,
       }) => ({
-        prepaidCards: data?.prepaidCards || [],
+        prepaidCards:
+          orderBy(data?.prepaidCards, 'spendFaceValue', 'desc') || [],
         isLoading: isLoadingCards || isUninitialized,
       }),
     }

--- a/cardstack/src/services/rewards-center/rewards-center-api.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-api.ts
@@ -1,6 +1,8 @@
 import { CacheTags, safesApi } from '../safes-api';
 import { queryPromiseWrapper } from '../utils';
 import {
+  RewardsRegisterMutationParams,
+  RewardsRegisterMutationResult,
   RewardsSafeQueryParams,
   RewardsSafeQueryResult,
   RewardsTokenBalancesResult,
@@ -8,6 +10,7 @@ import {
 import {
   fetchRewardPoolTokenBalances,
   fetchRewardsSafe,
+  registerToRewardProgram,
 } from './rewards-center-service';
 
 const rewardsApi = safesApi.injectEndpoints({
@@ -38,6 +41,22 @@ const rewardsApi = safesApi.injectEndpoints({
           errorLogMessage: 'Error fetching reward pool token balances',
         });
       },
+      providesTags: [CacheTags.REWARDS_SAFE],
+    }),
+    registerToRewardProgram: builder.mutation<
+      RewardsRegisterMutationResult,
+      RewardsRegisterMutationParams
+    >({
+      async queryFn(params) {
+        return queryPromiseWrapper<
+          RewardsRegisterMutationResult,
+          RewardsRegisterMutationParams
+        >(registerToRewardProgram, params, {
+          errorLogMessage: 'Error while registering to reward program',
+          resetHdProvider: true,
+        });
+      },
+      invalidatesTags: [CacheTags.REWARDS_SAFE],
     }),
   }),
 });
@@ -45,4 +64,5 @@ const rewardsApi = safesApi.injectEndpoints({
 export const {
   useGetRewardsSafeQuery,
   useGetRewardPoolTokenBalancesQuery,
+  useRegisterToRewardProgramMutation,
 } = rewardsApi;

--- a/cardstack/src/services/rewards-center/rewards-center-service.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-service.ts
@@ -4,6 +4,7 @@ import {
   updateSafeWithTokenPrices,
 } from '../gnosis-service';
 import {
+  RewardsRegisterMutationParams,
   RewardsSafeQueryParams,
   RewardsSafeType,
 } from './rewards-center-types';
@@ -83,4 +84,27 @@ export const fetchRewardPoolTokenBalances = async ({
   return {
     rewardPoolTokenBalances: rewardTokensWithPrice,
   };
+};
+
+// Mutations
+
+export const registerToRewardProgram = async ({
+  prepaidCardAddress,
+  rewardProgramId,
+  accountAddress,
+  walletId,
+  network,
+}: RewardsRegisterMutationParams) => {
+  const web3 = await Web3Instance.get({ walletId, network });
+
+  const rewardManager = await getSDK('RewardManager', web3);
+
+  const result = await rewardManager.registerRewardee(
+    prepaidCardAddress,
+    rewardProgramId,
+    undefined,
+    { from: accountAddress }
+  );
+
+  return result;
 };

--- a/cardstack/src/services/rewards-center/rewards-center-types.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-types.ts
@@ -1,4 +1,6 @@
 import { NativeCurrency, RewardSafe } from '@cardstack/cardpay-sdk';
+import { TransactionReceipt } from 'web3-core';
+import { SignedProviderParams } from '@cardstack/models/hd-provider';
 import { TokenType } from '@cardstack/types';
 
 export interface RewardsSafeQueryParams {
@@ -17,4 +19,19 @@ interface TokenByProgramID extends TokenType {
 }
 export interface RewardsTokenBalancesResult {
   rewardPoolTokenBalances: TokenByProgramID[];
+}
+
+export interface RewardsRegisterMutationParams extends SignedProviderParams {
+  accountAddress: string;
+  prepaidCardAddress: string;
+  rewardProgramId: string;
+}
+
+// Export type from sdk
+interface SuccessfulTransactionReceipt extends TransactionReceipt {
+  status: true;
+}
+export interface RewardsRegisterMutationResult {
+  rewardSafe: string;
+  txReceipt: SuccessfulTransactionReceipt;
 }


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
Adds the registration flow with mocked data and alerts, to get the flow working, it's not possible yet to retrieve the gas estimation from the sdk, so there's a mocked value, I'm using the alert to show the info until we build the UI and while adding the logic to claim the rewards, we might want to split the useRewardsCenter hook into useRegistration and useClaim or something, cause it's starting to get big. Also it orders the prepaidCard list by the spendable balance.
We also need to rethink about the choosePrepaidCard screen and maybe hide the `To pay this amount`, but it can be added to the backlog

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Simulator Screen Recording - iPhone 12 - 2022-03-22 at 13 31 04](https://user-images.githubusercontent.com/20520102/159538815-0b3c5048-80be-44e4-b8a8-02319b433557.gif)

