### PR TITLE
[CS-3386]: Add default timeout to queryWrapper

### DIFF
--- a/cardstack/src/services/utils/__tests__/services-utils.test.ts
+++ b/cardstack/src/services/utils/__tests__/services-utils.test.ts
@@ -57,6 +57,33 @@ describe('service utils', () => {
       });
     });
 
+    it('it should return a timeout error', async () => {
+      const timeToResolve = 20;
+
+      const longerPromise = () =>
+        new Promise(resolve => setTimeout(resolve, timeToResolve));
+
+      const queryWrapperResult = await queryPromiseWrapper(
+        longerPromise,
+        undefined,
+        { timeout: timeToResolve / 2 }
+      );
+
+      expect(logger.sentry).toBeCalledWith(
+        'Error on queryPromiseWrapper',
+        'Request timeout'
+      );
+
+      expect(captureExceptionSpy).toBeCalledWith('Error');
+
+      expect(queryWrapperResult).toStrictEqual({
+        error: {
+          status: 408,
+          data: 'Request timeout',
+        },
+      });
+    });
+
     it('it should return a strutured custom error object given a failed promise and status error', async () => {
       const anyPromise = () => Promise.reject('Error');
 


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds a default timeout of 2minutes for all promises wrapped with queryWrapper, it also adds an option to customize the amount of time

<!-- Include a summary of the changes. -->

Completes CS-3386
Completes CS-3384

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

In order to show the behavior I decrease the timeout to 10ms and displayed the error in the alert: 

![Simulator Screen Recording - iPhone 12 - 2022-03-28 at 18 04 21](https://user-images.githubusercontent.com/20520102/160487269-a9eb4e9a-65cc-4498-851e-a132b19efbfa.gif)