### PR TITLE
[CS-3418] Update ChoosePrepadCard to support custom payCostDesc

### DIFF
--- a/cardstack/src/components/ChoosePrepaidCard/ChoosePrepaidCard.tsx
+++ b/cardstack/src/components/ChoosePrepaidCard/ChoosePrepaidCard.tsx
@@ -20,6 +20,7 @@ export interface ChoosePrepaidCardProps {
   spendAmount: number;
   onPressEditAmount?: () => void;
   onConfirmSelectedCard: () => void;
+  payCostDesc?: string;
 }
 
 const shadowStyles: ContainerProps = {
@@ -54,6 +55,7 @@ export const ChoosePrepaidCard = memo(
     onConfirmSelectedCard,
     spendAmount,
     onPressEditAmount,
+    payCostDesc,
   }: ChoosePrepaidCardProps) => {
     const [
       network,
@@ -117,6 +119,7 @@ export const ChoosePrepaidCard = memo(
         <Header
           nativeBalanceDisplay={nativeBalanceDisplay}
           onPressEditAmount={onPressEditAmount}
+          payCostDesc={payCostDesc}
         />
         <FlatList
           data={prepaidCards}

--- a/cardstack/src/components/ChoosePrepaidCard/Header.tsx
+++ b/cardstack/src/components/ChoosePrepaidCard/Header.tsx
@@ -12,9 +12,11 @@ export const Header = memo(
   ({
     nativeBalanceDisplay,
     onPressEditAmount,
+    payCostDesc,
   }: {
     nativeBalanceDisplay: string;
     onPressEditAmount?: () => void;
+    payCostDesc?: string;
   }) => (
     <Container
       alignItems="center"
@@ -27,7 +29,7 @@ export const Header = memo(
         {strings.chooseAPrepadCard}
       </Text>
       <Text variant="subText" weight="bold" marginTop={3} marginBottom={1}>
-        {strings.payAmountDesc}
+        {payCostDesc || strings.payAmountDesc}
       </Text>
       <Container width="100%" alignItems="center">
         <Touchable onPress={onPressEditAmount}>

--- a/cardstack/src/components/ChoosePrepaidCard/Header.tsx
+++ b/cardstack/src/components/ChoosePrepaidCard/Header.tsx
@@ -28,7 +28,13 @@ export const Header = memo(
       <Text marginTop={4} weight="bold" size="body">
         {strings.chooseAPrepadCard}
       </Text>
-      <Text variant="subText" weight="bold" marginTop={3} marginBottom={1}>
+      <Text
+        fontSize={11}
+        fontWeight="600"
+        color="blueText"
+        marginTop={3}
+        marginBottom={1}
+      >
         {payCostDesc || strings.payAmountDesc}
       </Text>
       <Container width="100%" alignItems="center">

--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -15,7 +15,7 @@ export const strings = {
         'Before you can claim, you need to create and register a reward account.  This is an on-chain event and will cost you a small gas fee - you can use any existing prepaid card to pay the transaction fee.',
     },
     loading: 'Registering Account',
-    payCostDescription: 'To pay transaction amount cost',
+    payCostDescription: 'To pay transaction cost',
   },
   claim: {
     button: 'Claim',

--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -15,6 +15,7 @@ export const strings = {
         'Before you can claim, you need to create and register a reward account.  This is an on-chain event and will cost you a small gas fee - you can use any existing prepaid card to pay the transaction fee.',
     },
     loading: 'Registering Account',
+    payCostDescription: 'To pay transaction amount cost',
   },
   claim: {
     button: 'Claim',

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -194,6 +194,7 @@ export const useRewardsCenterScreen = () => {
       // Mocked estimated gas fee until we get from sdk
       spendAmount: convertToSpend(0.01, 'USD', 1),
       onConfirmChoosePrepaidCard: onPrepaidCardSelection,
+      payCostDesc: strings.register.payCostDescription.toUpperCase(),
     });
   }, [navigate, onPrepaidCardSelection]);
 

--- a/cardstack/src/screens/sheets/ChoosePrepaidCardSheet/ChoosePrepaidCardSheet.tsx
+++ b/cardstack/src/screens/sheets/ChoosePrepaidCardSheet/ChoosePrepaidCardSheet.tsx
@@ -15,6 +15,7 @@ const ChoosePrepaidCardSheet = () => {
     selectedPrepaidCard,
     onSelectPrepaidCard,
     onConfirmSelectedCard,
+    payCostDesc,
   } = useChoosePrepaidCard();
 
   return (
@@ -30,6 +31,7 @@ const ChoosePrepaidCardSheet = () => {
           prepaidCards={prepaidCards}
           onSelectPrepaidCard={onSelectPrepaidCard}
           spendAmount={spendAmount}
+          payCostDesc={payCostDesc}
         />
       )}
     </SafeAreaView>

--- a/cardstack/src/screens/sheets/ChoosePrepaidCardSheet/useChoosePrepaidCard.ts
+++ b/cardstack/src/screens/sheets/ChoosePrepaidCardSheet/useChoosePrepaidCard.ts
@@ -12,11 +12,12 @@ import { RouteType } from '@cardstack/navigation/types';
 type RouteParams = {
   spendAmount: number;
   onConfirmChoosePrepaidCard: (selectedPrepaidCard: PrepaidCardType) => void;
+  payCostDesc?: string;
 };
 
 export const useChoosePrepaidCard = () => {
   const {
-    params: { spendAmount = 0, onConfirmChoosePrepaidCard },
+    params: { spendAmount = 0, onConfirmChoosePrepaidCard, payCostDesc },
   } = useRoute<RouteType<RouteParams>>();
 
   const [selectedPrepaidCard, selectPrepaidCard] = useState<PrepaidCardType>();
@@ -88,5 +89,6 @@ export const useChoosePrepaidCard = () => {
     selectedPrepaidCard,
     onSelectPrepaidCard,
     onConfirmSelectedCard,
+    payCostDesc,
   };
 };

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/prepaid-card-payment-strategy.test.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/prepaid-card-payment-strategy.test.ts
@@ -48,6 +48,7 @@ const result = {
     slug: 'nfty',
     textColor: '#ffffff',
   },
+  merchantSafeAddress: '0x9Ed84407e5ed5B7c0323E5653A06F4528357e3B5',
   nativeBalanceDisplay: '$1.00 USD',
   spendAmount: '100',
   timestamp: '1629411270',


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Added `payCostDesc` prop to `CHOOSE_PREPAIDCARD_SHEET` screen to support custom pay cost description

<!-- Include a summary of the changes. -->

- [x] Completes #CS-3418

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

