### PR TITLE
[CS-3481] Fix for request payment crash on nav redesign

### DIFF
--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -117,12 +117,13 @@ const StackNavigator = () => {
 
   return (
     <Stack.Navigator
-      // On Android we're having issues with navigation trying to focus
-      // unmounted inputs ocurring in crashes.
+      // On Android theres an issue with navigation trying to focus
+      // unmounted inputs ocurring in crashes, disabling keyboard handling avoids it:
+      // ref: https://github.com/react-navigation/react-navigation/issues/10080
       keyboardHandlingEnabled={Device.isIOS}
       headerMode="none"
       mode="modal"
-      // On Android, gestureEnabled defaults to false, but we want it.
+      // On Android gestureEnabled defaults to false, but we want it.
       screenOptions={{ gestureEnabled: true }}
       initialRouteName={initialRoute}
     >

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -117,8 +117,12 @@ const StackNavigator = () => {
 
   return (
     <Stack.Navigator
+      // On Android we're having issues with navigation trying to focus
+      // unmounted inputs ocurring in crashes.
+      keyboardHandlingEnabled={Device.isIOS}
       headerMode="none"
       mode="modal"
+      // On Android, gestureEnabled defaults to false, but we want it.
       screenOptions={{ gestureEnabled: true }}
       initialRouteName={initialRoute}
     >


### PR DESCRIPTION
### Description

This PR disables navigation keyboard handling on Android since it introduces bugs with navigation trying to focus on unmounted inputs.

This was something present in the old navigation that didn't get through the new tab bar implementation.

Because we're disabling nav's auto dismiss of the keyboard, all screens that have inputs need to add the `dismissAndroidKeyboardOnClose` to its `Stack.Screen` listener prop.

- [x] Completes #(CS-3481)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

https://user-images.githubusercontent.com/129619/161268510-037301d0-5b9d-411e-8b08-343303bc786c.mp4


