### PR TITLE
[Fix]: Update sheets to work on mobile redesign

### DIFF
--- a/src/components/expanded-state/AvailableBalancesExpandedState.tsx
+++ b/src/components/expanded-state/AvailableBalancesExpandedState.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, RefreshControl, SectionList } from 'react-native';
-import { SlackSheet } from '../sheet';
 
 import {
   BalanceSection,
   Container,
   HorizontalDivider,
   ListEmptyComponent,
+  Sheet,
   Text,
   Touchable,
   TransactionItem,
@@ -57,7 +57,7 @@ export default function AvailableBalancesExpandedState(
   }, [setOptions]);
 
   return (
-    <SlackSheet scrollEnabled>
+    <Sheet isFullScreen scrollEnabled>
       <Container paddingHorizontal={5} paddingTop={3}>
         <Text size="medium">Available Balance</Text>
         <Container flexDirection="row" justifyContent="space-between">
@@ -79,7 +79,7 @@ export default function AvailableBalancesExpandedState(
       ) : (
         <Activities {...props} />
       )}
-    </SlackSheet>
+    </Sheet>
   );
 }
 

--- a/src/components/expanded-state/ChartExpandedState.js
+++ b/src/components/expanded-state/ChartExpandedState.js
@@ -7,7 +7,6 @@ import {
   SendActionButton,
   SheetActionButtonRow,
   SheetDivider,
-  SlackSheet,
   SwapActionButton,
 } from '../sheet';
 import {
@@ -17,7 +16,7 @@ import {
   TokenInfoSection,
 } from '../token-info';
 import { Chart } from '../value-chart';
-import { Container } from '@cardstack/components';
+import { Container, Sheet } from '@cardstack/components';
 import { ChartPathProvider } from '@rainbow-me/animated-charts';
 import AssetInputTypes from '@rainbow-me/helpers/assetInputTypes';
 
@@ -71,17 +70,11 @@ export default function ChartExpandedState(props) {
   if (duration.current === 0) {
     duration.current = 300;
   }
-  const ChartExpandedStateSheetHeight =
-    ios || showChart ? heightWithChart : heightWithoutChart;
 
   const hasNativeBalance = !!parseFloat(asset?.native?.balance?.amount);
 
   return (
-    <SlackSheet
-      additionalTopPadding={android}
-      contentHeight={ChartExpandedStateSheetHeight}
-      scrollEnabled={false}
-    >
+    <Sheet scrollEnabled={false}>
       <ChartPathProvider data={throttledData}>
         <Chart
           {...chartData}
@@ -132,6 +125,6 @@ export default function ChartExpandedState(props) {
           />
         </Container>
       )}
-    </SlackSheet>
+    </Sheet>
   );
 }

--- a/src/components/expanded-state/SupportAndFeedsState.tsx
+++ b/src/components/expanded-state/SupportAndFeedsState.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 import { FlatList } from 'react-native';
-import { SlackSheet } from '../sheet';
-import { Container, Text } from '@cardstack/components';
+import { Container, Sheet, Text } from '@cardstack/components';
 import { supportedCountries } from '@rainbow-me/references/wyre';
 
 type Country = keyof typeof supportedCountries;
@@ -42,7 +41,7 @@ const SupportAndFeedsState = () => {
   // Workaround to avoid not dismiss modal
   return useMemo(
     () => (
-      <SlackSheet scrollEnabled>
+      <Sheet isFullScreen scrollEnabled>
         <Container marginBottom={12} padding={6}>
           <Text
             color="black"
@@ -73,7 +72,7 @@ const SupportAndFeedsState = () => {
             renderItem={renderItem}
           />
         </Container>
-      </SlackSheet>
+      </Sheet>
     ),
     [renderItem]
   );

--- a/src/screens/ExpandedAssetSheet.js
+++ b/src/screens/ExpandedAssetSheet.js
@@ -1,10 +1,6 @@
 import { useRoute } from '@react-navigation/native';
-import React, { createElement } from 'react';
-import { StatusBar } from 'react-native';
-import { useSafeArea } from 'react-native-safe-area-context';
-import styled from 'styled-components';
+import { createElement } from 'react';
 
-import TouchableBackdrop from '../components/TouchableBackdrop';
 import {
   AvailableBalancesExpandedState,
   ChartExpandedState,
@@ -12,11 +8,8 @@ import {
   LiquidityPoolExpandedState,
   SupportAndFeedsState,
 } from '../components/expanded-state';
-import { Centered } from '../components/layout';
-import { useAsset, useDimensions } from '../hooks';
-import { useNavigation } from '../navigation/Navigation';
+import { useAsset } from '../hooks';
 import { ExpandedMerchantRoutes } from '@cardstack/components';
-import { position } from '@rainbow-me/styles';
 
 const ScreenTypes = {
   token: ChartExpandedState,
@@ -26,35 +19,14 @@ const ScreenTypes = {
   supportAndFees: SupportAndFeedsState,
 };
 
-const Container = styled(Centered).attrs({
-  direction: 'column',
-})`
-  ${position.cover};
-  ${({ deviceHeight, height }) =>
-    height ? `height: ${height + deviceHeight}` : null};
-`;
-
 export default function ExpandedAssetSheet(props) {
-  const { height: deviceHeight } = useDimensions();
-  const insets = useSafeArea();
-  const { goBack } = useNavigation();
   const { params } = useRoute();
 
   const selectedAsset = useAsset(params.asset);
 
-  return (
-    <Container
-      deviceHeight={deviceHeight}
-      height={params.longFormHeight}
-      insets={insets}
-    >
-      <StatusBar barStyle="light-content" />
-      {ios && <TouchableBackdrop onPress={goBack} />}
-      {createElement(ScreenTypes[params.type], {
-        asset: selectedAsset,
-        safeAddress: params?.safeAddress,
-        ...props,
-      })}
-    </Container>
-  );
+  return createElement(ScreenTypes[params.type], {
+    asset: selectedAsset,
+    safeAddress: params?.safeAddress,
+    ...props,
+  });
 }


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR fixes sheets opening over screen and also the chart/send sheet, I tested, but if you could, it would be really helpful to test across both navigation and devices. (of course the best fix would be to migrate the ones that are using the expanded state, to be it's own sheet, but we can do one by one next).

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->


<img width="250" alt="image" src="https://user-images.githubusercontent.com/20520102/160027836-a8e88fb4-2419-43fc-a8fb-ee88c1b6822c.png">


<img width="250" alt="image" src="https://user-images.githubusercontent.com/20520102/160027850-07e47c14-64b4-43ad-9a9d-fe565d86f220.png">


<img width="250" alt="image" src="https://user-images.githubusercontent.com/20520102/160027876-ed806c0d-4368-4a02-8d52-3d1ee4bfce06.png">
