### PR TITLE
[CS-3480]: Trigger refetch when reward data updates

### DIFF
--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { convertToSpend } from '@cardstack/cardpay-sdk';
 import { useNavigation, StackActions } from '@react-navigation/core';
 import { FetchBaseQueryError } from '@reduxjs/toolkit/dist/query/react';
@@ -43,6 +43,7 @@ export const useRewardsCenterScreen = () => {
       },
       options: {
         skip: !accountAddress,
+        refetchOnMountOrArgChange: 30,
       },
     }),
     [accountAddress, nativeCurrency]
@@ -248,7 +249,7 @@ export const useRewardsCenterScreen = () => {
     ]
   );
 
-  const { data } = useGetRewardClaimsQuery({
+  const { data, refetch: refetchClaimHistory } = useGetRewardClaimsQuery({
     skip: !accountAddress,
     variables: {
       rewardeeAddress: accountAddress,
@@ -267,6 +268,12 @@ export const useRewardsCenterScreen = () => {
     }),
     [data]
   );
+
+  // Refetchs when rewardSafes or rewardPoolTokenBalances updates
+  useEffect(() => {
+    refetchClaimHistory();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rewardSafes, rewardPoolTokenBalances]);
 
   const tokensBalanceData = useMemo(
     () => ({


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Manually refetch claim history when data is updated, as claim history is from Apollo and the data is from RTK  we can't automatically invalidate and refetch, also added `refetchOnMountOrArgChange` to try and make the data be up-to-date

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size


<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

Unfortunately the reward balance is not updated yet, but it's a db issue we will look into 

https://user-images.githubusercontent.com/20520102/160439472-c0c74229-0f92-472c-9d6f-21eb3765ac20.mp4


