### PR TITLE
[CS-3442] Claim sections and tabs UI

### DIFF
--- a/cardstack/src/components/AssetList/components/AssetSectionHeader.tsx
+++ b/cardstack/src/components/AssetList/components/AssetSectionHeader.tsx
@@ -73,15 +73,13 @@ const AssetSectionHeader = ({ section, onBuyCardPress }: AssetSectionProps) => {
           {showContextMenu && <PinnedHiddenSectionMenu type={type} />}
         </Container>
       </Container>
-      {isPrepaidCardSection && (
+      {isPrepaidCardSection && Device.supportsFiatOnRamp && (
         <Container
           paddingBottom={4}
           alignItems="center"
           backgroundColor={backgroundColor}
         >
-          {Device.supportsFiatOnRamp && (
-            <Button onPress={onBuyCardPress}>{strings.buyCardLabel}</Button>
-          )}
+          <Button onPress={onBuyCardPress}>{strings.buyCardLabel}</Button>
         </Container>
       )}
       {isEmptyPrepaidCard && (

--- a/cardstack/src/components/Button/Button.tsx
+++ b/cardstack/src/components/Button/Button.tsx
@@ -69,8 +69,6 @@ export const Button = ({
     props.variant
   );
 
-  console.log('::: textStyle bt', children, textStyle);
-
   const disabledTextStyle = useVariantValue(
     'buttonVariants',
     'disabledTextStyle',

--- a/cardstack/src/components/Button/Button.tsx
+++ b/cardstack/src/components/Button/Button.tsx
@@ -69,6 +69,8 @@ export const Button = ({
     props.variant
   );
 
+  console.log('::: textStyle bt', children, textStyle);
+
   const disabledTextStyle = useVariantValue(
     'buttonVariants',
     'disabledTextStyle',
@@ -115,7 +117,13 @@ export const Button = ({
               {...iconProps}
             />
           )}
-          <Text {...textStyle} {...disabledTextProps} allowFontScaling={false}>
+          <Text
+            {...textStyle}
+            {...disabledTextProps}
+            // Fixes text issue in buttons with set height prop
+            style={{ height: '100%' }}
+            allowFontScaling={false}
+          >
             {children}
           </Text>
         </Container>

--- a/cardstack/src/components/Button/Button.tsx
+++ b/cardstack/src/components/Button/Button.tsx
@@ -10,7 +10,7 @@ import {
   BorderProps,
   backgroundColor,
 } from '@shopify/restyle';
-import { ActivityIndicator } from 'react-native';
+import { ActivityIndicator, StyleSheet } from 'react-native';
 import React, { ReactNode, useMemo } from 'react';
 
 import { Text } from '../Text';
@@ -49,6 +49,13 @@ const AnimatedButton = createRestyleComponent<ButtonProps, Theme>(
   [layout, spacing, border, VariantRestyleComponent, backgroundColor],
   AnimatedPressable
 );
+
+const styles = StyleSheet.create({
+  // Ensures button's title size integrity if button's height gets to be manually set.
+  title: {
+    height: '100%',
+  },
+});
 
 /**
  * A button with a simple press animation
@@ -118,8 +125,7 @@ export const Button = ({
           <Text
             {...textStyle}
             {...disabledTextProps}
-            // Fixes text issue in buttons with set height prop
-            style={{ height: '100%' }}
+            style={styles.title}
             allowFontScaling={false}
           >
             {children}

--- a/cardstack/src/components/TabHeader/TabHeaderButton.tsx
+++ b/cardstack/src/components/TabHeader/TabHeaderButton.tsx
@@ -18,7 +18,7 @@ export const TabHeaderButton = ({
       justifyContent="center"
       onPress={onPress}
       paddingTop={5}
-      width="50%"
+      flex={1}
     >
       <Text
         color="black"

--- a/cardstack/src/components/TabHeader/TabHeaderButton.tsx
+++ b/cardstack/src/components/TabHeader/TabHeaderButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Container, Touchable, Text } from '@cardstack/components';
+
+export interface TabHeaderProps {
+  title: string;
+  isSelected?: boolean;
+  onPress: () => void;
+}
+
+export const TabHeaderButton = ({
+  title,
+  isSelected = false,
+  onPress,
+}: TabHeaderProps) => {
+  return (
+    <Touchable
+      alignItems="center"
+      justifyContent="center"
+      onPress={onPress}
+      paddingTop={5}
+      width="50%"
+    >
+      <Text
+        color="black"
+        marginBottom={3}
+        opacity={isSelected ? 1 : 0.5}
+        weight={isSelected ? 'bold' : 'regular'}
+      >
+        {title}
+      </Text>
+      <Container
+        backgroundColor={isSelected ? 'buttonPrimaryBorder' : 'white'}
+        height={3}
+        width="100%"
+      />
+    </Touchable>
+  );
+};

--- a/cardstack/src/components/TabHeader/index.ts
+++ b/cardstack/src/components/TabHeader/index.ts
@@ -1,0 +1,2 @@
+export * from './TabHeaderButton';
+export * from './useTabHeader';

--- a/cardstack/src/components/TabHeader/useTabHeader.tsx
+++ b/cardstack/src/components/TabHeader/useTabHeader.tsx
@@ -2,16 +2,17 @@ import React, { useState, useCallback } from 'react';
 import { TabHeaderButton } from '.';
 import { Container } from '@cardstack/components';
 
-export interface TabProps {
+export interface TabType {
   title: string;
+  key: string;
 }
 
-export interface TabsProps {
-  tabs: Array<TabProps>;
+export interface TabsArrayProps {
+  tabs: Array<TabType>;
 }
 
-export const useTabHeader = ({ tabs }: TabsProps) => {
-  const [currentTab, setCurrentTab] = useState(0);
+export const useTabHeader = ({ tabs }: TabsArrayProps) => {
+  const [currentTab, setCurrentTab] = useState<TabType>(tabs[0]);
 
   const tabHeaderComp = useCallback(
     () => (
@@ -21,11 +22,11 @@ export const useTabHeader = ({ tabs }: TabsProps) => {
           flexDirection="row"
           justifyContent="space-between"
         >
-          {tabs.map((tab, index) => (
+          {tabs.map(tab => (
             <TabHeaderButton
-              isSelected={index === currentTab}
+              isSelected={tab.key === currentTab.key}
               title={tab.title}
-              onPress={() => setCurrentTab(index)}
+              onPress={() => setCurrentTab(tab)}
             />
           ))}
         </Container>

--- a/cardstack/src/components/TabHeader/useTabHeader.tsx
+++ b/cardstack/src/components/TabHeader/useTabHeader.tsx
@@ -1,0 +1,42 @@
+import React, { useState, useCallback } from 'react';
+import { TabHeaderButton } from '.';
+import { Container } from '@cardstack/components';
+
+export interface TabProps {
+  title: string;
+}
+
+export interface TabsProps {
+  tabs: Array<TabProps>;
+}
+
+export const useTabHeader = ({ tabs }: TabsProps) => {
+  const [currentTab, setCurrentTab] = useState(0);
+
+  const tabHeaderComp = useCallback(
+    () => (
+      <>
+        <Container
+          paddingHorizontal={5}
+          flexDirection="row"
+          justifyContent="space-between"
+        >
+          {tabs.map((tab, index) => (
+            <TabHeaderButton
+              isSelected={index === currentTab}
+              title={tab.title}
+              onPress={() => setCurrentTab(index)}
+            />
+          ))}
+        </Container>
+        <Container backgroundColor="borderLightColor" height={1} width="100%" />
+      </>
+    ),
+    [tabs, currentTab]
+  );
+
+  return {
+    currentTab,
+    TabHeader: tabHeaderComp,
+  };
+};

--- a/cardstack/src/components/index.ts
+++ b/cardstack/src/components/index.ts
@@ -48,3 +48,4 @@ export * from './SwitchSelector';
 export * from './ProgressSteps';
 export * from './ChoosePrepaidCard';
 export * from './InfoBanner';
+export * from './TabHeader';

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
@@ -3,7 +3,7 @@ import { StyleSheet } from 'react-native';
 import rewardBanner from '../../assets/rewards-banner.png';
 import { strings } from './strings';
 import { useRewardsCenterScreen } from './useRewardsCenterScreen';
-import { RegisterContent, NoRewardContent, RewardRow } from './components';
+import { RegisterContent, NoRewardContent, ClaimContent } from './components';
 import { Container, NavigationStackHeader, Image } from '@cardstack/components';
 
 const RewardsCenterScreen = () => {
@@ -20,8 +20,13 @@ const RewardsCenterScreen = () => {
       primaryText: mainPoolTokenInfo?.balance.display || '',
       subText: mainPoolTokenInfo?.native.balance.display || '',
       coinSymbol: mainPoolTokenInfo?.token.symbol || '',
+      onClaimPress: () =>
+        onClaimPress(
+          mainPoolTokenInfo?.tokenAddress,
+          mainPoolTokenInfo?.rewardProgramId
+        ),
     }),
-    [mainPoolTokenInfo]
+    [mainPoolTokenInfo, onClaimPress]
   );
 
   return (
@@ -29,7 +34,7 @@ const RewardsCenterScreen = () => {
       <NavigationStackHeader title={strings.navigation.title} />
       <Container backgroundColor="white" flex={1}>
         <Image source={rewardBanner} style={styles.headerImage} />
-        <Container padding={5}>
+        <Container>
           {!isRegistered &&
             (hasRewardsAvailable ? (
               <RegisterContent
@@ -39,13 +44,9 @@ const RewardsCenterScreen = () => {
             ) : (
               <NoRewardContent />
             ))}
-          {isRegistered && hasRewardsAvailable && (
-            <RewardRow
-              {...mainPoolRowProps}
-              onClaimPress={onClaimPress(
-                mainPoolTokenInfo?.tokenAddress,
-                mainPoolTokenInfo?.rewardProgramId
-              )}
+          {isRegistered && (
+            <ClaimContent
+              claimList={hasRewardsAvailable ? [mainPoolRowProps] : undefined}
             />
           )}
         </Container>

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -55,14 +55,17 @@ const historyList = [
 ];
 
 enum Tabs {
-  BALANCE,
-  HISTORY,
+  BALANCE = 'BALANCE',
+  HISTORY = 'HISTORY',
 }
 
+const tabs = [
+  { title: strings.balance.title, key: Tabs.BALANCE },
+  { title: strings.history.title, key: Tabs.HISTORY },
+];
+
 export const ClaimContent = () => {
-  const { TabHeader, currentTab } = useTabHeader({
-    tabs: [{ title: strings.balance.title }, { title: strings.history.title }],
-  });
+  const { TabHeader, currentTab } = useTabHeader({ tabs });
 
   const renderClaimList = useCallback(
     () =>
@@ -117,7 +120,7 @@ export const ClaimContent = () => {
       </Container>
       <TabHeader />
       <Container padding={5}>
-        {currentTab === Tabs.BALANCE
+        {currentTab.key === Tabs.BALANCE
           ? renderBalanceList()
           : renderHistoryList()}
       </Container>

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -1,0 +1,126 @@
+import React, { useCallback } from 'react';
+import { strings } from '../strings';
+import { RewardsTitle, RewardRow } from '.';
+import { ScrollView, Container, useTabHeader } from '@cardstack/components';
+
+const claimList = [
+  {
+    coinSymbol: 'CARD',
+    primaryText: '3,200 CARD.CPXD',
+    subText: '$45.00 USD',
+  },
+  {
+    coinSymbol: 'CARD',
+    primaryText: '1,600 CARD.CPXD',
+    subText: '$22.50 USD',
+  },
+];
+
+const balanceList = [
+  {
+    coinSymbol: 'CARD',
+    primaryText: '1,600 CARD.CPXD',
+  },
+  {
+    coinSymbol: 'CARD',
+    primaryText: '800 CARD.CPXD',
+  },
+  {
+    coinSymbol: 'CARD',
+    primaryText: '400 CARD.CPXD',
+  },
+  {
+    coinSymbol: 'CARD',
+    primaryText: '200 CARD.CPXD',
+  },
+  {
+    coinSymbol: 'CARD',
+    primaryText: '100 CARD.CPXD',
+  },
+];
+
+const historyList = [
+  {
+    coinSymbol: 'CARD',
+    primaryText: '200 CARD.CPXD',
+  },
+  {
+    coinSymbol: 'CARD',
+    primaryText: '100 CARD.CPXD',
+  },
+  {
+    coinSymbol: 'CARD',
+    primaryText: '50 CARD.CPXD',
+  },
+];
+
+enum Tabs {
+  BALANCE,
+  HISTORY,
+}
+
+export const ClaimContent = () => {
+  const { TabHeader, currentTab } = useTabHeader({
+    tabs: [{ title: strings.balance.title }, { title: strings.history.title }],
+  });
+
+  const renderClaimList = useCallback(
+    () =>
+      claimList.map((item, index) => (
+        <RewardRow
+          coinSymbol={item.coinSymbol}
+          primaryText={item.primaryText}
+          subText={item.subText}
+          paddingBottom={index + 1 < claimList.length ? 5 : 0}
+          onClaimPress={() => {
+            //pass
+          }}
+        />
+      )),
+    []
+  );
+
+  const renderBalanceList = useCallback(
+    () =>
+      balanceList.map(item => (
+        <RewardRow
+          coinSymbol={item.coinSymbol}
+          primaryText={item.primaryText}
+          paddingBottom={4}
+        />
+      )),
+    []
+  );
+
+  const renderHistoryList = useCallback(
+    () =>
+      historyList.map(item => (
+        <RewardRow
+          claimed
+          coinSymbol={item.coinSymbol}
+          primaryText={item.primaryText}
+          paddingBottom={4}
+        />
+      )),
+    []
+  );
+
+  return (
+    <ScrollView>
+      <Container padding={5}>
+        <RewardsTitle
+          title={strings.register.title}
+          width="100%"
+          paddingBottom={5}
+        />
+        {renderClaimList()}
+      </Container>
+      <TabHeader />
+      <Container padding={5}>
+        {currentTab === Tabs.BALANCE
+          ? renderBalanceList()
+          : renderHistoryList()}
+      </Container>
+    </ScrollView>
+  );
+};

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { strings } from '../strings';
 import {
   RewardsTitle,
@@ -28,7 +28,7 @@ const tabs = [
 ];
 
 export const ClaimContent = ({
-  claimList = [],
+  claimList,
   balanceList,
   historyList,
 }: ClaimContentProps) => {
@@ -36,28 +36,28 @@ export const ClaimContent = ({
 
   const renderClaimList = useCallback(
     () =>
-      claimList.map((item, index) => (
+      claimList?.map((item, index) => (
         <RewardRow
           coinSymbol={item.coinSymbol}
           primaryText={item.primaryText}
           subText={item.subText}
           paddingBottom={index + 1 < claimList.length ? 5 : 0}
-          onClaimPress={() => {
-            //pass
-          }}
+          onClaimPress={item.onClaimPress}
         />
       )),
+    [claimList]
+  );
+
+  const title = useMemo(
+    () =>
+      claimList ? strings.register.title : strings.register.noRewards.title,
     [claimList]
   );
 
   return (
     <ScrollView>
       <Container padding={5}>
-        <RewardsTitle
-          title={strings.register.title}
-          width="100%"
-          paddingBottom={5}
-        />
+        <RewardsTitle title={title} width="100%" paddingBottom={5} />
         {renderClaimList()}
       </Container>
       <TabHeader />

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -1,58 +1,13 @@
 import React, { useCallback } from 'react';
 import { strings } from '../strings';
-import { RewardsTitle, RewardRow } from '.';
+import { claimList, balanceList, historyList } from './__mock__';
+import {
+  RewardsTitle,
+  RewardRow,
+  RewardsBalanceList,
+  RewardsHistoryList,
+} from '.';
 import { ScrollView, Container, useTabHeader } from '@cardstack/components';
-
-const claimList = [
-  {
-    coinSymbol: 'CARD',
-    primaryText: '3,200 CARD.CPXD',
-    subText: '$45.00 USD',
-  },
-  {
-    coinSymbol: 'CARD',
-    primaryText: '1,600 CARD.CPXD',
-    subText: '$22.50 USD',
-  },
-];
-
-const balanceList = [
-  {
-    coinSymbol: 'CARD',
-    primaryText: '1,600 CARD.CPXD',
-  },
-  {
-    coinSymbol: 'CARD',
-    primaryText: '800 CARD.CPXD',
-  },
-  {
-    coinSymbol: 'CARD',
-    primaryText: '400 CARD.CPXD',
-  },
-  {
-    coinSymbol: 'CARD',
-    primaryText: '200 CARD.CPXD',
-  },
-  {
-    coinSymbol: 'CARD',
-    primaryText: '100 CARD.CPXD',
-  },
-];
-
-const historyList = [
-  {
-    coinSymbol: 'CARD',
-    primaryText: '200 CARD.CPXD',
-  },
-  {
-    coinSymbol: 'CARD',
-    primaryText: '100 CARD.CPXD',
-  },
-  {
-    coinSymbol: 'CARD',
-    primaryText: '50 CARD.CPXD',
-  },
-];
 
 enum Tabs {
   BALANCE = 'BALANCE',
@@ -83,31 +38,6 @@ export const ClaimContent = () => {
     []
   );
 
-  const renderBalanceList = useCallback(
-    () =>
-      balanceList.map(item => (
-        <RewardRow
-          coinSymbol={item.coinSymbol}
-          primaryText={item.primaryText}
-          paddingBottom={4}
-        />
-      )),
-    []
-  );
-
-  const renderHistoryList = useCallback(
-    () =>
-      historyList.map(item => (
-        <RewardRow
-          claimed
-          coinSymbol={item.coinSymbol}
-          primaryText={item.primaryText}
-          paddingBottom={4}
-        />
-      )),
-    []
-  );
-
   return (
     <ScrollView>
       <Container padding={5}>
@@ -120,9 +50,11 @@ export const ClaimContent = () => {
       </Container>
       <TabHeader />
       <Container padding={5}>
-        {currentTab.key === Tabs.BALANCE
-          ? renderBalanceList()
-          : renderHistoryList()}
+        {currentTab.key === Tabs.BALANCE ? (
+          <RewardsBalanceList data={balanceList} />
+        ) : (
+          <RewardsHistoryList sections={historyList} />
+        )}
       </Container>
     </ScrollView>
   );

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -1,13 +1,21 @@
 import React, { useCallback } from 'react';
 import { strings } from '../strings';
-import { claimList, balanceList, historyList } from './__mock__';
 import {
   RewardsTitle,
   RewardRow,
+  RewardRowProps,
   RewardsBalanceList,
+  RewardsBalanceListProps,
   RewardsHistoryList,
+  RewardsHistoryListProps,
 } from '.';
 import { ScrollView, Container, useTabHeader } from '@cardstack/components';
+
+interface ClaimContentProps {
+  claimList?: Array<RewardRowProps>;
+  balanceList?: RewardsBalanceListProps;
+  historyList?: RewardsHistoryListProps;
+}
 
 enum Tabs {
   BALANCE = 'BALANCE',
@@ -19,7 +27,11 @@ const tabs = [
   { title: strings.history.title, key: Tabs.HISTORY },
 ];
 
-export const ClaimContent = () => {
+export const ClaimContent = ({
+  claimList = [],
+  balanceList,
+  historyList,
+}: ClaimContentProps) => {
   const { TabHeader, currentTab } = useTabHeader({ tabs });
 
   const renderClaimList = useCallback(
@@ -35,7 +47,7 @@ export const ClaimContent = () => {
           }}
         />
       )),
-    []
+    [claimList]
   );
 
   return (
@@ -51,9 +63,9 @@ export const ClaimContent = () => {
       <TabHeader />
       <Container padding={5}>
         {currentTab.key === Tabs.BALANCE ? (
-          <RewardsBalanceList data={balanceList} />
+          <RewardsBalanceList {...balanceList} />
         ) : (
-          <RewardsHistoryList sections={historyList} />
+          <RewardsHistoryList {...historyList} />
         )}
       </Container>
     </ScrollView>

--- a/cardstack/src/screens/RewardsCenterScreen/components/NoRewardContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/NoRewardContent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { strings } from '../strings';
+import { RewardsTitle } from '.';
 import {
   Container,
   ContainerProps,
@@ -8,16 +9,8 @@ import {
 } from '@cardstack/components';
 
 export const NoRewardContent = () => (
-  <Container alignItems="center">
-    <Text
-      weight="bold"
-      letterSpacing={1.1}
-      textTransform="uppercase"
-      size="xxs"
-      paddingBottom={5}
-    >
-      {strings.register.noRewards.title}
-    </Text>
+  <Container alignItems="center" padding={5}>
+    <RewardsTitle title={strings.register.noRewards.title} paddingBottom={5} />
     <NoRewardMessage paddingBottom={4} />
     <InfoBanner
       title={strings.register.infobanner.title}

--- a/cardstack/src/screens/RewardsCenterScreen/components/RegisterContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RegisterContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { strings } from '../strings';
-import { RewardRow } from './RewardRow';
-import { Container, Button, Text, InfoBanner } from '@cardstack/components';
+import { RewardRow, RewardsTitle } from '.';
+import { Container, Button, InfoBanner } from '@cardstack/components';
 
 interface RegisterContentProps {
   primaryText: string;
@@ -16,16 +16,8 @@ export const RegisterContent = ({
   subText,
   coinSymbol,
 }: RegisterContentProps) => (
-  <Container alignItems="center">
-    <Text
-      weight="bold"
-      letterSpacing={1.1}
-      textTransform="uppercase"
-      size="xxs"
-      paddingBottom={5}
-    >
-      {strings.register.title}
-    </Text>
+  <Container alignItems="center" padding={5}>
+    <RewardsTitle title={strings.register.title} paddingBottom={5} />
     <RewardRow
       coinSymbol={coinSymbol}
       primaryText={primaryText}

--- a/cardstack/src/screens/RewardsCenterScreen/components/RegisterContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RegisterContent.tsx
@@ -23,9 +23,6 @@ export const RegisterContent = ({
       primaryText={primaryText}
       subText={subText}
       paddingBottom={5}
-      onClaimPress={() => {
-        //pass
-      }}
     />
     <Button onPress={onRegisterPress}>{strings.register.button}</Button>
     <Container paddingBottom={5} />

--- a/cardstack/src/screens/RewardsCenterScreen/components/RegisterContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RegisterContent.tsx
@@ -31,6 +31,9 @@ export const RegisterContent = ({
       primaryText={primaryText}
       subText={subText}
       paddingBottom={5}
+      onClaimPress={() => {
+        //pass
+      }}
     />
     <Button onPress={onRegisterPress}>{strings.register.button}</Button>
     <Container paddingBottom={5} />

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
@@ -47,7 +47,7 @@ export const RewardRow = ({
         <Container paddingTop={4}>
           <Button
             variant="small"
-            height={35}
+            height={39}
             width="100%"
             onPress={onClaimPress}
           >

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
@@ -52,7 +52,7 @@ export const RewardRow = ({
         <Container paddingTop={4}>
           <Button
             variant="small"
-            height={39}
+            height={30}
             width="100%"
             onPress={onClaimPress}
           >

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
@@ -8,10 +8,11 @@ import {
   ContainerProps,
 } from '@cardstack/components';
 
-interface RewardRowProps extends ContainerProps {
+export interface RewardRowProps extends ContainerProps {
   coinSymbol: string;
   primaryText: string;
-  subText: string;
+  subText?: string;
+  claimed?: boolean;
   onClaimPress?: () => void;
 }
 
@@ -19,6 +20,7 @@ export const RewardRow = ({
   coinSymbol,
   primaryText,
   subText,
+  claimed = false,
   onClaimPress,
   ...props
 }: RewardRowProps) => (
@@ -37,8 +39,11 @@ export const RewardRow = ({
           alignItems="flex-start"
           flex={1}
         >
-          <Text weight="extraBold" fontSize={15} ellipsizeMode="tail">
-            {primaryText}
+          <Text fontSize={15}>
+            {claimed && strings.claim.claimed + ' '}
+            <Text weight="extraBold" fontSize={15} ellipsizeMode="tail">
+              {primaryText}
+            </Text>
           </Text>
           {subText && <Text variant="subText">{subText}</Text>}
         </Container>

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
@@ -45,7 +45,12 @@ export const RewardRow = ({
       </Container>
       {!!onClaimPress && (
         <Container paddingTop={4}>
-          <Button width="100%" onPress={onClaimPress}>
+          <Button
+            variant="small"
+            height={35}
+            width="100%"
+            onPress={onClaimPress}
+          >
             {strings.claim.button}
           </Button>
         </Container>

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsBalanceList.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsBalanceList.tsx
@@ -1,0 +1,22 @@
+import React, { useCallback } from 'react';
+import { FlatList } from 'react-native';
+import { RewardRow, RewardRowProps } from '.';
+import { Container } from '@cardstack/components';
+
+interface RewardsBalanceListProps {
+  data: Array<RewardRowProps>;
+}
+
+export const RewardsBalanceList = ({ data }: RewardsBalanceListProps) => {
+  const renderItem = useCallback(({ item }) => <RewardRow {...item} />, []);
+
+  const spacing = useCallback(() => <Container paddingBottom={4} />, []);
+
+  return (
+    <FlatList
+      data={data}
+      renderItem={renderItem}
+      ItemSeparatorComponent={spacing}
+    />
+  );
+};

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsBalanceList.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsBalanceList.tsx
@@ -1,13 +1,14 @@
 import React, { useCallback } from 'react';
 import { FlatList } from 'react-native';
+import { strings } from '../strings';
 import { RewardRow, RewardRowProps } from '.';
-import { Container } from '@cardstack/components';
+import { Container, ListEmptyComponent } from '@cardstack/components';
 
-interface RewardsBalanceListProps {
-  data: Array<RewardRowProps>;
+export interface RewardsBalanceListProps {
+  data?: Array<RewardRowProps>;
 }
 
-export const RewardsBalanceList = ({ data }: RewardsBalanceListProps) => {
+export const RewardsBalanceList = ({ data = [] }: RewardsBalanceListProps) => {
   const renderItem = useCallback(({ item }) => <RewardRow {...item} />, []);
 
   const spacing = useCallback(() => <Container paddingBottom={4} />, []);
@@ -17,6 +18,7 @@ export const RewardsBalanceList = ({ data }: RewardsBalanceListProps) => {
       data={data}
       renderItem={renderItem}
       ItemSeparatorComponent={spacing}
+      ListEmptyComponent={<ListEmptyComponent text={strings.balance.empty} />}
     />
   );
 };

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
@@ -1,0 +1,34 @@
+import React, { useCallback } from 'react';
+import { SectionList } from 'react-native';
+import { RewardRow, RewardRowProps } from '.';
+import { Container, Text } from '@cardstack/components';
+
+interface RewardsHistoryListProps {
+  sections: [
+    {
+      title: string;
+      data: Array<RewardRowProps>;
+    }
+  ];
+}
+
+export const RewardsHistoryList = ({ sections }: RewardsHistoryListProps) => {
+  const renderSectionHeader = useCallback(
+    ({ section }) => <Text size="medium">{section.title}</Text>,
+    []
+  );
+
+  const renderItem = useCallback(({ item }) => <RewardRow {...item} />, []);
+
+  const spacing = useCallback(() => <Container paddingBottom={4} />, []);
+
+  return (
+    <SectionList
+      renderSectionHeader={renderSectionHeader}
+      sections={sections}
+      renderItem={renderItem}
+      ItemSeparatorComponent={spacing}
+      SectionSeparatorComponent={spacing}
+    />
+  );
+};

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
@@ -3,13 +3,13 @@ import { SectionList } from 'react-native';
 import { RewardRow, RewardRowProps } from '.';
 import { Container, Text } from '@cardstack/components';
 
-interface RewardsHistoryListProps {
-  sections: [
-    {
-      title: string;
-      data: Array<RewardRowProps>;
-    }
-  ];
+export interface RewardsHistorySectionType {
+  title: string;
+  data: Array<RewardRowProps>;
+}
+
+export interface RewardsHistoryListProps {
+  sections: Array<RewardsHistorySectionType>;
 }
 
 export const RewardsHistoryList = ({ sections }: RewardsHistoryListProps) => {

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback } from 'react';
 import { SectionList } from 'react-native';
+import { strings } from '../strings';
 import { RewardRow, RewardRowProps } from '.';
-import { Container, Text } from '@cardstack/components';
+import { Container, Text, ListEmptyComponent } from '@cardstack/components';
 
 export interface RewardsHistorySectionType {
   title: string;
@@ -9,10 +10,12 @@ export interface RewardsHistorySectionType {
 }
 
 export interface RewardsHistoryListProps {
-  sections: Array<RewardsHistorySectionType>;
+  sections?: Array<RewardsHistorySectionType>;
 }
 
-export const RewardsHistoryList = ({ sections }: RewardsHistoryListProps) => {
+export const RewardsHistoryList = ({
+  sections = [],
+}: RewardsHistoryListProps) => {
   const renderSectionHeader = useCallback(
     ({ section }) => <Text size="medium">{section.title}</Text>,
     []
@@ -29,6 +32,7 @@ export const RewardsHistoryList = ({ sections }: RewardsHistoryListProps) => {
       renderItem={renderItem}
       ItemSeparatorComponent={spacing}
       SectionSeparatorComponent={spacing}
+      ListEmptyComponent={<ListEmptyComponent text={strings.history.empty} />}
     />
   );
 };

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsTitle.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsTitle.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Text, ContainerProps } from '@cardstack/components';
+
+interface Props extends ContainerProps {
+  title: string;
+}
+
+export const RewardsTitle = ({ title, ...props }: Props) => (
+  <Text
+    weight="bold"
+    letterSpacing={1.1}
+    textTransform="uppercase"
+    size="xxs"
+    textAlign="center"
+    {...props}
+  >
+    {title}
+  </Text>
+);

--- a/cardstack/src/screens/RewardsCenterScreen/components/__mock__.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/components/__mock__.ts
@@ -1,0 +1,72 @@
+export const claimList = [
+  {
+    coinSymbol: 'CARD',
+    primaryText: '3,200 CARD.CPXD',
+    subText: '$45.00 USD',
+  },
+  {
+    coinSymbol: 'CARD',
+    primaryText: '1,600 CARD.CPXD',
+    subText: '$22.50 USD',
+  },
+];
+
+export const balanceList = [
+  {
+    coinSymbol: 'CARD',
+    primaryText: '1,600 CARD.CPXD',
+  },
+  {
+    coinSymbol: 'CARD',
+    primaryText: '800 CARD.CPXD',
+  },
+  {
+    coinSymbol: 'CARD',
+    primaryText: '400 CARD.CPXD',
+  },
+  {
+    coinSymbol: 'CARD',
+    primaryText: '200 CARD.CPXD',
+  },
+  {
+    coinSymbol: 'CARD',
+    primaryText: '100 CARD.CPXD',
+  },
+];
+
+export const historyList = [
+  {
+    title: 'March',
+    data: [
+      {
+        coinSymbol: 'CARD',
+        primaryText: '200 CARD.CPXD',
+      },
+      {
+        coinSymbol: 'CARD',
+        primaryText: '100 CARD.CPXD',
+      },
+      {
+        coinSymbol: 'CARD',
+        primaryText: '50 CARD.CPXD',
+      },
+    ],
+  },
+  {
+    title: 'February',
+    data: [
+      {
+        coinSymbol: 'CARD',
+        primaryText: '25 CARD.CPXD',
+      },
+      {
+        coinSymbol: 'CARD',
+        primaryText: '12 CARD.CPXD',
+      },
+      {
+        coinSymbol: 'CARD',
+        primaryText: '6 CARD.CPXD',
+      },
+    ],
+  },
+];

--- a/cardstack/src/screens/RewardsCenterScreen/components/index.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/components/index.ts
@@ -3,3 +3,5 @@ export * from './NoRewardContent';
 export * from './RewardRow';
 export * from './RewardsTitle';
 export * from './ClaimContent';
+export * from './RewardsBalanceList';
+export * from './RewardsHistoryList';

--- a/cardstack/src/screens/RewardsCenterScreen/components/index.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/components/index.ts
@@ -1,3 +1,5 @@
 export * from './RegisterContent';
 export * from './NoRewardContent';
 export * from './RewardRow';
+export * from './RewardsTitle';
+export * from './ClaimContent';

--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -23,8 +23,10 @@ export const strings = {
   },
   balance: {
     title: 'Balance',
+    empty: 'No Reward Balance',
   },
   history: {
     title: 'History',
+    empty: 'No Reward History',
   },
 };

--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -19,5 +19,12 @@ export const strings = {
   claim: {
     button: 'Claim',
     loading: 'Claiming Reward',
+    claimed: 'Claimed',
+  },
+  balance: {
+    title: 'Balance',
+  },
+  history: {
+    title: 'History',
   },
 };


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds an MVP for the ClaimRewards content, adds TabHeader component with a hook for keeping track of the selected tab, and extracts RewardsTitle to its own component.

The structure of this screen makes it complex to implement, especially since we would need a header that is a dynamic list and tabs that also have dynamic section lists. I'm studying a better approach but didn't want to hold off on the MVP so the development of the complete picture could continue.

- [x] Completes #(CS-3442)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

https://user-images.githubusercontent.com/129619/159706735-53ef6d7d-fe57-4516-9583-93bbd82f0432.mp4
