### PR TITLE
[CS-3332]: Fix android restore PIN and cleanups

### DIFF
--- a/cardstack/src/navigation/presetOptions.ts
+++ b/cardstack/src/navigation/presetOptions.ts
@@ -49,8 +49,16 @@ export const overlayPreset: StackNavigationOptions = {
   cardStyleInterpolator: forFade,
 };
 
+/**
+ * With keyboardHandlingEnabled disabled on Android Nav
+ * we may need to manually dismiss the keyboard, iOS handles automatically
+ * ref: https://github.com/react-navigation/react-navigation/issues/10080
+ *  */
+export const dismissKeyboardOnAndroid = () =>
+  Device.isAndroid && Keyboard.dismiss();
+
 export const dismissAndroidKeyboardOnClose: ScreenNavigation['listeners'] = {
   transitionStart: ({ data: { closing } }) => {
-    closing && Device.isAndroid && Keyboard.dismiss();
+    closing && dismissKeyboardOnAndroid();
   },
 };

--- a/cardstack/src/screens/sheets/ConfirmClaimDestinySheet/ConfirmClaimDestinySheet.tsx
+++ b/cardstack/src/screens/sheets/ConfirmClaimDestinySheet/ConfirmClaimDestinySheet.tsx
@@ -1,5 +1,6 @@
 import { useRoute } from '@react-navigation/core';
-import React, { useMemo } from 'react';
+import React, { memo } from 'react';
+import { strings } from './strings';
 import { Container, Sheet, Text, TextOptionRow } from '@cardstack/components';
 import { RouteType } from '@cardstack/navigation/types';
 
@@ -12,37 +13,33 @@ const ConfirmClaimDestinySheet = () => {
     params: { onClaimAllPress },
   } = useRoute<RouteType<Params>>();
 
-  // Workaround to avoid not dismiss modal
-  return useMemo(
-    () => (
-      <Sheet
-        Header={
-          <Container paddingHorizontal={5} paddingVertical={3}>
-            <Text size="medium">How do you want to claim?</Text>
-          </Container>
-        }
-      >
-        <Container paddingHorizontal={5} paddingVertical={2}>
-          <TextOptionRow
-            description="Claim to your account balance."
-            onPress={onClaimAllPress}
-            title="Claim to Account"
-          />
-          <TextOptionRow
-            description="Refill or top up an existing prepaid card."
-            disabled
-            title="Refill Existing Prepaid Card"
-          />
-          <TextOptionRow
-            description="Create a new prepaid card with the balance to pay others with."
-            disabled
-            title="Create New Prepaid Card"
-          />
+  return (
+    <Sheet
+      Header={
+        <Container paddingHorizontal={5} paddingVertical={3}>
+          <Text size="medium">{strings.header}</Text>
         </Container>
-      </Sheet>
-    ),
-    [onClaimAllPress]
+      }
+    >
+      <Container paddingHorizontal={5} paddingVertical={2}>
+        <TextOptionRow
+          title={strings.claim.title}
+          description={strings.claim.description}
+          onPress={onClaimAllPress}
+        />
+        <TextOptionRow
+          title={strings.refill.title}
+          description={strings.refill.description}
+          disabled
+        />
+        <TextOptionRow
+          title={strings.create.title}
+          description={strings.create.description}
+          disabled
+        />
+      </Container>
+    </Sheet>
   );
 };
 
-export default ConfirmClaimDestinySheet;
+export default memo(ConfirmClaimDestinySheet);

--- a/cardstack/src/screens/sheets/ConfirmClaimDestinySheet/strings.ts
+++ b/cardstack/src/screens/sheets/ConfirmClaimDestinySheet/strings.ts
@@ -1,0 +1,16 @@
+export const strings = {
+  header: 'How do you want to claim?',
+  claim: {
+    title: 'Claim to Account',
+    description: 'Claim to your account balance.',
+  },
+  refill: {
+    title: 'Refill Existing Prepaid Card',
+    description: 'Refill or top up an existing prepaid card.',
+  },
+  create: {
+    title: 'Create New Prepaid Card',
+    description:
+      'Create a new prepaid card with the balance to pay others with.',
+  },
+};

