### PR TITLE
[CS-3376] Register Account Transaction Confirmation Screen

### DIFF
--- a/cardstack/src/components/TransactionConfirmationSheet/displays/DisplayInformation.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/displays/DisplayInformation.tsx
@@ -10,6 +10,7 @@ import { SplitPrepaidCardDisplay } from './PrepaidCard/SplitPrepaidCardDisplay';
 import { TransferPrepaidCardDisplay } from './PrepaidCard/TransferPrepaidCardDisplay';
 import { WithdrawalDisplay } from './WithdrawalDisplay';
 import { HubAuthenticationDisplay } from './HubAuthenticationDisplay';
+import { RewardsRegisterDisplay } from './RewardsRegisterDisplay';
 import { TransactionConfirmationType } from '@cardstack/types';
 import {
   CenteredContainer,
@@ -59,6 +60,10 @@ export const transactionTypeMap: Record<
   [TransactionConfirmationType.TRANSFER_PREPAID_CARD_2]: {
     title: 'Transfer Prepaid Card - Step 2/2',
     component: TransferPrepaidCardDisplay,
+  },
+  [TransactionConfirmationType.REWARDS_REGISTER]: {
+    title: 'Register Account',
+    component: RewardsRegisterDisplay,
   },
 };
 

--- a/cardstack/src/components/TransactionConfirmationSheet/displays/RewardsRegisterDisplay.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/displays/RewardsRegisterDisplay.tsx
@@ -6,6 +6,7 @@ import { PayThisAmountSection } from './components/sections/PayThisAmountSection
 import {
   HorizontalDivider,
   TransactionConfirmationDisplayProps,
+  IconProps,
 } from '@cardstack/components';
 import { RewardsRegisterData } from '@cardstack/types';
 
@@ -14,6 +15,12 @@ interface RewardsRegisterDisplayProps
   data: RewardsRegisterData;
 }
 
