### PR TITLE
[CS-3489]: Add register gas estimated from sdk 

### DIFF
--- a/cardstack/src/components/ChoosePrepaidCard/Header.tsx
+++ b/cardstack/src/components/ChoosePrepaidCard/Header.tsx
@@ -38,11 +38,16 @@ export const Header = memo(
         {payCostDesc || strings.payAmountDesc}
       </Text>
       <Container width="100%" alignItems="center">
-        <Touchable onPress={onPressEditAmount}>
-          <Text weight="bold" size="body">
-            {nativeBalanceDisplay}
-          </Text>
-        </Touchable>
+        {
+          //Temp condition to hide amount until adapation
+          !payCostDesc && (
+            <Touchable onPress={onPressEditAmount}>
+              <Text weight="bold" size="body">
+                {nativeBalanceDisplay}
+              </Text>
+            </Touchable>
+          )
+        }
         {onPressEditAmount ? (
           <Touchable
             position="absolute"

--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -16,6 +16,7 @@ export const strings = {
     },
     loading: 'Registering Account',
     payCostDescription: 'To pay transaction cost',
+    gasLoading: 'Getting estimated gas fee',
   },
   claim: {
     button: 'Claim',

--- a/cardstack/src/services/exchange-rate-service.ts
+++ b/cardstack/src/services/exchange-rate-service.ts
@@ -46,6 +46,13 @@ export const getCurrencyConversionsRates = async () => {
   return cachedCurrencyConversionRates;
 };
 
+const getLayerTwoOracleInstance = async () => {
+  const web3 = await Web3Instance.get();
+  const layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+
+  return layerTwoOracle;
+};
+
 // Token price to native currency
 export const getNativeBalanceFromOracle = async (props: {
   symbol?: string;
@@ -60,8 +67,7 @@ export const getNativeBalanceFromOracle = async (props: {
     return 0;
   }
 
-  const web3 = await Web3Instance.get();
-  const layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+  const layerTwoOracle = await getLayerTwoOracleInstance();
 
   const usdBalance = await layerTwoOracle.getUSDPrice(symbol, balance);
 
@@ -77,9 +83,17 @@ export const getNativeBalanceFromOracle = async (props: {
 };
 
 export const getUsdConverter = async (symbol: string) => {
-  const web3 = await Web3Instance.get();
-  const layerTwoOracle = await getSDK('LayerTwoOracle', web3);
+  const layerTwoOracle = await getLayerTwoOracleInstance();
+
   const converter = await layerTwoOracle.getUSDConverter(symbol);
 
   return converter;
+};
+
+export const convertTokenToSpend = async (token: string, amount: string) => {
+  const layerTwoOracle = await getLayerTwoOracleInstance();
+
+  const result = await layerTwoOracle.convertToSpend(token, amount);
+
+  return result;
 };

--- a/cardstack/src/services/rewards-center/rewards-center-api.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-api.ts
@@ -1,6 +1,7 @@
 import { CacheTags, safesApi } from '../safes-api';
 import { queryPromiseWrapper } from '../utils';
 import {
+  RegisterGasEstimateQueryParams,
   RewardsClaimMutationParams,
   RewardsRegisterMutationParams,
   RewardsRegisterMutationResult,
@@ -13,6 +14,7 @@ import {
   claimRewards,
   fetchRewardPoolTokenBalances,
   fetchRewardsSafe,
+  getRegisterGasEstimate,
   registerToRewardProgram,
 } from './rewards-center-service';
 
@@ -45,6 +47,20 @@ const rewardsApi = safesApi.injectEndpoints({
         });
       },
       providesTags: [CacheTags.REWARDS_POOL],
+    }),
+    getRegisterRewardeeGasEstimate: builder.query<
+      number,
+      RegisterGasEstimateQueryParams
+    >({
+      async queryFn(params) {
+        return queryPromiseWrapper<number, RegisterGasEstimateQueryParams>(
+          getRegisterGasEstimate,
+          params,
+          {
+            errorLogMessage: 'Error fetching rewardee register gas estimate',
+          }
+        );
+      },
     }),
     registerToRewardProgram: builder.mutation<
       RewardsRegisterMutationResult,
@@ -84,4 +100,5 @@ export const {
   useGetRewardPoolTokenBalancesQuery,
   useRegisterToRewardProgramMutation,
   useClaimRewardsMutation,
+  useLazyGetRegisterRewardeeGasEstimateQuery,
 } = rewardsApi;

--- a/cardstack/src/services/rewards-center/rewards-center-api.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-api.ts
@@ -58,6 +58,7 @@ const rewardsApi = safesApi.injectEndpoints({
           params,
           {
             errorLogMessage: 'Error fetching rewardee register gas estimate',
+            timeout: 60000, // 1 min
           }
         );
       },

--- a/cardstack/src/services/rewards-center/rewards-center-types.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-types.ts
@@ -46,3 +46,8 @@ export interface RewardsClaimMutationParams
   safeAddress: string;
   tokenAddress: string;
 }
+
+export interface RegisterGasEstimateQueryParams {
+  prepaidCardAddress: string;
+  rewardProgramId: string;
+}


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds the gas estimation for registering, some workarounds were done, since the design expected the gas before the prepaidcard selection, which currently is not possible given that the sdk needs the card address, so we hide the amount on chooseCard and there's a loading now in between the screens to fetch the gas estimate, if there's an error we continue anyway and use the default value to display, if there's a gas estimation we show it. Also wrapped some instances in their own functions to shrink a little.


### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Simulator Screen Recording - iPhone 12 - 2022-03-29 at 19 00 29](https://user-images.githubusercontent.com/20520102/160714438-dc12c053-a8ef-49f5-bf93-83cb96d4a47d.gif)



