### PR TITLE
[FIX] Workaround bug for exception in SDK function handleSignificantDecimals.

### DIFF
--- a/cardstack/src/services/gnosis-service.ts
+++ b/cardstack/src/services/gnosis-service.ts
@@ -269,8 +269,10 @@ export const addNativePriceToToken = async (
 
   const isAmountDust = nativeBalance < 0.01;
 
-  //decimal places formatting for residual crypto values
-  const bufferValue = isAmountDust ? 0 : undefined;
+  // Cecimal places formatting for residual crypto values.
+  // Using "2" is a workaround to a exception happening in
+  // handleSignificantDecimals function in SDK.
+  const bufferValue = isAmountDust ? 2 : undefined;
 
   const amount = isAmountDust ? 0 : nativeBalance;
 

--- a/cardstack/src/services/gnosis-service.ts
+++ b/cardstack/src/services/gnosis-service.ts
@@ -269,7 +269,7 @@ export const addNativePriceToToken = async (
 
   const isAmountDust = nativeBalance < 0.01;
 
-  // Cecimal places formatting for residual crypto values.
+  // Decimal places formatting for residual crypto values.
   // Using "2" is a workaround to a exception happening in
   // handleSignificantDecimals function in SDK.
   const bufferValue = isAmountDust ? 2 : undefined;


### PR DESCRIPTION
### Description

`handleSignificantDecimals` function in SDK excepts with error for parameters `value = 0, decimals = any, buffer = 0`, because it tries to slice an empty value, which return undefined, then undefined is feed into `search` regex causing it to return -1 and then causing an exception in `new BigNumber5`.

A proper fix requires handleSignificantDecimals to handle 0 values and additionally it could be refactored, with the aid of unit tests, to be stripped into smaller more maintainable functions. 

