### PR TITLE
[CS-2562]: Remove PrepaidCard non/reloadable references

### DIFF
--- a/cardstack/src/components/ChoosePrepaidCard/PrepaidCardItem.tsx
+++ b/cardstack/src/components/ChoosePrepaidCard/PrepaidCardItem.tsx
@@ -34,13 +34,7 @@ const PrepaidCardItem = ({
   spendAmount,
   isLastItem,
 }: PrepaidCardItemProps) => {
-  const {
-    address,
-    spendFaceValue,
-    cardCustomization,
-    reloadable,
-    transferrable,
-  } = item;
+  const { address, spendFaceValue, cardCustomization, transferrable } = item;
 
   const { nativeBalanceDisplay } = convertSpendForBalanceDisplay(
     spendFaceValue.toString(),
@@ -117,7 +111,6 @@ const PrepaidCardItem = ({
               address={address}
               networkName={networkName}
               spendFaceValue={spendFaceValue}
-              reloadable={reloadable}
               nativeCurrency={nativeCurrency}
               currencyConversionRates={currencyConversionRates}
               transferrable={transferrable}

--- a/cardstack/src/components/PrepaidCard/MediumPrepaidCard.tsx
+++ b/cardstack/src/components/PrepaidCard/MediumPrepaidCard.tsx
@@ -30,7 +30,6 @@ const MediumPrepaidCard = ({
   address,
   networkName,
   spendFaceValue,
-  reloadable,
   nativeCurrency,
   currencyConversionRates,
   transferrable,
@@ -59,7 +58,6 @@ const MediumPrepaidCard = ({
       />
       <PrepaidCardInnerBottom
         spendFaceValue={spendFaceValue}
-        reloadable={reloadable}
         nativeCurrency={nativeCurrency}
         currencyConversionRates={currencyConversionRates}
         transferrable={transferrable}

--- a/cardstack/src/components/PrepaidCard/PrepaidCard.story.tsx
+++ b/cardstack/src/components/PrepaidCard/PrepaidCard.story.tsx
@@ -22,7 +22,6 @@ storiesOf('Prepaid Card', module).add('Default', () => {
           },
         ] as any
       }
-      reloadable
       type="prepaid-card"
       networkName="xDai Chain"
       nativeCurrency="USD"

--- a/cardstack/src/components/PrepaidCard/components/PrepaidCardInnerBottom.tsx
+++ b/cardstack/src/components/PrepaidCard/components/PrepaidCardInnerBottom.tsx
@@ -31,7 +31,6 @@ interface VariantType {
 export type PrepaidCardInnerBottomProps = Pick<
   PrepaidCardProps,
   | 'spendFaceValue'
-  | 'reloadable'
   | 'nativeCurrency'
   | 'currencyConversionRates'
   | 'transferrable'
@@ -71,7 +70,6 @@ const styles = StyleSheet.create({
 
 const PrepaidCardInnerBottom = ({
   spendFaceValue,
-  reloadable,
   nativeCurrency,
   currencyConversionRates,
   transferrable,
@@ -124,9 +122,6 @@ const PrepaidCardInnerBottom = ({
         justifyContent="space-between"
       >
         <Container>
-          <Text variant={cardType[variant].textVariant}>
-            {reloadable ? 'RELOADABLE' : 'NON-RELOADABLE'}
-          </Text>
           <Text variant={cardType[variant].textVariant}>
             {transferrable ? 'TRANSFERRABLE' : 'NON-TRANSFERRABLE'}
           </Text>

--- a/cardstack/src/screens/BuyPrepaidCard/BuyPrepaidCard.tsx
+++ b/cardstack/src/screens/BuyPrepaidCard/BuyPrepaidCard.tsx
@@ -138,7 +138,6 @@ const BuyPrepaidCard = () => {
                   currencyConversionRates={currencyConversionRates}
                   address="0xXXXX…XXXX"
                   spendFaceValue={card['face-value'] || 0}
-                  reloadable={card.reloadable}
                   transferrable={card.transferrable}
                   cardCustomization={
                     card.customizationDID

--- a/cardstack/src/types/PrepaidCardType.ts
+++ b/cardstack/src/types/PrepaidCardType.ts
@@ -7,7 +7,7 @@ export interface PrepaidCardType {
   spendFaceValue: number;
   tokens: TokenType[];
   type: string;
-  reloadable: boolean;
+  reloadable?: boolean;
   transferrable: boolean;
   cardCustomization?: PrepaidCardCustomization;
 }


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Removes text and props about reloadability of prepaidCards, I made it optional on  `PrepaidCardType` , bc the sdk still delivers this flag and we might need to use, so I just removed the UI related stuff.

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

<img width="300" alt="image" src="https://user-images.githubusercontent.com/20520102/161980439-60c2b7b4-ca28-4016-9a74-e13a618acdb8.png">
