### PR TITLE
[CS-3620]: Fix crash on importing old nav

### DIFF
--- a/src/navigation/SwipeNavigator.js
+++ b/src/navigation/SwipeNavigator.js
@@ -7,15 +7,12 @@ import ProfileScreen from '../screens/ProfileScreen';
 import WalletScreen from '../screens/WalletScreen';
 import { deviceUtils } from '../utils';
 import Navigation from './Navigation';
-import ScrollPagerWrapper, { scrollPosition } from './ScrollPagerWrapper';
 import Routes from './routesNames';
 import { QRScannerScreen } from '@cardstack/screens';
 
 const Swipe = createMaterialTopTabNavigator();
 
 const renderTabBar = () => null;
-
-const renderPager = props => <ScrollPagerWrapper {...props} />;
 
 export function SwipeNavigator() {
   const { isCoinListEdited } = useCoinListEdited();
@@ -29,8 +26,6 @@ export function SwipeNavigator() {
       <Swipe.Navigator
         initialLayout={deviceUtils.dimensions}
         initialRouteName={Routes.WALLET_SCREEN}
-        pager={renderPager}
-        position={scrollPosition}
         swipeEnabled={!isCoinListEdited}
         tabBar={renderTabBar}
       >


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

`ScrollPagerWrapper` was throwing a ID error when it's replaced after importing the wallet,  but it seems we don't even need to use it anymore, my guess is that this implementation was to have the assetList etc, inside the scan screen, since we've moved away from those things, it's safe to remove, slide navigation still works on both platforms.

![Simulator Screen Recording - iPhone 11 - 2022-04-11 at 12 12 53](https://user-images.githubusercontent.com/20520102/162770644-d2195094-195d-4e95-b41d-aadfb168df06.gif)

