### PR TITLE
[CS-3460]: Display rewards claimed history

### DIFF
--- a/cardstack/src/graphql/graphql-codegen.ts
+++ b/cardstack/src/graphql/graphql-codegen.ts
@@ -1795,6 +1795,72 @@ export enum MerchantWithdrawOrderBy {
   TO = 'to'
 }
 
+export type MerkleRootSubmission = {
+  __typename?: 'MerkleRootSubmission';
+  id: Scalars['ID'];
+  rewardProgram: RewardProgram;
+  paymentCycle: Scalars['BigInt'];
+  timestamp: Scalars['BigInt'];
+  blockNumber: Scalars['BigInt'];
+};
+
+export type MerkleRootSubmissionFilter = {
+  id?: Maybe<Scalars['ID']>;
+  id_not?: Maybe<Scalars['ID']>;
+  id_gt?: Maybe<Scalars['ID']>;
+  id_lt?: Maybe<Scalars['ID']>;
+  id_gte?: Maybe<Scalars['ID']>;
+  id_lte?: Maybe<Scalars['ID']>;
+  id_in?: Maybe<Array<Scalars['ID']>>;
+  id_not_in?: Maybe<Array<Scalars['ID']>>;
+  rewardProgram?: Maybe<Scalars['String']>;
+  rewardProgram_not?: Maybe<Scalars['String']>;
+  rewardProgram_gt?: Maybe<Scalars['String']>;
+  rewardProgram_lt?: Maybe<Scalars['String']>;
+  rewardProgram_gte?: Maybe<Scalars['String']>;
+  rewardProgram_lte?: Maybe<Scalars['String']>;
+  rewardProgram_in?: Maybe<Array<Scalars['String']>>;
+  rewardProgram_not_in?: Maybe<Array<Scalars['String']>>;
+  rewardProgram_contains?: Maybe<Scalars['String']>;
+  rewardProgram_not_contains?: Maybe<Scalars['String']>;
+  rewardProgram_starts_with?: Maybe<Scalars['String']>;
+  rewardProgram_not_starts_with?: Maybe<Scalars['String']>;
+  rewardProgram_ends_with?: Maybe<Scalars['String']>;
+  rewardProgram_not_ends_with?: Maybe<Scalars['String']>;
+  paymentCycle?: Maybe<Scalars['BigInt']>;
+  paymentCycle_not?: Maybe<Scalars['BigInt']>;
+  paymentCycle_gt?: Maybe<Scalars['BigInt']>;
+  paymentCycle_lt?: Maybe<Scalars['BigInt']>;
+  paymentCycle_gte?: Maybe<Scalars['BigInt']>;
+  paymentCycle_lte?: Maybe<Scalars['BigInt']>;
+  paymentCycle_in?: Maybe<Array<Scalars['BigInt']>>;
+  paymentCycle_not_in?: Maybe<Array<Scalars['BigInt']>>;
+  timestamp?: Maybe<Scalars['BigInt']>;
+  timestamp_not?: Maybe<Scalars['BigInt']>;
+  timestamp_gt?: Maybe<Scalars['BigInt']>;
+  timestamp_lt?: Maybe<Scalars['BigInt']>;
+  timestamp_gte?: Maybe<Scalars['BigInt']>;
+  timestamp_lte?: Maybe<Scalars['BigInt']>;
+  timestamp_in?: Maybe<Array<Scalars['BigInt']>>;
+  timestamp_not_in?: Maybe<Array<Scalars['BigInt']>>;
+  blockNumber?: Maybe<Scalars['BigInt']>;
+  blockNumber_not?: Maybe<Scalars['BigInt']>;
+  blockNumber_gt?: Maybe<Scalars['BigInt']>;
+  blockNumber_lt?: Maybe<Scalars['BigInt']>;
+  blockNumber_gte?: Maybe<Scalars['BigInt']>;
+  blockNumber_lte?: Maybe<Scalars['BigInt']>;
+  blockNumber_in?: Maybe<Array<Scalars['BigInt']>>;
+  blockNumber_not_in?: Maybe<Array<Scalars['BigInt']>>;
+};
+
+export enum MerkleRootSubmissionOrderBy {
+  ID = 'id',
+  REWARDPROGRAM = 'rewardProgram',
+  PAYMENTCYCLE = 'paymentCycle',
+  TIMESTAMP = 'timestamp',
+  BLOCKNUMBER = 'blockNumber'
+}
+
 export enum OrderDirection {
   ASC = 'asc',
   DESC = 'desc'
@@ -3503,6 +3569,8 @@ export type Query = {
   rewardeeClaims: Array<RewardeeClaim>;
   rewardTokensAdd?: Maybe<RewardTokensAdd>;
   rewardTokensAdds: Array<RewardTokensAdd>;
+  merkleRootSubmission?: Maybe<MerkleRootSubmission>;
+  merkleRootSubmissions: Array<MerkleRootSubmission>;
   /** Access to subgraph metadata */
   _meta?: Maybe<Meta>;
 };
@@ -4408,6 +4476,24 @@ export type QueryRewardTokensAddsArgs = {
 };
 
 
+export type QueryMerkleRootSubmissionArgs = {
+  id: Scalars['ID'];
+  block?: Maybe<BlockHeight>;
+  subgraphError?: SubgraphErrorPolicy;
+};
+
+
+export type QueryMerkleRootSubmissionsArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<MerkleRootSubmissionOrderBy>;
+  orderDirection?: Maybe<OrderDirection>;
+  where?: Maybe<MerkleRootSubmissionFilter>;
+  block?: Maybe<BlockHeight>;
+  subgraphError?: SubgraphErrorPolicy;
+};
+
+
 export type QueryMetaArgs = {
   block?: Maybe<BlockHeight>;
 };
