### PR TITLE
[CS-3623] Seed Phrase backup decryption

### DIFF
--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -383,7 +383,7 @@ const loadPrivateKey = async (): Promise<
               userPIN,
               privateKey
             );
-            logger.sentry('Got decruypted key succesfully');
+            logger.sentry('Got decrypted key successfully');
             return decryptedPrivateKey;
           }
         } catch (e) {


### PR DESCRIPTION
### Description

We identified some problems returning a valid seed phrase when a backup to Google Cloud of the wallet was made in:
- A: a Touch/Face ID enabled device, errors when trying to recover in a PIN-based device.
- B: the reverse.

So this workaround first checks if the seed phrase is indeed encrypted before trying to unpack it, or just returns it.

There are some side effects, such as not asking for PINs in PIN-based devices because the BKP doesn't need one, and asking for PIN on Touch/Face ID enabled devices since it's needed to decrypt.

A better approach will be to create a PIN regardless, encrypt it regardless, and use Touch/Face ID only to unlock the PIN.

## Update

Included also the same workaround for `loadPrivateKey` function.

-[x] Completes #(CS-3623)