### PR TITLE
[CS-3549]: Redirect on wc qr code success and handle other cases

### DIFF
--- a/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/__tests__/useScanner.test.tsx
+++ b/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/__tests__/useScanner.test.tsx
@@ -34,6 +34,10 @@ jest.mock(
   })
 );
 
+jest.mock('@rainbow-me/hooks', () => ({
+  useTimeout: () => [jest.fn()],
+}));
+
 const wrapper: React.FC<{ isFocused: boolean }> = ({
   children,
   isFocused = true,

--- a/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/useScanner.ts
+++ b/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/useScanner.ts
@@ -49,10 +49,16 @@ export const useScanner = ({
 
   const walletConnectOnSessionRequestCallback = useCallback(
     (type: WCRedirectTypes) => {
-      if (type === WCRedirectTypes.qrcodeInvalid) {
-        navigate(Routes.WALLET_CONNECT_REDIRECT_SHEET, {
-          type,
-        });
+      switch (type) {
+        case WCRedirectTypes.qrcodeInvalid:
+          navigate(Routes.WALLET_CONNECT_REDIRECT_SHEET, {
+            type,
+          });
+
+          break;
+        case WCRedirectTypes.connect:
+          navigate(Routes.HOME_SCREEN);
+          break;
       }
     },
     [navigate]

--- a/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/useScanner.ts
+++ b/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/useScanner.ts
@@ -1,6 +1,6 @@
 import { isValidMerchantPaymentUrl } from '@cardstack/cardpay-sdk';
 import { useFocusEffect, useNavigation } from '@react-navigation/core';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { Linking } from 'react-native';
 
 import { strings } from './strings';
@@ -13,7 +13,9 @@ import { Alert } from '@rainbow-me/components/alerts';
 import { useBooleanState } from '@cardstack/hooks';
 import { getEthereumAddressFromQRCodeData } from '@rainbow-me/utils/address';
 import haptics from '@rainbow-me/utils/haptics';
+import { useTimeout } from '@rainbow-me/hooks';
 
+const WC_SCAN_TIMEOUT = 2000; // 2s
 export interface useScannerParams {
   customScanAddressHandler?: (address: string) => void;
 }
@@ -23,6 +25,8 @@ export const useScanner = ({
 }: useScannerParams = {}) => {
   const { navigate } = useNavigation();
   const { walletConnectOnSessionRequest } = useWalletConnectConnections();
+  const [startTimeout] = useTimeout();
+  const isWcScanEnabled = useRef(true);
 
   const [
     isScanningEnabled,
@@ -60,8 +64,15 @@ export const useScanner = ({
           navigate(Routes.HOME_SCREEN);
           break;
       }
+
+      // WC QrCode becames invalid once its used,
+      // so this waits a bit b4 enabling the scan again
+      startTimeout(() => {
+        isWcScanEnabled.current = true;
+      }, WC_SCAN_TIMEOUT);
     },
-    [navigate]
+
+    [navigate, startTimeout]
   );
 
   const handleScanWalletConnect = useCallback(
@@ -104,7 +115,7 @@ export const useScanner = ({
 
   const onScan = useCallback(
     async ({ data }) => {
-      if (!data || !isScanningEnabled) return null;
+      if (!data || !isScanningEnabled || !isWcScanEnabled.current) return null;
 
       try {
         disableScanning();
@@ -119,6 +130,8 @@ export const useScanner = ({
         }
 
         if (deeplink.startsWith('wc:')) {
+          isWcScanEnabled.current = false;
+
           return handleScanWalletConnect(data);
         }
 

--- a/cardstack/src/transaction-confirmation-strategies/pay-merchant-strategy.ts
+++ b/cardstack/src/transaction-confirmation-strategies/pay-merchant-strategy.ts
@@ -28,6 +28,7 @@ export class PayMerchantStrategy extends BaseStrategyWithActionDispatcherData {
 
     return {
       amount: this.actionDispatcherData.spendAmount,
+      spendAmount: this.actionDispatcherData.spendAmount,
       merchantSafe,
       infoDID: safeData.infoDID,
       prepaidCard: this.verifyingContract,

--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -31,7 +31,7 @@ import logger from 'logger';
 
 // -- Constants --------------------------------------- //
 
-const WC_REQUEST_TIMEOUT = 30000;
+const WC_REQUEST_TIMEOUT = 4000; // 4 seconds
 
 const WALLETCONNECT_ADD_REQUEST = 'walletconnect/WALLETCONNECT_ADD_REQUEST';
 const WALLETCONNECT_REMOVE_REQUEST =


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
This PR redirects to homeScreen on wallet connect connect success, but for other cases as reject, we were having the same issue of infinite loading, so I added a flag to decide if we read or not, and also a timeout to delay the scan a bit when one code has been scanned already, also it decreases the invalid code timeout, as 30 seconds was too much time and wc response is usually really fast.
A bit unrelated but I added the missing spendAmount field to pay merchant decode data in a attempt to fix the issue we saw this morning.

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->
![scan-wc-code](https://user-images.githubusercontent.com/20520102/162047508-bcc74207-090b-4461-b27a-1ac6c8011e33.gif)