--- a/cardstack/src/screens/sheets/ImportSeed/useImportSeedSheet.tsx
+++ b/cardstack/src/screens/sheets/ImportSeed/useImportSeedSheet.tsx
@@ -36,7 +36,10 @@ import {
 } from '@rainbow-me/utils';
 import logger from 'logger';
 import { Network } from '@rainbow-me/helpers/networkTypes';
-import { useLoadingOverlay } from '@cardstack/navigation';
+import {
+  dismissKeyboardOnAndroid,
+  useLoadingOverlay,
+} from '@cardstack/navigation';
 
 const useImportSeedSheet = () => {
   const { accountAddress } = useAccountSettings();
@@ -97,6 +100,8 @@ const useImportSeedSheet = () => {
       Network.mainnet
     );
 
+    dismissKeyboardOnAndroid();
+
     try {
       setBusy(true);
 
@@ -110,6 +115,7 @@ const useImportSeedSheet = () => {
         (await mainnetProvider.lookupAddress?.(walletResult.address)) || null;
 
       setBusy(false);
+
       showWalletProfileModal(ens);
     } catch (error) {
       logger.log('Error looking up ENS for imported HD type wallet', error);

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -13,8 +13,4 @@ declare module 'react-native-keychain' {
   export function getAllInternetCredentials(): Promise<null | {
     results: rnKeychain.UserCredentials[];
   }>;
-
-  export function getAllInternetCredentialsKeys(): Promise<null | {
-    results: string[];
-  }>;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -123,7 +123,6 @@ class App extends Component {
 
     this.identifyFlow();
     AppState.addEventListener('change', this.handleAppStateChange);
-    this.onTokenRefreshListener = registerTokenRefreshListener();
 
     this.foregroundNotificationListener = messaging().onMessage(
       this.onRemoteNotification
@@ -172,6 +171,7 @@ class App extends Component {
     if (!prevProps.walletReady && this.props.walletReady) {
       // Everything we need to do after the wallet is ready goes here
       Logger.sentry('✅ Wallet ready!');
+      this.onTokenRefreshListener = registerTokenRefreshListener();
       runKeychainIntegrityChecks();
       runWalletBackupStatusChecks();
     }

--- a/src/components/expanded-state/SupportAndFeedsState.tsx
+++ b/src/components/expanded-state/SupportAndFeedsState.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { memo, useCallback } from 'react';
 import { FlatList } from 'react-native';
 import { Container, Sheet, Text } from '@cardstack/components';
 import { supportedCountries } from '@rainbow-me/references/wyre';
@@ -38,43 +38,35 @@ const SupportAndFeedsState = () => {
     []
   );
 
-  // Workaround to avoid not dismiss modal
-  return useMemo(
-    () => (
-      <Sheet isFullScreen scrollEnabled>
-        <Container marginBottom={12} padding={6}>
-          <Text
-            color="black"
-            paddingBottom={12}
-            size="medium"
-            textAlign="center"
-            weight="bold"
-          >
-            {strings.header}
-          </Text>
-          <SectionHeaderText text={strings.activation.title} />
-          <Text>{strings.activation.faceValueList}</Text>
-          <Container paddingVertical={3}>
-            <TextBoldStart
-              info={strings.activation.limits.usa.info}
-              title={strings.activation.limits.usa.title}
-            />
-            <TextBoldStart
-              info={strings.activation.limits.international.info}
-              title={strings.activation.limits.international.title}
-            />
-          </Container>
-          <Text marginBottom={10}>{strings.activation.footerInfo}</Text>
-          <SectionHeaderText text={strings.supportedCountriesTitle} />
-          <FlatList
-            data={countriesKeys}
-            numColumns={2}
-            renderItem={renderItem}
+  return (
+    <Sheet isFullScreen scrollEnabled>
+      <Container marginBottom={12} padding={6}>
+        <Text
+          color="black"
+          paddingBottom={12}
+          size="medium"
+          textAlign="center"
+          weight="bold"
+        >
+          {strings.header}
+        </Text>
+        <SectionHeaderText text={strings.activation.title} />
+        <Text>{strings.activation.faceValueList}</Text>
+        <Container paddingVertical={3}>
+          <TextBoldStart
+            info={strings.activation.limits.usa.info}
+            title={strings.activation.limits.usa.title}
+          />
+          <TextBoldStart
+            info={strings.activation.limits.international.info}
+            title={strings.activation.limits.international.title}
           />
         </Container>
-      </Sheet>
-    ),
-    [renderItem]
+        <Text marginBottom={10}>{strings.activation.footerInfo}</Text>
+        <SectionHeaderText text={strings.supportedCountriesTitle} />
+        <FlatList data={countriesKeys} numColumns={2} renderItem={renderItem} />
+      </Container>
+    </Sheet>
   );
 };
 
@@ -93,4 +85,4 @@ const SectionHeaderText = ({ text }: { text: string }) => (
   </Text>
 );
 
-export default SupportAndFeedsState;
+export default memo(SupportAndFeedsState);

--- a/src/model/backup.ts
+++ b/src/model/backup.ts
@@ -12,6 +12,7 @@ import WalletTypes from '../helpers/walletTypes';
 import {
   allWalletsKey,
   iCloudKey,
+  pinKey,
   privateKeyKey,
   seedPhraseKey,
   selectedWalletKey,
@@ -83,6 +84,11 @@ async function extractSecretsForWallet(wallet: RainbowWallet) {
       item.username.indexOf(`_${privateKeyKey}`) !== -1 &&
       allowedPkeysKeys.indexOf(item.username) === -1
     ) {
+      return;
+    }
+
+    // Ignore pinKey
+    if (item.username === pinKey) {
       return;
     }
 

--- a/src/model/keychain.ts
+++ b/src/model/keychain.ts
@@ -1,6 +1,5 @@
 import { delay } from '@cardstack/cardpay-sdk';
 import { captureException, captureMessage } from '@sentry/react-native';
-import { forEach, isNil } from 'lodash';
 import DeviceInfo from 'react-native-device-info';
 import {
   ACCESS_CONTROL,
@@ -8,7 +7,6 @@ import {
   AUTHENTICATION_TYPE,
   canImplyAuthentication,
   getAllInternetCredentials,
-  getAllInternetCredentialsKeys,
   getInternetCredentials,
   getSupportedBiometryType,
   hasInternetCredentials,
@@ -20,16 +18,6 @@ import {
 } from 'react-native-keychain';
 import { Device } from '@cardstack/utils/device';
 import logger from 'logger';
-
-interface AnonymousKey {
-  length: number;
-  nil: boolean;
-  type: string;
-}
-
-interface AnonymousKeyData {
-  [key: string]: AnonymousKey;
-}
 
 export async function saveString(
   key: string,
@@ -137,32 +125,6 @@ export async function loadAllKeys(): Promise<null | UserCredentials[]> {
     }
   } catch (err) {
     logger.sentry(`Keychain: failed to loadAllKeys error: ${err}`);
-    captureException(err);
-  }
-  return null;
-}
-
-export async function getAllKeysAnonymized(): Promise<null | AnonymousKeyData> {
-  const data: AnonymousKeyData = {};
-  const results = await loadAllKeys();
-  forEach(results, result => {
-    data[result?.username] = {
-      length: result?.password?.length,
-      nil: isNil(result?.password),
-      type: typeof result?.password,
-    };
-  });
-  return data;
-}
-
-export async function loadAllKeysOnly(): Promise<null | string[]> {
-  try {
-    const response = await getAllInternetCredentialsKeys();
-    if (response) {
-      return response.results;
-    }
-  } catch (err) {
-    logger.log(`Keychain: failed to loadAllKeys error: ${err}`);
     captureException(err);
   }
   return null;


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
This PR replaces the Portal loading on restore step with loadingOverlay, this way the PIN screen is shown above the loading, also removes some unused functions and workarounds for the SlackSheet, since we replaced with Sheets already. It prevents the PIN key to be saved on cloud backup, as this might be pretty confusing. The only place now that uses the Portal loading is the backup flow which hopefully we can remove from there too.
Also it moves the tokenRefreshListener of firebase, to be called just when there's a wallet since it needs to authenticate to the hub

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="100" alt="Screenshot" src="URL_GOES_HERE"> -->

The .gif got cut off in the end, but you can see that the PIN screen is opening above the loading
![restore-PIN](https://user-images.githubusercontent.com/20520102/161820728-985d1fef-ee28-4a60-aef2-69f5c511afff.gif)

