### PR TITLE
[CS-3554] Improved Safe Area View top padding handling.

### DIFF
--- a/cardstack/src/components/MainHeader/components/MainHeaderWrapper.tsx
+++ b/cardstack/src/components/MainHeader/components/MainHeaderWrapper.tsx
@@ -1,6 +1,4 @@
-import React, { memo, useMemo } from 'react';
-import { StatusBar } from 'react-native';
-import { useSafeArea } from 'react-native-safe-area-context';
+import React, { memo } from 'react';
 import { Container, SafeAreaView, ContainerProps } from '@cardstack/components';
 
 export const NAV_HEADER_HEIGHT = 54;
@@ -9,31 +7,23 @@ const MainHeaderWrapper: React.FC<ContainerProps> = ({
   children,
   backgroundColor = 'backgroundBlue',
   ...props
-}) => {
-  const insets = useSafeArea();
-
-  const safeAreaStyle = useMemo(
-    () => ({
-      // Android uses StatusBar.currentHeight and iOS insets.top
-      paddingTop: StatusBar.currentHeight || insets.top,
-    }),
-    [insets]
-  );
-
-  return (
-    <SafeAreaView backgroundColor={backgroundColor} style={safeAreaStyle}>
-      <Container
-        flexDirection="row"
-        justifyContent="space-between"
-        alignItems="center"
-        height={NAV_HEADER_HEIGHT}
-        paddingHorizontal={5}
-        {...props}
-      >
-        {children}
-      </Container>
-    </SafeAreaView>
-  );
-};
+}) => (
+  <SafeAreaView
+    paddingBottom={0}
+    backgroundColor={backgroundColor}
+    edges={['top']}
+  >
+    <Container
+      flexDirection="row"
+      justifyContent="space-between"
+      alignItems="center"
+      height={NAV_HEADER_HEIGHT}
+      paddingHorizontal={5}
+      {...props}
+    >
+      {children}
+    </Container>
+  </SafeAreaView>
+);
 
 export default memo(MainHeaderWrapper);

--- a/cardstack/src/components/MainHeader/components/MainHeaderWrapper.tsx
+++ b/cardstack/src/components/MainHeader/components/MainHeaderWrapper.tsx
@@ -1,5 +1,6 @@
-import React, { memo } from 'react';
-
+import React, { memo, useMemo } from 'react';
+import { StatusBar } from 'react-native';
+import { useSafeArea } from 'react-native-safe-area-context';
 import { Container, SafeAreaView, ContainerProps } from '@cardstack/components';
 
 export const NAV_HEADER_HEIGHT = 54;
@@ -8,19 +9,31 @@ const MainHeaderWrapper: React.FC<ContainerProps> = ({
   children,
   backgroundColor = 'backgroundBlue',
   ...props
-}) => (
-  <SafeAreaView backgroundColor={backgroundColor}>
-    <Container
-      flexDirection="row"
-      justifyContent="space-between"
-      alignItems="center"
-      height={NAV_HEADER_HEIGHT}
-      paddingHorizontal={5}
-      {...props}
-    >
-      {children}
-    </Container>
-  </SafeAreaView>
-);
+}) => {
+  const insets = useSafeArea();
+
+  const containerStyle = useMemo(
+    () => ({
+      // Android uses StatusBar.currentHeight and iOS insets.top
+      paddingTop: StatusBar.currentHeight || insets.top,
+    }),
+    [insets]
+  );
+
+  return (
+    <SafeAreaView backgroundColor={backgroundColor} style={containerStyle}>
+      <Container
+        flexDirection="row"
+        justifyContent="space-between"
+        alignItems="center"
+        height={NAV_HEADER_HEIGHT}
+        paddingHorizontal={5}
+        {...props}
+      >
+        {children}
+      </Container>
+    </SafeAreaView>
+  );
+};
 
 export default memo(MainHeaderWrapper);