+const rewardsIconProps = {
+  name: 'rewards',
+  size: 22,
+  color: 'teal',
+} as IconProps;
+
 export const RewardsRegisterDisplay = ({
   data: { programName, prepaidCard, spendAmount },
 }: RewardsRegisterDisplayProps) => (
@@ -21,7 +28,7 @@ export const RewardsRegisterDisplay = ({
     <SectionIconTitle
       sectionHeaderText={strings.rewards.program.title}
       title={programName}
-      iconProps={{ name: 'rewards', size: 22, color: 'teal' }}
+      iconProps={rewardsIconProps}
     />
     <HorizontalDivider />
     <PrepaidCardTransactionSection

--- a/cardstack/src/components/TransactionConfirmationSheet/displays/RewardsRegisterDisplay.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/displays/RewardsRegisterDisplay.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { strings } from '../strings';
+import { SectionIconTitle } from './components/SectionIconTitle';
+import { PrepaidCardTransactionSection } from './components/sections/PrepaidCardTransactionSection';
+import { PayThisAmountSection } from './components/sections/PayThisAmountSection';
+import {
+  Container,
+  HorizontalDivider,
+  Icon,
+  Text,
+  TransactionConfirmationDisplayProps,
+} from '@cardstack/components';
+import { RewardsRegisterData } from '@cardstack/types';
+
+interface RewardsRegisterDisplayProps
+  extends TransactionConfirmationDisplayProps {
+  data: RewardsRegisterData;
+}
+
+export const RewardsRegisterDisplay = ({
+  data: { programName, prepaidCard, spendAmount },
+}: RewardsRegisterDisplayProps) => (
+  <>
+    <SectionIconTitle
+      title={programName}
+      iconProps={{ name: 'cardstack', size: 15 }}
+    />
+    <HorizontalDivider />
+    <PrepaidCardTransactionSection
+      headerText={strings.rewards.prepaidcard.title}
+      prepaidCardAddress={prepaidCard}
+    />
+    <PayThisAmountSection
+      headerText={strings.rewards.cost.title}
+      spendAmount={spendAmount}
+    />
+  </>
+);

--- a/cardstack/src/components/TransactionConfirmationSheet/displays/RewardsRegisterDisplay.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/displays/RewardsRegisterDisplay.tsx
@@ -4,10 +4,7 @@ import { SectionIconTitle } from './components/SectionIconTitle';
 import { PrepaidCardTransactionSection } from './components/sections/PrepaidCardTransactionSection';
 import { PayThisAmountSection } from './components/sections/PayThisAmountSection';
 import {
-  Container,
   HorizontalDivider,
-  Icon,
-  Text,
   TransactionConfirmationDisplayProps,
 } from '@cardstack/components';
 import { RewardsRegisterData } from '@cardstack/types';
@@ -22,8 +19,9 @@ export const RewardsRegisterDisplay = ({
 }: RewardsRegisterDisplayProps) => (
   <>
     <SectionIconTitle
+      sectionHeaderText={strings.rewards.program.title}
       title={programName}
-      iconProps={{ name: 'cardstack', size: 15 }}
+      iconProps={{ name: 'rewards', size: 22, color: 'teal' }}
     />
     <HorizontalDivider />
     <PrepaidCardTransactionSection

--- a/cardstack/src/components/TransactionConfirmationSheet/displays/components/SectionIconTitle.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/displays/components/SectionIconTitle.tsx
@@ -1,6 +1,12 @@
 import React, { memo } from 'react';
 import { SectionHeaderText } from './SectionHeaderText';
-import { Container, Icon, IconProps, Text } from '@cardstack/components';
+import {
+  Container,
+  CenteredContainer,
+  Icon,
+  IconProps,
+  Text,
+} from '@cardstack/components';
 
 interface SectionIconTitleProps {
   title?: string;
@@ -14,12 +20,12 @@ export const SectionIconTitle = memo(
       {!!sectionHeaderText && (
         <SectionHeaderText>{sectionHeaderText}</SectionHeaderText>
       )}
-      <Container paddingHorizontal={3} marginTop={4}>
+      <Container paddingHorizontal={2} marginTop={4}>
         <Container flexDirection="row">
           {!!iconProps && (
-            <Container>
+            <CenteredContainer>
               <Icon {...iconProps} />
-            </Container>
+            </CenteredContainer>
           )}
           {!!title && (
             <Text marginLeft={4} weight="extraBold">

--- a/cardstack/src/components/TransactionConfirmationSheet/displays/components/SectionIconTitle.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/displays/components/SectionIconTitle.tsx
@@ -1,0 +1,33 @@
+import React, { memo } from 'react';
+import { SectionHeaderText } from './SectionHeaderText';
+import { Container, Icon, IconProps, Text } from '@cardstack/components';
+
+interface SectionIconTitleProps {
+  title?: string;
+  iconProps?: IconProps;
+  sectionHeaderText?: string;
+}
+
+export const SectionIconTitle = memo(
+  ({ title, iconProps, sectionHeaderText }: SectionIconTitleProps) => (
+    <Container marginTop={8} width="100%">
+      {!!sectionHeaderText && (
+        <SectionHeaderText>{sectionHeaderText}</SectionHeaderText>
+      )}
+      <Container paddingHorizontal={3} marginTop={4}>
+        <Container flexDirection="row">
+          {!!iconProps && (
+            <Container>
+              <Icon {...iconProps} />
+            </Container>
+          )}
+          {!!title && (
+            <Text marginLeft={4} weight="extraBold">
+              {title}
+            </Text>
+          )}
+        </Container>
+      </Container>
+    </Container>
+  )
+);

--- a/cardstack/src/components/TransactionConfirmationSheet/strings.ts
+++ b/cardstack/src/components/TransactionConfirmationSheet/strings.ts
@@ -6,4 +6,12 @@ export const strings = {
     payThisAmount: 'Pay This Amount',
     profileName: 'Profile Name',
   },
+  rewards: {
+    prepaidcard: {
+      title: 'Pay with',
+    },
+    cost: {
+      title: 'Transaction gas cost',
+    },
+  },
 };

--- a/cardstack/src/components/TransactionConfirmationSheet/strings.ts
+++ b/cardstack/src/components/TransactionConfirmationSheet/strings.ts
@@ -7,6 +7,9 @@ export const strings = {
     profileName: 'Profile Name',
   },
   rewards: {
+    program: {
+      title: 'Register',
+    },
     prepaidcard: {
       title: 'Pay with',
     },

--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -23,6 +23,7 @@ export const MainRoutes = {
   SETTINGS_MODAL: 'SettingModal',
   TRANSFER_CARD: 'TransferCardScreen',
   REWARDS_CENTER_SCREEN: 'RewardsCenterScreen',
+  REWARDS_REGISTER_SHEET: 'RewardsRegisterSheet',
   TRANSACTION_CONFIRMATION_SHEET: 'TransactionConfirmationScreen',
 } as const;
 

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -33,6 +33,7 @@ import {
   MerchantTransactionSheet,
   ChoosePrepaidCardSheet,
   RewardsCenterScreen,
+  RewardsRegisterSheet,
   TransactionConfirmationSheet,
 } from '@cardstack/screens';
 import {
@@ -177,6 +178,10 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
   REWARDS_CENTER_SCREEN: {
     component: RewardsCenterScreen,
     options: horizontalInterpolator,
+  },
+  REWARDS_REGISTER_SHEET: {
+    component: RewardsRegisterSheet,
+    options: expandedPreset as StackNavigationOptions,
   },
   TRANSACTION_CONFIRMATION_SHEET: {
     component: TransactionConfirmationSheet,

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsRegisterSheet/RewardsRegisterSheet.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsRegisterSheet/RewardsRegisterSheet.tsx
@@ -1,0 +1,33 @@
+import React, { memo } from 'react';
+import { useRoute } from '@react-navigation/native';
+import { RouteType } from '@cardstack/navigation/types';
+import { TransactionConfirmationData } from '@cardstack/types';
+import {
+  TransactionConfirmationSheet,
+  SafeAreaView,
+} from '@cardstack/components';
+
+interface RouteParams {
+  data: TransactionConfirmationData;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+}
+
+const RewardsRegisterSheet = () => {
+  const {
+    params: { data, onConfirm, onCancel },
+  } = useRoute<RouteType<RouteParams>>();
+
+  return (
+    <SafeAreaView backgroundColor="black" flex={1} width="100%">
+      <TransactionConfirmationSheet
+        data={data}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        loading={false}
+      />
+    </SafeAreaView>
+  );
+};
+
+export default memo(RewardsRegisterSheet);

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -8,6 +8,7 @@ import { TokensWithSafeAddress } from './components';
 import {
   RewardsRegisterData,
   TransactionConfirmationType,
+  TokenType,
 } from '@cardstack/types';
 import {
   useClaimRewardsMutation,
@@ -22,7 +23,6 @@ import { Alert } from '@rainbow-me/components/alerts';
 import { useMutationEffects } from '@cardstack/hooks';
 import { RewardeeClaim, useGetRewardClaimsQuery } from '@cardstack/graphql';
 import { groupTransactionsByDate } from '@cardstack/utils';
-import { TokenType } from '@cardstack/types';
 import { RewardsSafeType } from '@cardstack/services/rewards-center/rewards-center-types';
 
 const rewardDefaultProgramId = {

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { convertToSpend } from '@cardstack/cardpay-sdk';
-import { useNavigation } from '@react-navigation/core';
+import { useNavigation, StackActions } from '@react-navigation/core';
 import { FetchBaseQueryError } from '@reduxjs/toolkit/dist/query/react';
 import { groupBy } from 'lodash';
 import { strings } from './strings';
@@ -32,7 +32,7 @@ const rewardDefaultProgramId = {
 };
 
 export const useRewardsCenterScreen = () => {
-  const { navigate } = useNavigation();
+  const { navigate, dispatch: navDispatch } = useNavigation();
   const { accountAddress, nativeCurrency, network } = useAccountSettings();
 
   const query = useMemo(
@@ -104,16 +104,25 @@ export const useRewardsCenterScreen = () => {
   const { selectedWallet } = useWallets();
 
   const onMutationEndAlert = useCallback(
-    ({ title, message }) => () => {
+    ({ title, message, shouldGoBack }) => () => {
       dismissLoadingOverlay();
 
       Alert({
         message,
         title,
-        buttons: [{ text: 'Okay' }],
+        buttons: [
+          {
+            text: 'Okay',
+            onPress: shouldGoBack
+              ? () => {
+                  navDispatch(StackActions.pop(2));
+                }
+              : undefined,
+          },
+        ],
       });
     },
-    [dismissLoadingOverlay]
+    [dismissLoadingOverlay, navDispatch]
   );
 
   useMutationEffects(
@@ -124,6 +133,7 @@ export const useRewardsCenterScreen = () => {
           callback: onMutationEndAlert({
             title: 'Success',
             message: 'Registration successful',
+            shouldGoBack: true,
           }),
         },
         error: {

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -176,7 +176,6 @@ export const useRewardsCenterScreen = () => {
         spendAmount: convertToSpend(0.01, 'USD', 1),
         prepaidCard: prepaidCard.address,
         programName: 'Cardstack Rewards',
-        network: rewardDefaultProgramId[network],
       };
 
       navigate(MainRoutes.TRANSACTION_CONFIRMATION_SHEET, {

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -6,6 +6,10 @@ import { groupBy } from 'lodash';
 import { strings } from './strings';
 import { TokensWithSafeAddress } from './components';
 import {
+  RewardsRegisterData,
+  TransactionConfirmationType,
+} from '@cardstack/types';
+import {
   useClaimRewardsMutation,
   useGetRewardPoolTokenBalancesQuery,
   useGetRewardsSafeQuery,
@@ -157,23 +161,23 @@ export const useRewardsCenterScreen = () => {
 
   const onPrepaidCardSelection = useCallback(
     prepaidCard => {
-      // TODO: Replace with confirmation sheet
-      Alert({
-        buttons: [
-          { text: 'Cancel' },
-          {
-            text: 'Confirm',
-            onPress: onRegisterConfirmPress(
-              prepaidCard.address,
-              rewardDefaultProgramId[network]
-            ),
-          },
-        ],
-        title: 'Register Account',
-        message: `Cardstack Rewards\n(${rewardDefaultProgramId[network]})\nPrepaid Card:\n${prepaidCard.address}`,
+      const data: RewardsRegisterData = {
+        type: TransactionConfirmationType.REWARDS_REGISTER,
+        spendAmount: convertToSpend(0.01, 'USD', 1),
+        prepaidCard: prepaidCard.address,
+        programName: 'Cardstack Rewards',
+        network: rewardDefaultProgramId[network],
+      };
+
+      navigate(MainRoutes.TRANSACTION_CONFIRMATION_SHEET, {
+        data,
+        onConfirm: onRegisterConfirmPress(
+          prepaidCard.address,
+          rewardDefaultProgramId[network]
+        ),
       });
     },
-    [network, onRegisterConfirmPress]
+    [navigate, network, onRegisterConfirmPress]
   );
 
   const onRegisterPress = useCallback(() => {

--- a/cardstack/src/screens/index.ts
+++ b/cardstack/src/screens/index.ts
@@ -27,4 +27,5 @@ export { default as TransferCardScreen } from './TransferCardScreen/TransferCard
 export { default as QRScannerScreen } from './QRScannerScreen/QRScannerScreen';
 export { default as ChoosePrepaidCardSheet } from './sheets/ChoosePrepaidCardSheet/ChoosePrepaidCardSheet';
 export { default as RewardsCenterScreen } from './RewardsCenterScreen/RewardsCenterScreen';
+export { default as RewardsRegisterSheet } from './RewardsCenterScreen/RewardsRegisterSheet/RewardsRegisterSheet';
 export { default as TransactionConfirmationSheet } from './sheets/TransactionConfirmationSheet/TransactionConfirmationSheet';

--- a/cardstack/src/types/transaction-confirmation-types.ts
+++ b/cardstack/src/types/transaction-confirmation-types.ts
@@ -1,5 +1,6 @@
 import { PrepaidCardCustomization } from './transaction-types';
 import { MerchantInformation } from './';
+import { RewardsRegisterSheet } from '@cardstack/screens';
 
 export enum TransactionConfirmationType {
   GENERIC = 'generic',
@@ -12,6 +13,7 @@ export enum TransactionConfirmationType {
   TRANSFER_PREPAID_CARD_2 = 'transferPrepaidCard2',
   CLAIM_REVENUE = 'claimRevenue',
   WITHDRAWAL = 'withdrawal',
+  REWARDS_REGISTER = 'rewardsRegister',
 }
 
 export interface Level1DecodedData {
@@ -50,6 +52,14 @@ export interface RegisterMerchantDecodedData {
   merchantInfo?: MerchantInformation;
   prepaidCard: string;
   type: TransactionConfirmationType.REGISTER_MERCHANT;
+}
+
+export interface RewardsRegisterData {
+  programName: string;
+  prepaidCard: string;
+  spendAmount: number;
+  network: string;
+  type: TransactionConfirmationType.REWARDS_REGISTER;
 }
 
 export interface PayMerchantDecodedData {
@@ -128,4 +138,5 @@ export type TransactionConfirmationData =
   | TransferPrepaidCard2DecodedData
   | ClaimRevenueDecodedData
   | WithdrawalDecodedData
-  | PayMerchantDecodedData;
+  | PayMerchantDecodedData
+  | RewardsRegisterData;

--- a/cardstack/src/types/transaction-confirmation-types.ts
+++ b/cardstack/src/types/transaction-confirmation-types.ts
@@ -1,6 +1,5 @@
 import { PrepaidCardCustomization } from './transaction-types';
 import { MerchantInformation } from './';
-import { RewardsRegisterSheet } from '@cardstack/screens';
 
 export enum TransactionConfirmationType {
   GENERIC = 'generic',

--- a/cardstack/src/types/transaction-confirmation-types.ts
+++ b/cardstack/src/types/transaction-confirmation-types.ts
@@ -57,7 +57,6 @@ export interface RewardsRegisterData {
   programName: string;
   prepaidCard: string;
   spendAmount: number;
-  network: string;
   type: TransactionConfirmationType.REWARDS_REGISTER;
 }
 


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds a new TransactionConfirmation sheet, `RewardsRegisterSheet`, all its navigation structure, and a new SectionIconTitle component for displaying icon + title in a transaction sheet.

- [x] Completes #(CS-3376)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

![Simulator_Screen_Recording_-_iPhone_12_-_2022-03-25_at_11 51 06](https://user-images.githubusercontent.com/129619/160144643-a6378e75-c4d6-4012-ba88-bcedbb9fbffd.gif)

