### PR TITLE
[CS-3618]: Format rewards tokens amount

### DIFF
--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback } from 'react';
 import { SectionList } from 'react-native';
-import { fromWei } from '@cardstack/cardpay-sdk';
 import { strings } from '../strings';
 import { RewardRow } from '.';
 import { Container, Text, ListEmptyComponent } from '@cardstack/components';
 import { RewardeeClaim } from '@cardstack/graphql';
+import { fromWeiToFixedEth } from '@cardstack/utils';
 
 export interface RewardsHistorySectionType {
   title: string;
@@ -28,7 +28,7 @@ export const RewardsHistoryList = ({
   );
 
   const renderItem = useCallback(({ item }: { item: RewardeeClaim }) => {
-    const amountInEth = fromWei(item.amount);
+    const amountInEth = fromWeiToFixedEth(item.amount);
     const symbol = item.token.symbol || '';
 
     return (

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawConfimation/useRewardWithdrawConfimationScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawConfimation/useRewardWithdrawConfimationScreen.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from 'react';
 import { useNavigation, useRoute } from '@react-navigation/core';
 
 import { BN } from 'ethereumjs-util';
-import { formatCurrencyAmount, fromWei } from '@cardstack/cardpay-sdk';
 import { strings } from './strings';
 import { RouteType } from '@cardstack/navigation/types';
 
@@ -16,6 +15,7 @@ import { useAccountSettings, useWallets } from '@rainbow-me/hooks';
 import { useMutationEffects } from '@cardstack/hooks';
 import { Alert } from '@rainbow-me/components/alerts';
 import { defaultErrorAlert } from '@cardstack/constants';
+import { fromWeiToFixedEth } from '@cardstack/utils';
 
 interface NavParams {
   tokenInfo: TokenWithSafeAddress;
@@ -61,12 +61,12 @@ export const useRewardWithdrawConfimationScreen = () => {
   );
 
   const estimatedNetClaim = useMemo(
-    () => formatCurrencyAmount(fromWei(totalBalanceMinusGasInWei), 2),
+    () => fromWeiToFixedEth(totalBalanceMinusGasInWei),
     [totalBalanceMinusGasInWei]
   );
 
   const gasEstimateInEth = useMemo(
-    () => formatCurrencyAmount(fromWei(gasEstimate.toString()), 2),
+    () => fromWeiToFixedEth(gasEstimate.toString()),
     [gasEstimate]
   );
 

--- a/cardstack/src/utils/__tests__/formatting-utils.test.ts
+++ b/cardstack/src/utils/__tests__/formatting-utils.test.ts
@@ -1,4 +1,7 @@
-import { normalizeTxHash } from '@cardstack/utils/formatting-utils';
+import {
+  normalizeTxHash,
+  fromWeiToFixedEth,
+} from '@cardstack/utils/formatting-utils';
 
 describe('formatting utils', () => {
   describe('normalizeHash', () => {
@@ -15,6 +18,22 @@ describe('formatting utils', () => {
         expect(normalizeTxHash(hash)).toEqual(
           '0x45db6437ea2d515a06485bb0d33fbfd8986343c6fbadf7799d63eeea0a445c19'
         );
+      }
+    );
+  });
+
+  describe('fromWeiToFixedEth', () => {
+    const amounts = [
+      { wei: '58702316848670658683', formatted: '58.70' },
+      { wei: '382409177820267686424', formatted: '382.41' },
+      { wei: '3818914000000000', formatted: '0.00' },
+      { wei: '184162869133241516766', formatted: '184.16' },
+    ];
+
+    test.each(amounts)(
+      'should return amount in eth with 2 decimals',
+      ({ wei, formatted }) => {
+        expect(fromWeiToFixedEth(wei)).toEqual(formatted);
       }
     );
   });

--- a/cardstack/src/utils/formatting-utils.ts
+++ b/cardstack/src/utils/formatting-utils.ts
@@ -1,3 +1,4 @@
+import { formatCurrencyAmount, fromWei } from '@cardstack/cardpay-sdk';
 import GraphemeSplitter from 'grapheme-splitter';
 
 export const numberWithCommas = (number: string) =>
@@ -69,3 +70,6 @@ export const getValidColorHexString = (color?: string) => {
 
   return convertedColorString.substring(0, 7);
 };
+
+export const fromWeiToFixedEth = (amountInWei: string) =>
+  formatCurrencyAmount(fromWei(amountInWei), 2);


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
This PR adds a util function to convert wei values to ether with 2 decimals, in order to display all token amounts rounded, I don't have a claim amount of this type, so I added tests to make sure we will get the expected result.