--- a/cardstack/src/components/MainHeader/components/MainHeaderWrapper.tsx
+++ b/cardstack/src/components/MainHeader/components/MainHeaderWrapper.tsx
@@ -12,7 +12,7 @@ const MainHeaderWrapper: React.FC<ContainerProps> = ({
 }) => {
   const insets = useSafeArea();
 
-  const containerStyle = useMemo(
+  const safeAreaStyle = useMemo(
     () => ({
       // Android uses StatusBar.currentHeight and iOS insets.top
       paddingTop: StatusBar.currentHeight || insets.top,
@@ -21,7 +21,7 @@ const MainHeaderWrapper: React.FC<ContainerProps> = ({
   );
 
   return (
-    <SafeAreaView backgroundColor={backgroundColor} style={containerStyle}>
+    <SafeAreaView backgroundColor={backgroundColor} style={safeAreaStyle}>
       <Container
         flexDirection="row"
         justifyContent="space-between"

--- a/cardstack/src/components/SafeAreaView/SafeAreaView.tsx
+++ b/cardstack/src/components/SafeAreaView/SafeAreaView.tsx
@@ -12,11 +12,8 @@ import {
   BackgroundColorProps,
 } from '@shopify/restyle';
 import { ReactNode } from 'react';
-import {
-  SafeAreaView as ReactNativeSafeAreaView,
-  StatusBar,
-  ViewProps,
-} from 'react-native';
+import { SafeAreaView as RNSafeAreaContextView } from 'react-native-safe-area-context';
+import { StatusBar, ViewProps } from 'react-native';
 
 import { Theme } from '../../theme';
 
@@ -38,7 +35,7 @@ export const SafeAreaView = createRestyleComponent<SafeAreaViewProps, Theme>(
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   [layout, spacing, position, border, backgroundColor],
-  ReactNativeSafeAreaView
+  RNSafeAreaContextView
 );
 
 SafeAreaView.defaultProps = {

--- a/cardstack/src/components/SafeAreaView/SafeAreaView.tsx
+++ b/cardstack/src/components/SafeAreaView/SafeAreaView.tsx
@@ -12,8 +12,11 @@ import {
   BackgroundColorProps,
 } from '@shopify/restyle';
 import { ReactNode } from 'react';
-import { SafeAreaView as RNSafeAreaContextView } from 'react-native-safe-area-context';
-import { StatusBar, ViewProps } from 'react-native';
+import {
+  SafeAreaView as RNSafeAreaContextView,
+  SafeAreaViewProps,
+} from 'react-native-safe-area-context';
+import { ViewProps } from 'react-native';
 
 import { Theme } from '../../theme';
 
@@ -22,22 +25,22 @@ type RestyleProps = ViewProps &
   SpacingProps<Theme> &
   PositionProps<Theme> &
   BackgroundColorProps<Theme> &
-  BorderProps<Theme>;
+  BorderProps<Theme> &
+  SafeAreaViewProps;
 
-export interface SafeAreaViewProps extends RestyleProps {
+export interface RNSafeAreaContextViewProps extends RestyleProps {
   children: ReactNode;
 }
 
 /**
  * This is our primitive SafeAreaView component with restyle props applied
  */
-export const SafeAreaView = createRestyleComponent<SafeAreaViewProps, Theme>(
+export const SafeAreaView = createRestyleComponent<
+  RNSafeAreaContextViewProps,
+  Theme
+>(
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   [layout, spacing, position, border, backgroundColor],
   RNSafeAreaContextView
 );
-
-SafeAreaView.defaultProps = {
-  style: { paddingTop: StatusBar.currentHeight },
-};

--- a/cardstack/src/components/Sheet/Sheet.tsx
+++ b/cardstack/src/components/Sheet/Sheet.tsx
@@ -1,5 +1,5 @@
 import React, { memo, ReactNode, useCallback, useMemo, useRef } from 'react';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { KeyboardAvoidingView, StatusBar, StyleSheet } from 'react-native';
 import { ScrollView } from '../ScrollView';
@@ -54,7 +54,7 @@ const Sheet = ({
   Header,
   Footer,
 }: SheetProps) => {
-  const insets = useSafeArea();
+  const insets = useSafeAreaInsets();
   const { goBack, setOptions } = useNavigation();
 
   const containerStyle = useMemo(

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -163,7 +163,7 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
   ...LoadingOverlayComponent,
   SETTINGS_MODAL: {
     component: SettingsModal,
-    options: slideLeftToRightPreset,
+    options: { ...slideLeftToRightPreset, gestureEnabled: false },
   },
   TRANSFER_CARD: {
     component: TransferCardScreen,

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -122,8 +122,9 @@ const StackNavigator = () => {
       // ref: https://github.com/react-navigation/react-navigation/issues/10080
       keyboardHandlingEnabled={Device.isIOS}
       headerMode="none"
+      // default mode 'card' cause flickers on Android when poping up a modal.
       mode="modal"
-      // On Android gestureEnabled defaults to false, but we want it.
+      // gestureEnabled defaults to false on Android
       screenOptions={{ gestureEnabled: true }}
       initialRouteName={initialRoute}
     >

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -122,9 +122,8 @@ const StackNavigator = () => {
       // ref: https://github.com/react-navigation/react-navigation/issues/10080
       keyboardHandlingEnabled={Device.isIOS}
       headerMode="none"
-      // default mode 'card' cause flickers on Android when poping up a modal.
       mode="modal"
-      // gestureEnabled defaults to false on Android
+      // On Android gestureEnabled defaults to false, but we want it.
       screenOptions={{ gestureEnabled: true }}
       initialRouteName={initialRoute}
     >

--- a/cardstack/src/test-utils/jest-setup.js
+++ b/cardstack/src/test-utils/jest-setup.js
@@ -4,9 +4,11 @@ import React from 'react';
 import { View as RNView } from 'react-native';
 import '@testing-library/jest-native/extend-expect';
 import 'react-native-gesture-handler/jestSetup';
+import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock';
 import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
 
 // GLOBAL LIBS MOCKS
+jest.mock('react-native-safe-area-context', () => mockSafeAreaContext);
 
 jest.mock('redux-persist', () => {
   const real = jest.requireActual('redux-persist');

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -377,8 +377,12 @@ PODS:
     - React
   - react-native-restart (0.0.20):
     - React-Core
-  - react-native-safe-area-context (0.5.0):
+  - react-native-safe-area-context (4.2.4):
+    - RCT-Folly
+    - RCTRequired
+    - RCTTypeSafety
     - React
+    - ReactCommon/turbomodule/core
   - react-native-splash-screen (3.2.0):
     - React
   - react-native-text-input-mask (2.0.0):
@@ -963,7 +967,7 @@ SPEC CHECKSUMS:
   react-native-netinfo: 5a001e406317eaaf1e4846906650e107dadcaa72
   react-native-randombytes: 3638d24759d67c68f6ccba60c52a7a8a8faa6a23
   react-native-restart: a01029aadfe8e71f9e8205fdb17da2f0a4472d50
-  react-native-safe-area-context: 13004a45f3021328fdd9ee1f987c3131fb65928d
+  react-native-safe-area-context: f98b0b16d1546d208fc293b4661e3f81a895afd9
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
   react-native-text-input-mask: 07227297075f9653315f43b0424d596423a01736
   react-native-udp: f0fbf5386c45af5523dc143a86afe2cbf29f764e

--- a/ios/TransactionListLoadingViewCell.xib
+++ b/ios/TransactionListLoadingViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreaInsetss="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>

--- a/ios/TransactionListRequestViewCell.xib
+++ b/ios/TransactionListRequestViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreaInsetss="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>

--- a/ios/TransactionListViewCell.xib
+++ b/ios/TransactionListViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreaInsetss="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "react-native-reanimated": "2.2.1",
     "react-native-redash": "16.2.2",
     "react-native-restart": "^0.0.20",
-    "react-native-safe-area-context": "^0.5.0",
+    "react-native-safe-area-context": "^4.2.4",
     "react-native-safe-area-view": "mikedemarais/react-native-safe-area-view",
     "react-native-screens": "2.9.0",
     "react-native-slack-bottom-sheet": "osdnk/react-native-slack-bottom-sheet#hack",

--- a/src/components/asset-list/EmptyAssetList.js
+++ b/src/components/asset-list/EmptyAssetList.js
@@ -1,6 +1,6 @@
 import { times } from 'lodash';
 import React, { useMemo } from 'react';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import styled from 'styled-components';
 import AddFundsInterstitial from '../AddFundsInterstitial';
 import { FabWrapperBottomPosition } from '../fab';
@@ -21,7 +21,7 @@ const EmptyAssetList = ({
   title,
   ...props
 }) => {
-  const { bottom: bottomInset } = useSafeArea();
+  const { bottom: bottomInset } = useSafeAreaInsets();
 
   const interstitialOffset = useMemo(() => {
     let offset = bottomInset + FabWrapperBottomPosition;

--- a/src/components/layout/KeyboardFixedOpenLayout.js
+++ b/src/components/layout/KeyboardFixedOpenLayout.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { KeyboardAvoidingView } from 'react-native';
 import { Transition, Transitioning } from 'react-native-reanimated';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import styled from 'styled-components';
 import { useDimensions, useKeyboardHeight } from '../../hooks';
 import Centered from './Centered';
@@ -29,7 +29,7 @@ export default function KeyboardFixedOpenLayout({
   additionalPadding = 0,
   ...props
 }) {
-  const insets = useSafeArea();
+  const insets = useSafeAreaInsets();
   const { height: screenHeight } = useDimensions();
   const keyboardHeight = useKeyboardHeight();
   const ref = useRef();

--- a/src/components/layout/Page.js
+++ b/src/components/layout/Page.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import styled from 'styled-components';
 import { useTheme } from '../../context/ThemeContext';
 import { position } from '@rainbow-me/styles';
@@ -12,7 +12,7 @@ const PageElement = styled.View`
 `;
 
 const Page = ({ color, showBottomInset, showTopInset, ...props }, ref) => {
-  const insets = useSafeArea();
+  const insets = useSafeAreaInsets();
   const { colors } = useTheme();
   return (
     <PageElement

--- a/src/components/send/SendContactList.js
+++ b/src/components/send/SendContactList.js
@@ -2,7 +2,7 @@ import { toLower } from 'lodash';
 import React, { useCallback, useMemo, useRef } from 'react';
 import DeviceInfo from 'react-native-device-info';
 import { FlatList } from 'react-native-gesture-handler';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import styled from 'styled-components';
 import { FlyInAnimation } from '../animations';
 import { SwipeableContactRow } from '../contacts';
@@ -47,7 +47,7 @@ export default function SendContactList({
   removeContact,
 }) {
   const { navigate } = useNavigation();
-  const insets = useSafeArea();
+  const insets = useSafeAreaInsets();
   const keyboardHeight = useKeyboardHeight();
 
   const contactRefs = useRef({});

--- a/src/components/sheet/Sheet.js
+++ b/src/components/sheet/Sheet.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../context/ThemeContext';
 import { useDimensions } from '../../hooks';
 import { useNavigation } from '../../navigation/Navigation';
@@ -13,7 +13,7 @@ import { borders } from '@rainbow-me/styles';
 const Sheet = ({ borderRadius, children, hideHandle }) => {
   const { width } = useDimensions();
   const { goBack } = useNavigation();
-  const insets = useSafeArea();
+  const insets = useSafeAreaInsets();
   const { colors } = useTheme();
 
   return (

--- a/src/components/sheet/SlackSheet.js
+++ b/src/components/sheet/SlackSheet.js
@@ -8,7 +8,7 @@ import {
   TouchableWithoutFeedback,
 } from 'react-native';
 import Animated from 'react-native-reanimated';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import styled from 'styled-components';
 import { useReanimatedValue } from '../list/MarqueeList';
 import SheetHandleFixedToTop, {
@@ -73,7 +73,7 @@ export default function SlackSheet({
   const yPosition = useReanimatedValue(0);
   const { height: deviceHeight } = useDimensions();
   const { goBack } = useNavigation();
-  const insets = useSafeArea();
+  const insets = useSafeAreaInsets();
   const bottomInset = useMemo(
     () => (insets.bottom || scrollEnabled ? 42 : 30),
     [insets.bottom, scrollEnabled]

--- a/src/components/walletconnect-list/WalletConnectList.js
+++ b/src/components/walletconnect-list/WalletConnectList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FlatList } from 'react-native';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { FlexItem } from '../layout';
 import WalletConnectListItem, {
   WalletConnectListItemHeight,
@@ -17,7 +17,7 @@ const keyExtractor = item => item.dappUrl;
 const renderItem = ({ item }) => <WalletConnectListItem {...item} />;
 
 export default function WalletConnectList({ items = [], onLayout, ...props }) {
-  const insets = useSafeArea();
+  const insets = useSafeAreaInsets();
   const maxListItemsForDeviceSize = insets.bottom ? 4 : 3;
 
   return (

--- a/src/screens/ModalScreen.js
+++ b/src/screens/ModalScreen.js
@@ -1,6 +1,6 @@
 import { useRoute } from '@react-navigation/native';
 import React, { createElement } from 'react';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import styled from 'styled-components';
 import TouchableBackdrop from '../components/TouchableBackdrop';
 import {
@@ -28,7 +28,7 @@ const Container = styled(Centered).attrs({ direction: 'column' })`
 `;
 
 export default function ModalScreen(props) {
-  const insets = useSafeArea();
+  const insets = useSafeAreaInsets();
   const { goBack } = useNavigation();
   const { params } = useRoute();
 

--- a/src/screens/SavingsSheet.js
+++ b/src/screens/SavingsSheet.js
@@ -3,7 +3,7 @@ import { useRoute } from '@react-navigation/native';
 import React, { Fragment, useCallback, useMemo } from 'react';
 import { Alert, StatusBar } from 'react-native';
 import { getSoftMenuBarHeight } from 'react-native-extra-dimensions-android';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import styled from 'styled-components';
 import Divider from '../components/Divider';
 import { SavingsCoinRow } from '../components/coin-row';
@@ -47,7 +47,7 @@ const SavingsSheet = () => {
   const { height: deviceHeight } = useDimensions();
   const { navigate } = useNavigation();
   const { params } = useRoute();
-  const insets = useSafeArea();
+  const insets = useSafeAreaInsets();
   const { isReadOnlyWallet } = useWallets();
   const { nativeCurrency, nativeCurrencySymbol } = useAccountSettings();
   const cTokenBalance = params['cTokenBalance'];

--- a/src/screens/SettingsModal.js
+++ b/src/screens/SettingsModal.js
@@ -2,7 +2,7 @@ import { useRoute } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import React, { useCallback, useEffect } from 'react';
 import { Animated, InteractionManager, View } from 'react-native';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   CurrencySection,
   LanguageSection,
@@ -195,7 +195,7 @@ export default function SettingsModal() {
     }
   }, [getRealRoute, navigate, params]);
 
-  const insets = useSafeArea();
+  const insets = useSafeAreaInsets();
 
   return (
     <Stack.Navigator

--- a/yarn.lock
+++ b/yarn.lock
@@ -17816,10 +17816,10 @@ react-native-restart@^0.0.20:
   resolved "https://registry.yarnpkg.com/react-native-restart/-/react-native-restart-0.0.20.tgz#6ed0244eb1e9a8d81cf7cadfb1f90dd4bb0754ec"
   integrity sha512-lpWqKvfKaCfolosRHHH9+hDdjqMntEedRiLdVqmwNJejjfA4gUH+VEn0uhSaVueBgQJl5525X6B/0bSP55g+iQ==
 
-react-native-safe-area-context@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.5.0.tgz#2185519ad6296dd7bd4ecc79864c02ca3a7f40b5"
-  integrity sha512-ukg9gO9jCdQIkYYwQf0/mp+67XiFSJH7BOxthoBbJq0x3f61Q/6U6E2v5MkcHO0vJg1Ul4/Pq77V+nR5eY/9fA==
+react-native-safe-area-context@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.2.4.tgz#4df42819759c4d3c74252c8678c2772cfa2271a6"
+  integrity sha512-OOX+W2G4YYufvryonn6Kw6YnyT8ZThkxPHZBD04NLHaZmicUaaDVII/PZ3M5fD1o5N62+T+8K4bCS5Un2ggvkA==
 
 react-native-safe-area-view@mikedemarais/react-native-safe-area-view:
   version "0.11.0"


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

PR improves Safe Area View padding Top handling by using component and hook from safe-area-context lib. React-Native's one seems to not update values correctly.

Also, we need to use the top's navigator `mode="modal"`, so on Android, the navigator knows it needs to keep the instance of the underlying screen alive, with card mode the background "flashes".

--

Updates:

- Upgraded react-native-safe-area-view package to the latest. Now it works as we would expect, defining safe areas even for bottom handlers and proper sizes for the status bar. But that means we either use SafeAreaView or set insets, if both are set we see the inset doubled. The new version also works properly on Android, so there is no need to grab the `StatusBar.currentHeight` anymore.
- Refactored all uses of hook `useSafeArea` to `useSafeAreaInsets`. Works the same, just a better naming.

- [x] Completes #(CS-3554)

### Checklist

- [x] All UI changes have been tested on a small device
- [x] Tested on Android, iPhone SE, and iPhone MAX, iOS 12 up to 15.

### Screenshots

https://user-images.githubusercontent.com/129619/162227851-9ee53e9c-64c0-4fff-80aa-05a6a053fcac.MP4

https://user-images.githubusercontent.com/129619/162273560-86337dd7-bf46-4665-b99f-ad1a9e6538db.mov