@@ -4491,6 +4577,7 @@ export type RewardProgram = {
   rewardSafes: Array<Maybe<RewardSafe>>;
   tokenAddEvents: Array<Maybe<RewardTokensAdd>>;
   rewardClaimEvents: Array<Maybe<RewardeeClaim>>;
+  merkleRoots: Array<Maybe<MerkleRootSubmission>>;
 };
 
 
@@ -4518,6 +4605,15 @@ export type RewardProgramRewardClaimEventsArgs = {
   orderBy?: Maybe<RewardeeClaimOrderBy>;
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<RewardeeClaimFilter>;
+};
+
+
+export type RewardProgramMerkleRootsArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<MerkleRootSubmissionOrderBy>;
+  orderDirection?: Maybe<OrderDirection>;
+  where?: Maybe<MerkleRootSubmissionFilter>;
 };
 
 export type RewardProgramRegistrationPayment = {
@@ -4654,7 +4750,8 @@ export enum RewardProgramOrderBy {
   ADMIN = 'admin',
   REWARDSAFES = 'rewardSafes',
   TOKENADDEVENTS = 'tokenAddEvents',
-  REWARDCLAIMEVENTS = 'rewardClaimEvents'
+  REWARDCLAIMEVENTS = 'rewardClaimEvents',
+  MERKLEROOTS = 'merkleRoots'
 }
 
 export type RewardSafe = {
@@ -5517,7 +5614,6 @@ export type SafeTransaction = {
   safe: Safe;
   to: Scalars['String'];
   value: Scalars['BigInt'];
-  data: Scalars['Bytes'];
   operation: Scalars['BigInt'];
   safeTxGas: Scalars['BigInt'];
   baseGas: Scalars['BigInt'];
@@ -5603,12 +5699,6 @@ export type SafeTransactionFilter = {
   value_lte?: Maybe<Scalars['BigInt']>;
   value_in?: Maybe<Array<Scalars['BigInt']>>;
   value_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  data?: Maybe<Scalars['Bytes']>;
-  data_not?: Maybe<Scalars['Bytes']>;
-  data_in?: Maybe<Array<Scalars['Bytes']>>;
-  data_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  data_contains?: Maybe<Scalars['Bytes']>;
-  data_not_contains?: Maybe<Scalars['Bytes']>;
   operation?: Maybe<Scalars['BigInt']>;
   operation_not?: Maybe<Scalars['BigInt']>;
   operation_gt?: Maybe<Scalars['BigInt']>;
@@ -5693,7 +5783,6 @@ export enum SafeTransactionOrderBy {
   SAFE = 'safe',
   TO = 'to',
   VALUE = 'value',
-  DATA = 'data',
   OPERATION = 'operation',
   SAFETXGAS = 'safeTxGas',
   BASEGAS = 'baseGas',
@@ -5931,6 +6020,8 @@ export type Subscription = {
   rewardeeClaims: Array<RewardeeClaim>;
   rewardTokensAdd?: Maybe<RewardTokensAdd>;
   rewardTokensAdds: Array<RewardTokensAdd>;
+  merkleRootSubmission?: Maybe<MerkleRootSubmission>;
+  merkleRootSubmissions: Array<MerkleRootSubmission>;
   /** Access to subgraph metadata */
   _meta?: Maybe<Meta>;
 };
@@ -6831,6 +6922,24 @@ export type SubscriptionRewardTokensAddsArgs = {
   orderBy?: Maybe<RewardTokensAddOrderBy>;
   orderDirection?: Maybe<OrderDirection>;
   where?: Maybe<RewardTokensAddFilter>;
+  block?: Maybe<BlockHeight>;
+  subgraphError?: SubgraphErrorPolicy;
+};
+
+
+export type SubscriptionMerkleRootSubmissionArgs = {
+  id: Scalars['ID'];
+  block?: Maybe<BlockHeight>;
+  subgraphError?: SubgraphErrorPolicy;
+};
+
+
+export type SubscriptionMerkleRootSubmissionsArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<MerkleRootSubmissionOrderBy>;
+  orderDirection?: Maybe<OrderDirection>;
+  where?: Maybe<MerkleRootSubmissionFilter>;
   block?: Maybe<BlockHeight>;
   subgraphError?: SubgraphErrorPolicy;
 };
@@ -8269,6 +8378,26 @@ export type GetLifetimeEarningsAccumulationsQuery = (
   )> }
 );
 
+export type GetRewardClaimsQueryVariables = Exact<{
+  rewardeeAddress: Scalars['String'];
+}>;
+
+
+export type GetRewardClaimsQuery = (
+  { __typename?: 'Query' }
+  & { rewardeeClaims: Array<(
+    { __typename?: 'RewardeeClaim' }
+    & Pick<RewardeeClaim, 'id' | 'amount' | 'timestamp'>
+    & { token: (
+      { __typename?: 'Token' }
+      & Pick<Token, 'id' | 'name' | 'symbol' | 'decimals'>
+    ), rewardSafe: (
+      { __typename?: 'RewardSafe' }
+      & Pick<RewardSafe, 'id'>
+    ) }
+  )> }
+);
+
 export const PrepaidCardPaymentFragmentDoc = gql`
     fragment PrepaidCardPayment on PrepaidCardPayment {
   id
@@ -8845,3 +8974,47 @@ export function useGetLifetimeEarningsAccumulationsLazyQuery(baseOptions?: Apoll
 export type GetLifetimeEarningsAccumulationsQueryHookResult = ReturnType<typeof useGetLifetimeEarningsAccumulationsQuery>;
 export type GetLifetimeEarningsAccumulationsLazyQueryHookResult = ReturnType<typeof useGetLifetimeEarningsAccumulationsLazyQuery>;
 export type GetLifetimeEarningsAccumulationsQueryResult = ApolloReactCommon.QueryResult<GetLifetimeEarningsAccumulationsQuery, GetLifetimeEarningsAccumulationsQueryVariables>;
+export const GetRewardClaimsDocument = gql`
+    query GetRewardClaims($rewardeeAddress: String!) {
+  rewardeeClaims(orderBy: timestamp, orderDirection: desc, where: {rewardee: $rewardeeAddress}) {
+    id
+    amount
+    timestamp
+    token {
+      id
+      name
+      symbol
+      decimals
+    }
+    rewardSafe {
+      id
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetRewardClaimsQuery__
+ *
+ * To run a query within a React component, call `useGetRewardClaimsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetRewardClaimsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetRewardClaimsQuery({
+ *   variables: {
+ *      rewardeeAddress: // value for 'rewardeeAddress'
+ *   },
+ * });
+ */
+export function useGetRewardClaimsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetRewardClaimsQuery, GetRewardClaimsQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetRewardClaimsQuery, GetRewardClaimsQueryVariables>(GetRewardClaimsDocument, baseOptions);
+      }
+export function useGetRewardClaimsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetRewardClaimsQuery, GetRewardClaimsQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetRewardClaimsQuery, GetRewardClaimsQueryVariables>(GetRewardClaimsDocument, baseOptions);
+        }
+export type GetRewardClaimsQueryHookResult = ReturnType<typeof useGetRewardClaimsQuery>;
+export type GetRewardClaimsLazyQueryHookResult = ReturnType<typeof useGetRewardClaimsLazyQuery>;
+export type GetRewardClaimsQueryResult = ApolloReactCommon.QueryResult<GetRewardClaimsQuery, GetRewardClaimsQueryVariables>;

--- a/cardstack/src/graphql/queries.graphql
+++ b/cardstack/src/graphql/queries.graphql
@@ -1,7 +1,16 @@
-query GetAccountTransactionHistoryData($address: ID!, $skip: Int = 0, $pageSize: Int = 25) {
+query GetAccountTransactionHistoryData(
+  $address: ID!
+  $skip: Int = 0
+  $pageSize: Int = 25
+) {
   account(id: $address) {
     id
-    transactions(first: $pageSize, skip: $skip, orderBy: timestamp, orderDirection: desc) {
+    transactions(
+      first: $pageSize
+      skip: $skip
+      orderBy: timestamp
+      orderDirection: desc
+    ) {
       timestamp
       transaction {
         ...Transaction
@@ -10,20 +19,39 @@ query GetAccountTransactionHistoryData($address: ID!, $skip: Int = 0, $pageSize:
   }
 }
 
-query GetDepotTransactionHistoryData($address: String!, $skip: Int = 0, $pageSize: Int = 25) {
-  eoatransactions(where: {safe: $address}, first: $pageSize, skip: $skip, orderBy: timestamp, orderDirection: asc) {
+query GetDepotTransactionHistoryData(
+  $address: String!
+  $skip: Int = 0
+  $pageSize: Int = 25
+) {
+  eoatransactions(
+    where: { safe: $address }
+    first: $pageSize
+    skip: $skip
+    orderBy: timestamp
+    orderDirection: asc
+  ) {
     transaction {
       ...Transaction
     }
   }
 }
 
-query GetMerchantTransactionHistoryData($address: ID!, $skip: Int = 0, $pageSize: Int = 25) {
+query GetMerchantTransactionHistoryData(
+  $address: ID!
+  $skip: Int = 0
+  $pageSize: Int = 25
+) {
   merchantSafe(id: $address) {
     id
     merchantRevenue {
       id
-      revenueEvents(first: $pageSize, skip: $skip, orderBy: timestamp, orderDirection: desc) {
+      revenueEvents(
+        first: $pageSize
+        skip: $skip
+        orderBy: timestamp
+        orderDirection: desc
+      ) {
         ...MerchantRevenueEvent
       }
     }
@@ -54,12 +82,33 @@ query GetPrepaidCardHistoryData($address: ID!) {
 }
 
 query GetLifetimeEarningsAccumulations($address: ID!) {
-  merchantSafe (id: $address) {
+  merchantSafe(id: $address) {
     id
     spendAccumulations(orderBy: timestamp, orderDirection: asc) {
       timestamp
       amount
       historicSpendBalance
+    }
+  }
+}
+
+query GetRewardClaims($rewardeeAddress: String!) {
+  rewardeeClaims(
+    orderBy: timestamp
+    orderDirection: desc
+    where: { rewardee: $rewardeeAddress }
+  ) {
+    id
+    amount
+    timestamp
+    token {
+      id
+      name
+      symbol
+      decimals
+    }
+    rewardSafe {
+      id
     }
   }
 }

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
@@ -13,6 +13,7 @@ const RewardsCenterScreen = () => {
     hasRewardsAvailable,
     mainPoolTokenInfo,
     onClaimPress,
+    claimHistorySectionData,
   } = useRewardsCenterScreen();
 
   const mainPoolRowProps = useMemo(
@@ -34,7 +35,7 @@ const RewardsCenterScreen = () => {
       <NavigationStackHeader title={strings.navigation.title} />
       <Container backgroundColor="white" flex={1}>
         <Image source={rewardBanner} style={styles.headerImage} />
-        <Container>
+        <Container flex={1}>
           {!isRegistered &&
             (hasRewardsAvailable ? (
               <RegisterContent
@@ -47,6 +48,7 @@ const RewardsCenterScreen = () => {
           {isRegistered && (
             <ClaimContent
               claimList={hasRewardsAvailable ? [mainPoolRowProps] : undefined}
+              historyList={claimHistorySectionData}
             />
           )}
         </Container>

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
@@ -1,12 +1,14 @@
 import React, { useCallback } from 'react';
 import { SectionList } from 'react-native';
+import { fromWei } from '@cardstack/cardpay-sdk';
 import { strings } from '../strings';
-import { RewardRow, RewardRowProps } from '.';
+import { RewardRow } from '.';
 import { Container, Text, ListEmptyComponent } from '@cardstack/components';
+import { RewardeeClaim } from '@cardstack/graphql';
 
 export interface RewardsHistorySectionType {
   title: string;
-  data: Array<RewardRowProps>;
+  data: RewardeeClaim[];
 }
 
 export interface RewardsHistoryListProps {
@@ -17,11 +19,26 @@ export const RewardsHistoryList = ({
   sections = [],
 }: RewardsHistoryListProps) => {
   const renderSectionHeader = useCallback(
-    ({ section }) => <Text size="medium">{section.title}</Text>,
+    ({ section }) => (
+      <Container backgroundColor="white">
+        <Text size="medium">{section.title}</Text>
+      </Container>
+    ),
     []
   );
 
-  const renderItem = useCallback(({ item }) => <RewardRow {...item} />, []);
+  const renderItem = useCallback(({ item }: { item: RewardeeClaim }) => {
+    const amountInEth = fromWei(item.amount);
+    const symbol = item.token.symbol || '';
+
+    return (
+      <RewardRow
+        primaryText={`${amountInEth} ${symbol}`}
+        coinSymbol={symbol}
+        claimed
+      />
+    );
+  }, []);
 
   const spacing = useCallback(() => <Container paddingBottom={4} />, []);
 

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,5 @@
 schema:
-  - https://graph-staging.stack.cards/subgraphs/name/habdelra/cardpay-sokol
+  - https://graph.cardstack.com/subgraphs/name/habdelra/cardpay-xdai
 overwrite: true
 generates:
   cardstack/src/graphql/graphql-codegen.ts:


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
Get reward claimed data from subgraph and display on rewards center, improvements to be made, is to make the row touchable to redirect to blockscout, and I'm thinking about extracting the history logic to the HistoryList itself, as there are no shared data, but we can decide that later when I split the rewards hooks.

<!-- Include a summary of the changes. -->

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Simulator Screen Recording - iPhone 12 - 2022-03-24 at 18 09 24](https://user-images.githubusercontent.com/20520102/160010664-5a566c2e-1652-4744-8ac5-e6af9b39aa07.gif)

