### PR TITLE
[CS-3336] Update networksection ui, move mainnet into testnet

### DIFF
--- a/src/components/settings-menu/NetworkSection.tsx
+++ b/src/components/settings-menu/NetworkSection.tsx
@@ -17,20 +17,20 @@ import {
 } from '@cardstack/components';
 
 const networks = values(networkInfo);
+const defaultNetwork = INITIAL_STATE.network;
 
 const NetworkSection = () => {
   const { network, showTestnets } = useAccountSettings();
   const [selectedNetwork, setSelectedNetwork] = useState(network);
   const dispatch = useDispatch();
   const networkSelected = useMemo(() => networkInfo[network], [network]);
-  const defaultNetwork = INITIAL_STATE.network;
 
   // transform data for sectionList
   const sectionListItems = useMemo(() => {
     const filteredNetworks = networks.filter(item =>
       showTestnets ? true : !item.isTestnet
     );
-    // merge networks by layer and then sort by title
+    // merge networks by layer and then sort by layer title
     const sectionLists = filteredNetworks
       .reduce((result: RadioItemProps[], curr, currentIndex) => {
         result[curr.layer] =
@@ -58,7 +58,7 @@ const NetworkSection = () => {
       );
 
     return sectionLists;
-  }, [defaultNetwork, selectedNetwork, showTestnets]);
+  }, [selectedNetwork, showTestnets]);
 
   useEffect(() => {
     if (networkSelected.isTestnet !== showTestnets) {

--- a/src/components/settings-menu/NetworkSection/NetworkSection.tsx
+++ b/src/components/settings-menu/NetworkSection/NetworkSection.tsx
@@ -5,26 +5,30 @@ import { Button, Checkbox, Container, RadioList } from '@cardstack/components';
 
 const NetworkSection = () => {
   const {
-    isSameNetwork,
-    showTestnets,
+    isSelectedCurrentNetwork,
+    isShowAllNetworks,
     sectionListItems,
     onNetworkChange,
     updateNetwork,
-    onShowTestsPress,
+    onToggleShowAllNetworks,
   } = useNetworkSection();
 
   return (
     <Container backgroundColor="white" paddingVertical={4} width="100%">
       <Container flexDirection="row" justifyContent="flex-end" padding={5}>
         <Checkbox
-          isSelected={showTestnets}
+          isSelected={isShowAllNetworks}
           label={strings.showAllNetworks}
-          onPress={onShowTestsPress}
+          onPress={onToggleShowAllNetworks}
         />
       </Container>
       <RadioList items={sectionListItems} onChange={onNetworkChange} />
       <Container marginTop={5} paddingHorizontal={5}>
-        <Button disabled={isSameNetwork} onPress={updateNetwork} width="100%">
+        <Button
+          disabled={isSelectedCurrentNetwork}
+          onPress={updateNetwork}
+          width="100%"
+        >
           {strings.update}
         </Button>
       </Container>

--- a/src/components/settings-menu/NetworkSection/NetworkSection.tsx
+++ b/src/components/settings-menu/NetworkSection/NetworkSection.tsx
@@ -5,11 +5,11 @@ import { Button, Checkbox, Container, RadioList } from '@cardstack/components';
 
 const NetworkSection = () => {
   const {
-    isSelectedCurrentNetwork,
+    isCurrentNetworkSelected,
     isShowAllNetworks,
     sectionListItems,
     onNetworkChange,
-    updateNetwork,
+    onUpdateNetwork,
     onToggleShowAllNetworks,
   } = useNetworkSection();
 
@@ -25,8 +25,8 @@ const NetworkSection = () => {
       <RadioList items={sectionListItems} onChange={onNetworkChange} />
       <Container marginTop={5} paddingHorizontal={5}>
         <Button
-          disabled={isSelectedCurrentNetwork}
-          onPress={updateNetwork}
+          disabled={isCurrentNetworkSelected}
+          onPress={onUpdateNetwork}
           width="100%"
         >
           {strings.update}

--- a/src/components/settings-menu/NetworkSection/NetworkSection.tsx
+++ b/src/components/settings-menu/NetworkSection/NetworkSection.tsx
@@ -1,0 +1,35 @@
+import React, { memo } from 'react';
+import { strings } from './strings';
+import { useNetworkSection } from './useNetworkSection';
+import { Button, Checkbox, Container, RadioList } from '@cardstack/components';
+
+const NetworkSection = () => {
+  const {
+    isSameNetwork,
+    showTestnets,
+    sectionListItems,
+    onNetworkChange,
+    updateNetwork,
+    onShowTestsPress,
+  } = useNetworkSection();
+
+  return (
+    <Container backgroundColor="white" paddingVertical={4} width="100%">
+      <Container flexDirection="row" justifyContent="flex-end" padding={5}>
+        <Checkbox
+          isSelected={showTestnets}
+          label={strings.showAllNetworks}
+          onPress={onShowTestsPress}
+        />
+      </Container>
+      <RadioList items={sectionListItems} onChange={onNetworkChange} />
+      <Container marginTop={5} paddingHorizontal={5}>
+        <Button disabled={isSameNetwork} onPress={updateNetwork} width="100%">
+          {strings.update}
+        </Button>
+      </Container>
+    </Container>
+  );
+};
+
+export default memo(NetworkSection);

--- a/src/components/settings-menu/NetworkSection/strings.ts
+++ b/src/components/settings-menu/NetworkSection/strings.ts
@@ -1,0 +1,4 @@
+export const strings = {
+  update: 'Update',
+  showAllNetworks: 'Show all networks',
+};

--- a/src/components/settings-menu/NetworkSection/useNetworkSection.ts
+++ b/src/components/settings-menu/NetworkSection/useNetworkSection.ts
@@ -13,13 +13,17 @@ export const useNetworkSection = () => {
   const { network } = useAccountSettings();
   const dispatch = useDispatch();
   const [selectedNetwork, setSelectedNetwork] = useState(network);
-  const [isShowAllNetworks, setShowAllNetworks] = useState<boolean>(false);
-  const selectedNetworkInfo = useMemo(() => networkInfo[network], [network]);
+  const selectedNetworkInfo = useMemo(() => networkInfo[selectedNetwork], [
+    selectedNetwork,
+  ]);
+  const [isShowAllNetworks, setShowAllNetworks] = useState<boolean>(
+    selectedNetworkInfo.hidden
+  );
 
   // transform data for sectionList
   const sectionListItems = useMemo(() => {
-    const filteredNetworks = networks.filter(item =>
-      isShowAllNetworks ? true : !item.hidden
+    const filteredNetworks = networks.filter(
+      item => isShowAllNetworks || !item.hidden
     );
     // merge networks by layer and then sort by layer title
     const sectionLists = filteredNetworks
@@ -52,17 +56,8 @@ export const useNetworkSection = () => {
   }, [selectedNetwork, isShowAllNetworks]);
 
   useEffect(() => {
-    if (selectedNetworkInfo.hidden !== isShowAllNetworks) {
-      setShowAllNetworks(selectedNetworkInfo.hidden);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setShowAllNetworks(selectedNetworkInfo.hidden);
   }, [selectedNetworkInfo.hidden]);
-
-  useEffect(() => {
-    if (network) {
-      setSelectedNetwork(network);
-    }
-  }, [network, setSelectedNetwork]);
 
   const onNetworkChange = useCallback(
     async selected => {

--- a/src/components/settings-menu/NetworkSection/useNetworkSection.ts
+++ b/src/components/settings-menu/NetworkSection/useNetworkSection.ts
@@ -73,7 +73,7 @@ export const useNetworkSection = () => {
     [setSelectedNetwork]
   );
 
-  const updateNetwork = useCallback(() => {
+  const onUpdateNetwork = useCallback(() => {
     dispatch(settingsUpdateNetwork(selectedNetwork));
   }, [dispatch, selectedNetwork]);
 
@@ -82,17 +82,17 @@ export const useNetworkSection = () => {
     []
   );
 
-  const isSelectedCurrentNetwork = useMemo(() => selectedNetwork === network, [
+  const isCurrentNetworkSelected = useMemo(() => selectedNetwork === network, [
     network,
     selectedNetwork,
   ]);
 
   return {
-    isSelectedCurrentNetwork,
+    isCurrentNetworkSelected,
     isShowAllNetworks,
     sectionListItems,
     onNetworkChange,
-    updateNetwork,
+    onUpdateNetwork,
     onToggleShowAllNetworks,
   };
 };

--- a/src/components/settings-menu/NetworkSection/useNetworkSection.ts
+++ b/src/components/settings-menu/NetworkSection/useNetworkSection.ts
@@ -1,25 +1,19 @@
 import { toLower, values } from 'lodash';
-import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import networkInfo from '../../helpers/networkInfo';
-import { useAccountSettings } from '../../hooks';
+import networkInfo from '../../../helpers/networkInfo';
+import { useAccountSettings } from '../../../hooks';
 import {
   INITIAL_STATE,
   settingsUpdateNetwork,
   toggleShowTestnets,
-} from '../../redux/settings';
-import {
-  Button,
-  Checkbox,
-  Container,
-  RadioItemProps,
-  RadioList,
-} from '@cardstack/components';
+} from '../../../redux/settings';
+import { RadioItemProps } from '@cardstack/components';
 
 const networks = values(networkInfo);
 const defaultNetwork = INITIAL_STATE.network;
 
-const NetworkSection = () => {
+export const useNetworkSection = () => {
   const { network, showTestnets } = useAccountSettings();
   const [selectedNetwork, setSelectedNetwork] = useState(network);
   const dispatch = useDispatch();
@@ -90,27 +84,17 @@ const NetworkSection = () => {
     dispatch,
   ]);
 
-  return (
-    <Container backgroundColor="white" paddingVertical={4} width="100%">
-      <Container flexDirection="row" justifyContent="flex-end" padding={5}>
-        <Checkbox
-          isSelected={showTestnets}
-          label="Show all networks"
-          onPress={onShowTestsPress}
-        />
-      </Container>
-      <RadioList items={sectionListItems} onChange={onNetworkChange} />
-      <Container marginTop={5} paddingHorizontal={5}>
-        <Button
-          disabled={selectedNetwork === network}
-          onPress={updateNetwork}
-          width="100%"
-        >
-          Update
-        </Button>
-      </Container>
-    </Container>
-  );
-};
+  const isSameNetwork = useMemo(() => selectedNetwork === network, [
+    network,
+    selectedNetwork,
+  ]);
 
-export default memo(NetworkSection);
+  return {
+    isSameNetwork,
+    showTestnets,
+    sectionListItems,
+    onNetworkChange,
+    updateNetwork,
+    onShowTestsPress,
+  };
+};

--- a/src/components/settings-menu/NetworkSection/useNetworkSection.ts
+++ b/src/components/settings-menu/NetworkSection/useNetworkSection.ts
@@ -19,7 +19,7 @@ export const useNetworkSection = () => {
   // transform data for sectionList
   const sectionListItems = useMemo(() => {
     const filteredNetworks = networks.filter(item =>
-      isShowAllNetworks ? true : !item.isTestnet
+      isShowAllNetworks ? true : !item.hidden
     );
     // merge networks by layer and then sort by layer title
     const sectionLists = filteredNetworks
@@ -52,11 +52,11 @@ export const useNetworkSection = () => {
   }, [selectedNetwork, isShowAllNetworks]);
 
   useEffect(() => {
-    if (selectedNetworkInfo.isTestnet !== isShowAllNetworks) {
-      setShowAllNetworks(selectedNetworkInfo.isTestnet);
+    if (selectedNetworkInfo.hidden !== isShowAllNetworks) {
+      setShowAllNetworks(selectedNetworkInfo.hidden);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedNetworkInfo.isTestnet]);
+  }, [selectedNetworkInfo.hidden]);
 
   useEffect(() => {
     if (network) {

--- a/src/components/settings-menu/index.js
+++ b/src/components/settings-menu/index.js
@@ -1,6 +1,6 @@
 export { default as CurrencySection } from './CurrencySection';
 export { default as LanguageSection } from './LanguageSection';
-export { default as NetworkSection } from './NetworkSection';
+export { default as NetworkSection } from './NetworkSection/NetworkSection';
 export { default as NotificationsSection } from './NotificationsSection';
 export { default as WalletConnectSessionsSection } from './WalletConnectSessionsSection';
 export { default as SettingsSection } from './SettingsSection';

--- a/src/components/toasts/NetworkToast.js
+++ b/src/components/toasts/NetworkToast.js
@@ -9,14 +9,14 @@ const NetworkToast = () => {
   const isConnected = useInternetStatus();
   const { network } = useAccountSettings();
   const providerUrl = web3Provider?.connection?.url;
-  const { name, isTestnet } = networkInfo[network];
-  const [visible, setVisible] = useState(isTestnet);
+  const { name } = networkInfo[network];
+  const [visible, setVisible] = useState();
   const [networkName, setNetworkName] = useState(name);
 
   useEffect(() => {
     setVisible(isConnected);
     setNetworkName(networkInfo[network].shortName);
-  }, [name, network, providerUrl, isConnected, isTestnet, networkName]);
+  }, [name, network, providerUrl, isConnected, networkName]);
 
   const { colors } = useTheme();
 

--- a/src/helpers/networkInfo.ts
+++ b/src/helpers/networkInfo.ts
@@ -29,7 +29,7 @@ export const networkInfo = {
     shortName: 'Mainnet',
     layer: 1,
     value: networkTypes.mainnet,
-    isTestnet: false,
+    isTestnet: true,
   },
   [`${networkTypes.kovan}`]: {
     disabled: false,

--- a/src/helpers/networkInfo.ts
+++ b/src/helpers/networkInfo.ts
@@ -9,7 +9,7 @@ export const networkInfo = {
     shortName: 'Gnosis',
     layer: 2,
     value: networkTypes.xdai,
-    isTestnet: false,
+    hidden: false,
   },
   [networkTypes.sokol]: {
     disabled: false,
@@ -19,7 +19,7 @@ export const networkInfo = {
     shortName: 'Sokol',
     layer: 2,
     value: networkTypes.sokol,
-    isTestnet: true,
+    hidden: true,
   },
   [`${networkTypes.mainnet}`]: {
     disabled: false,
@@ -29,7 +29,7 @@ export const networkInfo = {
     shortName: 'Mainnet',
     layer: 1,
     value: networkTypes.mainnet,
-    isTestnet: true,
+    hidden: true,
   },
   [`${networkTypes.kovan}`]: {
     disabled: false,
@@ -39,7 +39,7 @@ export const networkInfo = {
     shortName: 'Kovan',
     layer: 1,
     value: networkTypes.kovan,
-    isTestnet: true,
+    hidden: true,
   },
 };
 

--- a/src/hooks/useAccountSettings.js
+++ b/src/hooks/useAccountSettings.js
@@ -23,22 +23,13 @@ export default function useAccountSettings() {
   const { language } = useSelector(createLanguageSelector);
   const dispatch = useDispatch();
   const settingsData = useSelector(
-    ({
-      settings: {
-        accountAddress,
-        chainId,
-        nativeCurrency,
-        network,
-        showTestnets,
-      },
-    }) => ({
+    ({ settings: { accountAddress, chainId, nativeCurrency, network } }) => ({
       accountAddress,
       chainId,
       language,
       nativeCurrency,
       nativeCurrencySymbol: currencies[nativeCurrency].symbol,
       network,
-      showTestnets,
     })
   );
 

--- a/src/redux/settings.js
+++ b/src/redux/settings.js
@@ -36,7 +36,6 @@ const SETTINGS_UPDATE_LANGUAGE_SUCCESS =
   'settings/SETTINGS_UPDATE_LANGUAGE_SUCCESS';
 const SETTINGS_UPDATE_NETWORK_SUCCESS =
   'settings/SETTINGS_UPDATE_NETWORK_SUCCESS';
-const SETTINGS_UPDATE_SHOW_TESTNETS = 'settings/SETTINGS_UPDATE_SHOW_TESTNETS';
 
 // -- Actions --------------------------------------------------------------- //
 export const settingsLoadState = () => async (dispatch, getState) => {
@@ -128,15 +127,6 @@ export const settingsChangeNativeCurrency = nativeCurrency => async dispatch => 
   }
 };
 
-export const toggleShowTestnets = () => (dispatch, getState) => {
-  const { showTestnets } = getState().settings;
-
-  dispatch({
-    payload: !showTestnets,
-    type: SETTINGS_UPDATE_SHOW_TESTNETS,
-  });
-};
-
 // -- Reducer --------------------------------------------------------------- //
 export const INITIAL_STATE = {
   accountAddress: '',
@@ -144,7 +134,6 @@ export const INITIAL_STATE = {
   language: 'en',
   nativeCurrency: 'USD',
   network: networkTypes.xdai,
-  showTestnets: false,
 };
 
 export default (state = INITIAL_STATE, action) => {
@@ -169,11 +158,6 @@ export default (state = INITIAL_STATE, action) => {
       return {
         ...state,
         language: action.payload,
-      };
-    case SETTINGS_UPDATE_SHOW_TESTNETS:
-      return {
-        ...state,
-        showTestnets: action.payload,
       };
     default:
       return state;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "isolatedModules": false,
     "module": "es2020",
     "jsx": "react-native",
-    "lib": ["es6"],
+    "lib": ["es6", "es2019"],
     "moduleResolution": "node",
     "noEmit": true,
     "strict": true,


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

- Updated "Show testnets" to "Show all networks" and removed Advanced Users
- Moved Ethereum Mainnet to testnet so can be controlled by toggle (`isTestnet` is being used by NetworkToast only and it does not show up in new Navigations, so used `isTestnet` existing flag for toggling, let me know if better thought)

<!-- Include a summary of the changes. -->

- [x] Completes #CS-3336

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Mar-29-2022 21-21-18](https://user-images.githubusercontent.com/16714648/160620778-a2b27304-b4fe-48fc-989f-e29c80b8c8a4.gif)

