### PR TITLE
[CS-3520] Adds gas fee InfoBanner to ClaimContent.

### DIFF
--- a/cardstack/src/components/InfoBanner/InfoBanner.tsx
+++ b/cardstack/src/components/InfoBanner/InfoBanner.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 
-import { Container, Text, Icon, IconName } from '@cardstack/components';
+import {
+  Container,
+  ContainerProps,
+  Text,
+  Icon,
+  IconName,
+} from '@cardstack/components';
 import { ColorTypes } from '@cardstack/theme';
 
-interface Props {
+interface Props extends ContainerProps {
   title: string;
-  message?: string;
+  message: string | React.ReactElement;
   iconName?: IconName;
   iconColor?: ColorTypes;
 }
@@ -15,19 +21,21 @@ export const InfoBanner = ({
   message,
   iconName = 'info',
   iconColor = 'appleBlue',
+  ...rest
 }: Props) => (
-  <Container
-    width="100%"
-    padding={5}
-    backgroundColor="grayCardBackground"
-    borderRadius={10}
-  >
-    <Container flexDirection="row" paddingBottom={3}>
-      <Icon name={iconName} color={iconColor} iconSize="medium" />
-      <Text weight="bold" size="body" paddingLeft={2}>
-        {title}
-      </Text>
+  <Container width="100%" {...rest}>
+    <Container
+      padding={5}
+      backgroundColor="grayCardBackground"
+      borderRadius={10}
+    >
+      <Container flexDirection="row" paddingBottom={3}>
+        <Icon name={iconName} color={iconColor} iconSize="medium" />
+        <Text weight="bold" size="body" paddingLeft={2}>
+          {title}
+        </Text>
+      </Container>
+      <Text size="xs">{message}</Text>
     </Container>
-    <Text size="xs">{message}</Text>
   </Container>
 );

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -14,7 +14,6 @@ import {
   Container,
   useTabHeader,
   InfoBanner,
-  Text,
 } from '@cardstack/components';
 
 interface ClaimContentProps {

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -9,7 +9,13 @@ import {
   RewardsHistoryList,
   RewardsHistoryListProps,
 } from '.';
-import { ScrollView, Container, useTabHeader } from '@cardstack/components';
+import {
+  ScrollView,
+  Container,
+  useTabHeader,
+  InfoBanner,
+  Text,
+} from '@cardstack/components';
 
 interface ClaimContentProps {
   claimList?: Array<RewardRowProps>;
@@ -61,6 +67,19 @@ export const ClaimContent = ({
     <ScrollView>
       <Container padding={5}>
         <RewardsTitle title={title} width="100%" paddingBottom={5} />
+        <InfoBanner
+          paddingBottom={5}
+          title={strings.register.gasInfoBanner.title}
+          message={
+            <Text size="xs">
+              {strings.register.gasInfoBanner.message.part1}
+              <Text size="xs" weight="bold">
+                {strings.register.gasInfoBanner.message.part2}
+              </Text>
+              {strings.register.gasInfoBanner.message.part3}
+            </Text>
+          }
+        />
         {renderClaimList()}
       </Container>
       <TabHeader />

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -72,11 +72,11 @@ export const ClaimContent = ({
           title={strings.register.gasInfoBanner.title}
           message={
             <Text size="xs">
-              {strings.register.gasInfoBanner.message.part1}
+              {strings.register.gasInfoBanner.message.intro}
               <Text size="xs" weight="bold">
-                {strings.register.gasInfoBanner.message.part2}
+                {strings.register.gasInfoBanner.message.gasEstimative}
               </Text>
-              {strings.register.gasInfoBanner.message.part3}
+              {strings.register.gasInfoBanner.message.finalNote}
             </Text>
           }
         />

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -70,15 +70,7 @@ export const ClaimContent = ({
         <InfoBanner
           paddingBottom={5}
           title={strings.register.gasInfoBanner.title}
-          message={
-            <Text size="xs">
-              {strings.register.gasInfoBanner.message.intro}
-              <Text size="xs" weight="bold">
-                {strings.register.gasInfoBanner.message.gasEstimative}
-              </Text>
-              {strings.register.gasInfoBanner.message.finalNote}
-            </Text>
-          }
+          message={strings.register.gasInfoBanner.message}
         />
         {renderClaimList()}
       </Container>

--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -17,6 +17,15 @@ export const strings = {
     loading: 'Registering Account',
     payCostDescription: 'To pay transaction cost',
     gasLoading: 'Getting estimated gas fee',
+    gasInfoBanner: {
+      title: 'Claiming Gas Fee',
+      message: {
+        part1:
+          'Claiming is an on chain transaction which required a small blockchain gas fee: ',
+        part2: '~0.25 CARD.CPXD. ',
+        part3: 'This is paid from your claimable reward.',
+      },
+    },
   },
   claim: {
     button: 'Claim',

--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -19,12 +19,8 @@ export const strings = {
     gasLoading: 'Getting estimated gas fee',
     gasInfoBanner: {
       title: 'Claiming Gas Fee',
-      message: {
-        intro:
-          'Claiming is an on chain transaction which requires a small blockchain gas fee: ',
-        gasEstimative: '~0.25 CARD.CPXD. ',
-        finalNote: 'This is paid from your claimable reward.',
-      },
+      message:
+        'Claiming is an on chain transaction which requires a small blockchain gas fee. This is paid from your claimable reward.',
     },
   },
   claim: {

--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -20,10 +20,10 @@ export const strings = {
     gasInfoBanner: {
       title: 'Claiming Gas Fee',
       message: {
-        part1:
-          'Claiming is an on chain transaction which required a small blockchain gas fee: ',
-        part2: '~0.25 CARD.CPXD. ',
-        part3: 'This is paid from your claimable reward.',
+        intro:
+          'Claiming is an on chain transaction which requires a small blockchain gas fee: ',
+        gasEstimative: '~0.25 CARD.CPXD. ',
+        finalNote: 'This is paid from your claimable reward.',
       },
     },
   },


### PR DESCRIPTION
### Description

PR adds Claim Fee Notice to Rewards screen. 

The message in the banner is part in bold, so I updated InfoBanner to allow custom Text components to be added and had the message split into 3 parts to handle the bold part. Please let me know if there's a more elegant way of handling this scenario.

- [x] Completes #(CS-3520)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/161088958-7e517ac3-e89b-4c00-8cde-243fa3b4233e.jpg">
