### PR TITLE
[CS-3371]: Add loading state to rewards center

### DIFF
--- a/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
@@ -3,7 +3,12 @@ import { StyleSheet } from 'react-native';
 import rewardBanner from '../../assets/rewards-banner.png';
 import { strings } from './strings';
 import { useRewardsCenterScreen } from './useRewardsCenterScreen';
-import { RegisterContent, NoRewardContent, ClaimContent } from './components';
+import {
+  RegisterContent,
+  NoRewardContent,
+  ClaimContent,
+  RewardLoadingSkeleton,
+} from './components';
 import { Container, NavigationStackHeader, Image } from '@cardstack/components';
 
 const RewardsCenterScreen = () => {
@@ -15,6 +20,7 @@ const RewardsCenterScreen = () => {
     onClaimPress,
     claimHistorySectionData,
     tokensBalanceData,
+    isLoading,
   } = useRewardsCenterScreen();
 
   const mainPoolRowProps = useMemo(
@@ -35,24 +41,28 @@ const RewardsCenterScreen = () => {
       <NavigationStackHeader title={strings.navigation.title} />
       <Container backgroundColor="white" flex={1}>
         <Image source={rewardBanner} style={styles.headerImage} />
-        <Container flex={1}>
-          {!isRegistered &&
-            (hasRewardsAvailable ? (
-              <RegisterContent
-                onRegisterPress={onRegisterPress}
-                {...mainPoolRowProps}
+        {isLoading ? (
+          <RewardLoadingSkeleton />
+        ) : (
+          <Container flex={1}>
+            {!isRegistered &&
+              (hasRewardsAvailable ? (
+                <RegisterContent
+                  onRegisterPress={onRegisterPress}
+                  {...mainPoolRowProps}
+                />
+              ) : (
+                <NoRewardContent />
+              ))}
+            {isRegistered && (
+              <ClaimContent
+                claimList={hasRewardsAvailable ? [mainPoolRowProps] : undefined}
+                historyList={claimHistorySectionData}
+                balanceList={tokensBalanceData}
               />
-            ) : (
-              <NoRewardContent />
-            ))}
-          {isRegistered && (
-            <ClaimContent
-              claimList={hasRewardsAvailable ? [mainPoolRowProps] : undefined}
-              historyList={claimHistorySectionData}
-              balanceList={tokensBalanceData}
-            />
-          )}
-        </Container>
+            )}
+          </Container>
+        )}
       </Container>
     </Container>
   );

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardLoadingSkeleton.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardLoadingSkeleton.tsx
@@ -1,0 +1,21 @@
+import React, { memo } from 'react';
+import {
+  CenteredContainer,
+  ContainerProps,
+  Skeleton,
+} from '@cardstack/components';
+
+export const RewardLoadingSkeleton = (props: ContainerProps) => (
+  <CenteredContainer
+    padding={5}
+    justifyContent="space-between"
+    flex={0.6}
+    {...props}
+  >
+    <Skeleton height="5%" light width="75%" borderRadius={5} />
+    <Skeleton height="28%" light />
+    <Skeleton height="50%" light />
+  </CenteredContainer>
+);
+
+export default memo(RewardLoadingSkeleton);

--- a/cardstack/src/screens/RewardsCenterScreen/components/index.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/components/index.ts
@@ -5,3 +5,4 @@ export * from './RewardsTitle';
 export * from './ClaimContent';
 export * from './RewardsBalanceList';
 export * from './RewardsHistoryList';
+export { default as RewardLoadingSkeleton } from './RewardLoadingSkeleton';

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -46,6 +46,7 @@ export const useRewardsCenterScreen = () => {
 
   const {
     isLoading: isLoadindSafes,
+    isUninitialized,
     data: { rewardSafes } = {},
   } = useGetRewardsSafeQuery(query.params, query.options);
 
@@ -280,7 +281,7 @@ export const useRewardsCenterScreen = () => {
     onRegisterPress,
     hasRewardsAvailable: !!mainPoolTokenInfo,
     mainPoolTokenInfo,
-    isLoading: isLoadindSafes || isLoadingTokens,
+    isLoading: isLoadindSafes || isLoadingTokens || isUninitialized,
     onClaimPress,
     claimHistorySectionData,
     tokensBalanceData,


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

I tweak the designs a little to match the components we have on the screen after the redesign, but it's basically the same thing. Also we use `isUninitialized` to set the first loading as default in case we don't have an accountAddress yet and the query is skipped, so we can prevent a registered user to see the unregistered state.

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Simulator Screen Recording - iPhone 12 - 2022-03-25 at 09 59 01](https://user-images.githubusercontent.com/20520102/160125196-afb0a2d6-6b72-4cba-89e2-abec7d8d5d91.gif)


