### PR TITLE
[CS-3534]: Scaffolds  rewards withdraw flow and enables it 

### DIFF
--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -25,6 +25,8 @@ export const MainRoutes = {
   REWARDS_CENTER_SCREEN: 'RewardsCenterScreen',
   REWARDS_REGISTER_SHEET: 'RewardsRegisterSheet',
   REWARDS_CLAIM_SHEET: 'RewardsClaimSheet',
+  REWARD_WITHDRAW_TO: 'RewardWithdrawToScreen',
+  REWARD_WITHDRAW_CONFIRMATION: 'RewardWithdrawConfirmationScreen',
   TRANSACTION_CONFIRMATION_SHEET: 'TransactionConfirmationScreen',
   BACKUP_SHEET: 'BackupSheet',
 } as const;

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -49,6 +49,10 @@ import SendSheetEOA from '@rainbow-me/screens/SendSheetEOA';
 import { Device } from '@cardstack/utils';
 import SettingsModal from '@rainbow-me/screens/SettingsModal';
 import BackupSheet from '@rainbow-me/screens/BackupSheet';
+import {
+  RewardWithdrawConfirmationScreen,
+  RewardWithdrawToScreen,
+} from '@cardstack/screens/RewardsCenterScreen/flows';
 
 export interface ScreenNavigation {
   component: React.ComponentType<any>;
@@ -189,6 +193,14 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
   REWARDS_CLAIM_SHEET: {
     component: RewardsClaimSheet,
     options: expandedPreset as StackNavigationOptions,
+  },
+  REWARD_WITHDRAW_TO: {
+    component: RewardWithdrawToScreen,
+    options: horizontalInterpolator,
+  },
+  REWARD_WITHDRAW_CONFIRMATION: {
+    component: RewardWithdrawConfirmationScreen,
+    options: horizontalInterpolator,
   },
   TRANSACTION_CONFIRMATION_SHEET: {
     component: TransactionConfirmationSheet,

--- a/cardstack/src/screens/Dev/DesignSystemScreen.tsx
+++ b/cardstack/src/screens/Dev/DesignSystemScreen.tsx
@@ -1,0 +1,46 @@
+import React, { memo, useCallback } from 'react';
+import { SectionList } from 'react-native';
+import {
+  Button,
+  CenteredContainer,
+  Container,
+  Text,
+} from '@cardstack/components';
+import { buttonVariants } from '@cardstack/theme';
+
+// Not worrying about perfomance and typing as this is a developer feature
+const DesignSystemScreen = () => {
+  const sections = [
+    {
+      title: 'Buttons',
+      data: Object.keys(buttonVariants),
+    },
+  ];
+
+  const renderItem = useCallback(({ item, section: { title } }) => {
+    switch (title) {
+      case 'Buttons':
+        return (
+          <CenteredContainer padding={2} backgroundColor="overlayGray">
+            <Button variant={item}>{item}</Button>
+          </CenteredContainer>
+        );
+    }
+  }, []);
+
+  return (
+    <SectionList
+      renderItem={renderItem as any}
+      sections={sections}
+      renderSectionHeader={item => (
+        <Container padding={4} backgroundColor="black">
+          <Text color="white" fontSize={20}>
+            {item.section.title}
+          </Text>
+        </Container>
+      )}
+    />
+  );
+};
+
+export default memo(DesignSystemScreen);

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
@@ -16,6 +16,7 @@ export interface RewardRowProps extends Omit<TouchableProps, 'children'> {
   claimed?: boolean;
   onClaimPress?: () => void;
   isLoading?: boolean;
+  isBalance?: boolean;
 }
 
 export const RewardRow = ({
@@ -26,6 +27,7 @@ export const RewardRow = ({
   onClaimPress,
   onPress,
   isLoading = false,
+  isBalance = false,
   ...props
 }: RewardRowProps) => (
   <CardPressable
@@ -57,6 +59,14 @@ export const RewardRow = ({
           </Text>
           {subText && <Text variant="subText">{subText}</Text>}
         </Container>
+        {
+          // Press is disabled bc whole row is clickable
+          isBalance && (
+            <Button variant="tiny" disablePress>
+              {strings.withdraw.button}
+            </Button>
+          )
+        }
       </Container>
       {!!onClaimPress && (
         <Container paddingTop={4}>

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsBalanceList.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsBalanceList.tsx
@@ -4,42 +4,34 @@ import { strings } from '../strings';
 import { RewardRow } from '.';
 import { Container, ListEmptyComponent } from '@cardstack/components';
 import { TokenType } from '@cardstack/types';
-import Routes from '@rainbow-me/navigation/routesNames';
-import { useNavigation } from '@rainbow-me/navigation';
-import { Alert } from '@rainbow-me/components/alerts';
 
-export type TokensWithSafeAddress = Array<TokenType & { safeAddress: string }>;
+import { useNavigation } from '@rainbow-me/navigation';
+import { MainRoutes } from '@cardstack/navigation';
+
+export type TokenWithSafeAddress = TokenType & { safeAddress: string };
 export interface RewardsBalanceListProps {
-  data?: TokensWithSafeAddress;
+  data?: TokenWithSafeAddress[];
 }
-const disableSendFlow = true;
 
 export const RewardsBalanceList = ({ data = [] }: RewardsBalanceListProps) => {
   const { navigate } = useNavigation();
 
   const onPress = useCallback(
-    (token: TokenType, safeAddress) => () => {
-      if (disableSendFlow) {
-        Alert({ title: 'Sending is unavailable at this time.' });
-
-        return;
-      }
-
-      navigate(Routes.EXPANDED_ASSET_SHEET, {
-        asset: token,
-        type: 'token',
-        safeAddress,
+    tokenInfo => () => {
+      navigate(MainRoutes.REWARD_WITHDRAW_TO, {
+        tokenInfo,
       });
     },
     [navigate]
   );
 
   const renderItem = useCallback(
-    ({ item: { safeAddress, ...token } }) => (
+    ({ item }) => (
       <RewardRow
-        primaryText={token.balance.display}
-        coinSymbol={token.token.symbol}
-        onPress={onPress(token, safeAddress)}
+        isBalance
+        primaryText={item.balance.display}
+        coinSymbol={item.token.symbol}
+        onPress={onPress(item)}
       />
     ),
     [onPress]

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawConfimation/RewardWithdrawConfimationScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawConfimation/RewardWithdrawConfimationScreen.tsx
@@ -1,0 +1,40 @@
+import React, { memo } from 'react';
+import { strings } from './strings';
+import { useRewardWithdrawConfimationScreen } from './useRewardWithdrawConfimationScreen';
+import {
+  Button,
+  Container,
+  NavigationStackHeader,
+  Text,
+} from '@cardstack/components';
+
+const RewardWithdrawConfirmationScreen = () => {
+  const {
+    params: { tokenInfo, fromRewardSafe, withdrawTo },
+    onCancelPress,
+    onConfirmPress,
+  } = useRewardWithdrawConfimationScreen();
+
+  return (
+    <Container backgroundColor="white" flex={1}>
+      <NavigationStackHeader title={strings.headerTitle} />
+      <Container padding={4}>
+        <Text>
+          {tokenInfo.token.name} {tokenInfo.balance.display}
+        </Text>
+        <Text>FROM: {fromRewardSafe}</Text>
+        <Text>TO: {withdrawTo.address}</Text>
+        <Container flexDirection="row" justifyContent="space-between">
+          <Button onPress={onCancelPress} variant="smallWhite">
+            Cancel
+          </Button>
+          <Button onPress={onConfirmPress} variant="small">
+            Confirm
+          </Button>
+        </Container>
+      </Container>
+    </Container>
+  );
+};
+
+export default memo(RewardWithdrawConfirmationScreen);

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawConfimation/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawConfimation/strings.ts
@@ -1,0 +1,3 @@
+export const strings = {
+  headerTitle: 'Withdraw Rewards',
+};

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawConfimation/useRewardWithdrawConfimationScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawConfimation/useRewardWithdrawConfimationScreen.ts
@@ -1,0 +1,30 @@
+import { useCallback } from 'react';
+import { useNavigation, useRoute } from '@react-navigation/core';
+
+import { RouteType } from '@cardstack/navigation/types';
+
+import { TokenWithSafeAddress } from '@cardstack/screens/RewardsCenterScreen/components';
+
+interface NavParams {
+  tokenInfo: TokenWithSafeAddress;
+  fromRewardSafe: string;
+  withdrawTo: any; // TODO: create right type with avatar customization
+}
+
+export const useRewardWithdrawConfimationScreen = () => {
+  const { params } = useRoute<RouteType<NavParams>>();
+
+  const { goBack } = useNavigation();
+
+  const onCancelPress = useCallback(goBack, []);
+
+  const onConfirmPress = useCallback(() => {
+    //TODO
+  }, []);
+
+  return {
+    params,
+    onCancelPress,
+    onConfirmPress,
+  };
+};

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawConfimation/useRewardWithdrawConfimationScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawConfimation/useRewardWithdrawConfimationScreen.ts
@@ -4,6 +4,7 @@ import { useNavigation, useRoute } from '@react-navigation/core';
 import { RouteType } from '@cardstack/navigation/types';
 
 import { TokenWithSafeAddress } from '@cardstack/screens/RewardsCenterScreen/components';
+import { MainRoutes } from '@cardstack/navigation';
 
 interface NavParams {
   tokenInfo: TokenWithSafeAddress;
@@ -14,9 +15,11 @@ interface NavParams {
 export const useRewardWithdrawConfimationScreen = () => {
   const { params } = useRoute<RouteType<NavParams>>();
 
-  const { goBack } = useNavigation();
+  const { navigate } = useNavigation();
 
-  const onCancelPress = useCallback(goBack, []);
+  const onCancelPress = useCallback(() => {
+    navigate(MainRoutes.REWARDS_CENTER_SCREEN);
+  }, [navigate]);
 
   const onConfirmPress = useCallback(() => {
     //TODO

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawTo/RewardWithdrawToScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawTo/RewardWithdrawToScreen.tsx
@@ -1,0 +1,26 @@
+import React, { memo } from 'react';
+import { strings } from './strings';
+import { useRewardWithdrawToScreen } from './useRewardWithdrawToScreen';
+import {
+  Container,
+  NavigationStackHeader,
+  Text,
+  Touchable,
+} from '@cardstack/components';
+
+const RewardWithdrawToScreen = () => {
+  const { onSafePress, availableSafesToWithdraw } = useRewardWithdrawToScreen();
+
+  return (
+    <Container backgroundColor="white" flex={1}>
+      <NavigationStackHeader title={strings.headerTitle} />
+      {availableSafesToWithdraw.map(safe => (
+        <Touchable padding={2} onPress={onSafePress(safe)}>
+          <Text>{`${safe.type}\n${safe.address} `}</Text>
+        </Touchable>
+      ))}
+    </Container>
+  );
+};
+
+export default memo(RewardWithdrawToScreen);

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawTo/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawTo/strings.ts
@@ -1,0 +1,3 @@
+export const strings = {
+  headerTitle: 'Withdraw to',
+};

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawTo/useRewardWithdrawToScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawTo/useRewardWithdrawToScreen.ts
@@ -1,0 +1,47 @@
+import { useCallback } from 'react';
+import { useNavigation, useRoute } from '@react-navigation/core';
+import { RouteType } from '@cardstack/navigation/types';
+import { useAccountSettings } from '@rainbow-me/hooks';
+
+import { useGetSafesDataQuery } from '@cardstack/services';
+
+import { TokenWithSafeAddress } from '@cardstack/screens/RewardsCenterScreen/components';
+import { MainRoutes } from '@cardstack/navigation';
+
+export const useRewardWithdrawToScreen = () => {
+  const {
+    params: { tokenInfo },
+  } = useRoute<RouteType<{ tokenInfo: TokenWithSafeAddress }>>();
+
+  const { navigate } = useNavigation();
+
+  const { accountAddress, nativeCurrency } = useAccountSettings();
+
+  const { availableSafesToWithdraw } = useGetSafesDataQuery(
+    { address: accountAddress, nativeCurrency },
+    {
+      selectFromResult: ({ data }) => ({
+        availableSafesToWithdraw: [
+          ...data?.merchantSafes,
+          ...data?.depots,
+        ].filter(Boolean),
+      }),
+    }
+  );
+
+  const onSafePress = useCallback(
+    safe => () => {
+      navigate(MainRoutes.REWARD_WITHDRAW_CONFIRMATION, {
+        tokenInfo,
+        fromRewardSafe: tokenInfo.safeAddress,
+        withdrawTo: safe,
+      });
+    },
+    [navigate, tokenInfo]
+  );
+
+  return {
+    onSafePress,
+    availableSafesToWithdraw,
+  };
+};

--- a/cardstack/src/screens/RewardsCenterScreen/flows/index.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/index.ts
@@ -1,0 +1,2 @@
+export { default as RewardWithdrawToScreen } from './RewardWithdraw/RewardWithdrawTo/RewardWithdrawToScreen';
+export { default as RewardWithdrawConfirmationScreen } from './RewardWithdraw/RewardWithdrawConfimation/RewardWithdrawConfimationScreen';

--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -31,4 +31,7 @@ export const strings = {
     title: 'History',
     empty: 'No Reward History',
   },
+  withdraw: {
+    button: 'Withdraw',
+  },
 };

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -3,7 +3,7 @@ import { convertToSpend } from '@cardstack/cardpay-sdk';
 import { useNavigation, StackActions } from '@react-navigation/core';
 import { groupBy } from 'lodash';
 import { strings } from './strings';
-import { TokensWithSafeAddress } from './components';
+import { TokenWithSafeAddress } from './components';
 import {
   RewardsRegisterData,
   RewardsClaimData,
@@ -389,7 +389,7 @@ export const useRewardsCenterScreen = () => {
             safeAddress: safe.address,
           }));
 
-          return [...tokens, ...tokensWithAddress] as TokensWithSafeAddress;
+          return [...tokens, ...tokensWithAddress] as TokenWithSafeAddress[];
         },
         []
       ),

--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -63,6 +63,7 @@ export default function SettingsSection({
   onPressWCSessions,
   onPressShowSecret,
   onPressMyWalletAddress,
+  onPressDS,
 }) {
   const { wallets } = useWallets();
   const { nativeCurrency, network, accountAddress } = useAccountSettings();
@@ -223,6 +224,12 @@ export default function SettingsSection({
             label="Developer Settings"
             onPress={onPressDev}
             testID="developer-section"
+          />
+          <ListFooter height={10} />
+          <ListItem
+            icon={<Icon color="black" name="archive" />}
+            label="Design System"
+            onPress={onPressDS}
           />
         </>
       )}

--- a/src/screens/SettingsModal.js
+++ b/src/screens/SettingsModal.js
@@ -20,6 +20,7 @@ import { useWallets } from '../hooks';
 import { Icon, Text, Touchable } from '@cardstack/components';
 import { NAV_HEADER_HEIGHT } from '@cardstack/components/MainHeader/components/MainHeaderWrapper';
 import { slideLeftToRightPreset } from '@cardstack/navigation';
+import DesignSystemScreen from '@cardstack/screens/Dev/DesignSystemScreen';
 import WalletAddressScreen from '@cardstack/screens/WalletAddressScreen/WalletAddressScreen';
 import { palette } from '@cardstack/theme';
 import { useNavigation } from '@rainbow-me/navigation';
@@ -78,6 +79,11 @@ const SettingsPages = {
     component: IS_DEV ? DeveloperSettings : null,
     key: 'DevSection',
     title: 'Dev',
+  },
+  designSystem: {
+    component: IS_DEV ? DesignSystemScreen : null,
+    key: 'DesignSystem',
+    title: 'Design System',
   },
   language: {
     component: LanguageSection,
@@ -215,6 +221,7 @@ export default function SettingsModal() {
             onCloseModal={goBack}
             onPressBackup={onPressSection(SettingsPages.backup)}
             onPressCurrency={onPressSection(SettingsPages.currency)}
+            onPressDS={onPressSection(SettingsPages.designSystem)}
             onPressDev={onPressSection(SettingsPages.dev)}
             onPressLanguage={onPressSection(SettingsPages.language)}
             onPressMyWalletAddress={onPressSection(


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds the rewards withdraw flow structure to enable UI and logic to be build in parallel, also adds a developer page, called design system where we can see all the button variants. For  the placeholders I didn't extract anything into strings files, cause it's going to be removed, any UI stuff is available to change so didn't worry to much about that. For this new flow I created a new folder structure called flows, inside the rewards center, we may thing about moving the claiming and registering pieces there too eventually.

- Completes CS-3534
- Completes CS-3543
- Completes CS-3544

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->


![Simulator Screen Recording - iPhone 12 - 2022-04-01 at 14 26 36](https://user-images.githubusercontent.com/20520102/161312627-f5b0b813-30e1-4587-95bc-43af221e5601.gif)

Not pretty but it helps 😅 
<img width="250" alt="image" src="https://user-images.githubusercontent.com/20520102/161312912-f02a92a5-0f3b-427a-8f52-d96cc35d9c50.png">

