### PR TITLE
[CS-3495]: Get and display est gas fee for claiming rewards

### DIFF
--- a/cardstack/src/components/Button/Button.tsx
+++ b/cardstack/src/components/Button/Button.tsx
@@ -103,11 +103,13 @@ export const Button = ({
     <AnimatedButton
       {...variantMergedStyles}
       {...props}
-      disabled={disabled || disablePress}
+      disabled={disabled || disablePress || loading}
       onPress={onPress}
     >
       {loading ? (
-        <ActivityIndicator testID="button-loading" />
+        <Container>
+          <ActivityIndicator testID="button-loading" />
+        </Container>
       ) : (
         <Container
           flexDirection={iconPosition === 'left' ? 'row' : 'row-reverse'}

--- a/cardstack/src/components/TransactionConfirmationSheet/displays/components/sections/RewardsNetAmountSection.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/displays/components/sections/RewardsNetAmountSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { strings } from '../../../strings';
 import { SectionHeaderText } from '../SectionHeaderText';
 import { Container, Text } from '@cardstack/components';
@@ -14,7 +14,10 @@ export const RewardsNetAmountSection = ({
   estGasFee,
   token,
 }: RewardsNetAmountSectionProps) => {
-  const estimateNetClaim = Number(balance?.amount) - Number(estGasFee);
+  const estimateNetClaim = useMemo(
+    () => (Number(balance?.amount) - Number(estGasFee)).toFixed(2),
+    [balance, estGasFee]
+  );
 
   return (
     <Container>

--- a/cardstack/src/components/TransactionConfirmationSheet/displays/components/sections/RewardsNetAmountSection.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/displays/components/sections/RewardsNetAmountSection.tsx
@@ -14,7 +14,7 @@ export const RewardsNetAmountSection = ({
   estGasFee,
   token,
 }: RewardsNetAmountSectionProps) => {
-  const estimateNetClaim = Number(balance?.amount) - (estGasFee || 0);
+  const estimateNetClaim = Number(balance?.amount) - Number(estGasFee);
 
   return (
     <Container>

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
@@ -21,6 +21,7 @@ const RewardsCenterScreen = () => {
     claimHistorySectionData,
     tokensBalanceData,
     isLoading,
+    isLoadingClaimGas,
   } = useRewardsCenterScreen();
 
   const mainPoolRowProps = useMemo(
@@ -59,6 +60,7 @@ const RewardsCenterScreen = () => {
                 claimList={hasRewardsAvailable ? [mainPoolRowProps] : undefined}
                 historyList={claimHistorySectionData}
                 balanceList={tokensBalanceData}
+                isLoadingClaimGas={isLoadingClaimGas}
               />
             )}
           </Container>

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -15,6 +15,7 @@ interface ClaimContentProps {
   claimList?: Array<RewardRowProps>;
   balanceList?: RewardsBalanceListProps;
   historyList?: RewardsHistoryListProps;
+  isLoadingClaimGas?: boolean;
 }
 
 enum Tabs {
@@ -31,6 +32,7 @@ export const ClaimContent = ({
   claimList,
   balanceList,
   historyList,
+  isLoadingClaimGas,
 }: ClaimContentProps) => {
   const { TabHeader, currentTab } = useTabHeader({ tabs });
 
@@ -43,9 +45,10 @@ export const ClaimContent = ({
           subText={item.subText}
           paddingBottom={index + 1 < claimList.length ? 5 : 0}
           onClaimPress={item.onClaimPress}
+          isLoading={isLoadingClaimGas}
         />
       )),
-    [claimList]
+    [claimList, isLoadingClaimGas]
   );
 
   const title = useMemo(

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
@@ -15,6 +15,7 @@ export interface RewardRowProps extends Omit<TouchableProps, 'children'> {
   subText?: string;
   claimed?: boolean;
   onClaimPress?: () => void;
+  isLoading?: boolean;
 }
 
 export const RewardRow = ({
@@ -24,6 +25,7 @@ export const RewardRow = ({
   claimed = false,
   onClaimPress,
   onPress,
+  isLoading = false,
   ...props
 }: RewardRowProps) => (
   <CardPressable
@@ -63,6 +65,7 @@ export const RewardRow = ({
             height={30}
             width="100%"
             onPress={onClaimPress}
+            loading={isLoading}
           >
             {strings.claim.button}
           </Button>

--- a/cardstack/src/services/rewards-center/rewards-center-types.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-types.ts
@@ -42,12 +42,23 @@ export interface RewardsRegisterMutationResult {
 }
 
 export interface RewardsClaimMutationParams
-  extends RewardsPoolSignedBaseParams {
+  extends RewardsPoolSignedBaseParams,
+    ValidProofsParams {
   safeAddress: string;
-  tokenAddress: string;
 }
 
 export interface RegisterGasEstimateQueryParams {
   prepaidCardAddress: string;
   rewardProgramId: string;
 }
+
+export interface ValidProofsParams {
+  accountAddress: string;
+  tokenAddress: string;
+  rewardProgramId: string;
+}
+
+export type RewardsClaimGasEstimateParams = Omit<
+  RewardsClaimMutationParams,
+  keyof SignedProviderParams
+>;

--- a/cardstack/src/types/transaction-confirmation-types.ts
+++ b/cardstack/src/types/transaction-confirmation-types.ts
@@ -62,7 +62,7 @@ export interface RewardsRegisterData {
 }
 
 export interface RewardsClaimData extends TokenType {
-  estGasFee: number;
+  estGasFee: string;
   type: TransactionConfirmationType.REWARDS_CLAIM;
 }
 


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR gets and displays the estimate gas fee on claiming rewards.
- Adds loading prop to claim button and fixes uncentered loading
- Caches validProofs to make the claim request quicker and cleans after claim
- Updates ClaimTxConfirmationDisplay to show formatted estimatedValue

PS: For this case we are not using the query from RTK to fetch the gas estimate, given the difficulty to store the parameters based on the each token,I'll be refactoring this piece anyways in order to improve readability given useRewards hook is huge.

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->


https://user-images.githubusercontent.com/20520102/160880407-6b179741-9448-4454-a238-bd7ce9c7a8c3.mp4


