### PR TITLE
[CS-3602]: Add withdraw transaction on  rewards history

### DIFF
--- a/cardstack/src/graphql/graphql-codegen.ts
+++ b/cardstack/src/graphql/graphql-codegen.ts
@@ -8398,6 +8398,20 @@ export type GetRewardClaimsQuery = (
   )> }
 );
 
+export type GetTransactionsFromSafesQueryVariables = Exact<{
+  safeAddresses?: Maybe<Array<Scalars['String']> | Scalars['String']>;
+  relayAddress: Scalars['String'];
+}>;
+
+
+export type GetTransactionsFromSafesQuery = (
+  { __typename?: 'Query' }
+  & { tokenTransfers: Array<(
+    { __typename?: 'TokenTransfer' }
+    & TokenTransferFragment
+  )> }
+);
+
 export const PrepaidCardPaymentFragmentDoc = gql`
     fragment PrepaidCardPayment on PrepaidCardPayment {
   id
@@ -9018,3 +9032,37 @@ export function useGetRewardClaimsLazyQuery(baseOptions?: ApolloReactHooks.LazyQ
 export type GetRewardClaimsQueryHookResult = ReturnType<typeof useGetRewardClaimsQuery>;
 export type GetRewardClaimsLazyQueryHookResult = ReturnType<typeof useGetRewardClaimsLazyQuery>;
 export type GetRewardClaimsQueryResult = ApolloReactCommon.QueryResult<GetRewardClaimsQuery, GetRewardClaimsQueryVariables>;
+export const GetTransactionsFromSafesDocument = gql`
+    query GetTransactionsFromSafes($safeAddresses: [String!], $relayAddress: String!) {
+  tokenTransfers(where: {from_in: $safeAddresses, to_not: $relayAddress}) {
+    ...TokenTransfer
+  }
+}
+    ${TokenTransferFragmentDoc}`;
+
+/**
+ * __useGetTransactionsFromSafesQuery__
+ *
+ * To run a query within a React component, call `useGetTransactionsFromSafesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetTransactionsFromSafesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetTransactionsFromSafesQuery({
+ *   variables: {
+ *      safeAddresses: // value for 'safeAddresses'
+ *      relayAddress: // value for 'relayAddress'
+ *   },
+ * });
+ */
+export function useGetTransactionsFromSafesQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetTransactionsFromSafesQuery, GetTransactionsFromSafesQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetTransactionsFromSafesQuery, GetTransactionsFromSafesQueryVariables>(GetTransactionsFromSafesDocument, baseOptions);
+      }
+export function useGetTransactionsFromSafesLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetTransactionsFromSafesQuery, GetTransactionsFromSafesQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetTransactionsFromSafesQuery, GetTransactionsFromSafesQueryVariables>(GetTransactionsFromSafesDocument, baseOptions);
+        }
+export type GetTransactionsFromSafesQueryHookResult = ReturnType<typeof useGetTransactionsFromSafesQuery>;
+export type GetTransactionsFromSafesLazyQueryHookResult = ReturnType<typeof useGetTransactionsFromSafesLazyQuery>;
+export type GetTransactionsFromSafesQueryResult = ApolloReactCommon.QueryResult<GetTransactionsFromSafesQuery, GetTransactionsFromSafesQueryVariables>;

--- a/cardstack/src/graphql/queries.graphql
+++ b/cardstack/src/graphql/queries.graphql
@@ -112,3 +112,15 @@ query GetRewardClaims($rewardeeAddress: String!) {
     }
   }
 }
+
+query GetTransactionsFromSafes(
+  $safeAddresses: [String!]
+  $relayAddress: String!
+) {
+  tokenTransfers(
+    # Excluding relay address to remove gas tx
+    where: { from_in: $safeAddresses, to_not: $relayAddress }
+  ) {
+    ...TokenTransfer
+  }
+}

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
@@ -18,7 +18,7 @@ const RewardsCenterScreen = () => {
     hasRewardsAvailable,
     mainPoolTokenInfo,
     onClaimPress,
-    claimHistorySectionData,
+    historySectionData,
     tokensBalanceData,
     isLoading,
     isLoadingClaimGas,
@@ -58,7 +58,7 @@ const RewardsCenterScreen = () => {
             {isRegistered && (
               <ClaimContent
                 claimList={hasRewardsAvailable ? [mainPoolRowProps] : undefined}
-                historyList={claimHistorySectionData}
+                historyList={historySectionData}
                 balanceList={tokensBalanceData}
                 isLoadingClaimGas={isLoadingClaimGas}
               />

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
@@ -9,21 +9,23 @@ import {
   CardPressable,
 } from '@cardstack/components';
 
+type TxStatus = 'claimed' | 'withdrawn' | 'none';
+
 export interface RewardRowProps extends Omit<TouchableProps, 'children'> {
   coinSymbol: string;
   primaryText: string;
   subText?: string;
-  claimed?: boolean;
   onClaimPress?: () => void;
   isLoading?: boolean;
   showWithdrawBtn?: boolean;
+  txStatus?: TxStatus;
 }
 
 export const RewardRow = ({
   coinSymbol,
   primaryText,
   subText,
-  claimed = false,
+  txStatus = 'none',
   onClaimPress,
   onPress,
   isLoading = false,
@@ -52,7 +54,7 @@ export const RewardRow = ({
           flex={1}
         >
           <Text fontSize={15}>
-            {claimed && strings.claim.claimed + ' '}
+            {strings.transaction[txStatus] + ' '}
             <Text weight="extraBold" fontSize={15} ellipsizeMode="tail">
               {primaryText}
             </Text>

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react';
 import { SectionList } from 'react-native';
-import { fromWeiToFixedEth } from '@cardstack/utils';
 import { OptionalUnion } from 'globals';
 import { strings } from '../strings';
 import { RewardRow } from '.';
+import { fromWeiToFixedEth } from '@cardstack/utils';
 import { Container, Text, ListEmptyComponent } from '@cardstack/components';
 import { RewardeeClaim, TokenTransfer } from '@cardstack/graphql';
 

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
@@ -1,14 +1,16 @@
 import React, { useCallback } from 'react';
 import { SectionList } from 'react-native';
+import { fromWeiToFixedEth } from '@cardstack/utils';
+import { OptionalUnion } from 'globals';
 import { strings } from '../strings';
 import { RewardRow } from '.';
 import { Container, Text, ListEmptyComponent } from '@cardstack/components';
-import { RewardeeClaim } from '@cardstack/graphql';
-import { fromWeiToFixedEth } from '@cardstack/utils';
+import { RewardeeClaim, TokenTransfer } from '@cardstack/graphql';
 
+export type ClaimOrTokenWithdraw = OptionalUnion<RewardeeClaim, TokenTransfer>;
 export interface RewardsHistorySectionType {
   title: string;
-  data: RewardeeClaim[];
+  data: ClaimOrTokenWithdraw[];
 }
 
 export interface RewardsHistoryListProps {
@@ -27,15 +29,18 @@ export const RewardsHistoryList = ({
     []
   );
 
-  const renderItem = useCallback(({ item }: { item: RewardeeClaim }) => {
+  const renderItem = useCallback(({ item }: { item: ClaimOrTokenWithdraw }) => {
     const amountInEth = fromWeiToFixedEth(item.amount);
     const symbol = item.token.symbol || '';
+
+    const txStatus =
+      item.__typename === 'RewardeeClaim' ? 'claimed' : 'withdrawn';
 
     return (
       <RewardRow
         primaryText={`${amountInEth} ${symbol}`}
         coinSymbol={symbol}
-        claimed
+        txStatus={txStatus}
       />
     );
   }, []);

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/components/SafeSelectionItem.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/components/SafeSelectionItem.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useCallback, useMemo } from 'react';
 import { StyleSheet } from 'react-native';
 import { DepotSafe } from '@cardstack/cardpay-sdk';
+import { OptionalUnion } from 'globals';
 import { strings } from './strings';
 import { getAddressPreview } from '@cardstack/utils';
 import {
@@ -13,11 +14,6 @@ import {
 import { ContactAvatar } from '@rainbow-me/components/contacts';
 import { MerchantSafeType } from '@cardstack/types';
 import { palette } from '@cardstack/theme';
-
-type OptionalUnion<T1, T2> = {
-  [P in keyof Omit<T1 & T2, keyof (T1 | T2)>]?: (T1 & T2)[P];
-} &
-  (T1 | T2);
 
 type MerchantOrDepotSafe = OptionalUnion<MerchantSafeType, DepotSafe>;
 

--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -26,7 +26,6 @@ export const strings = {
   claim: {
     button: 'Claim',
     loading: 'Claiming Reward',
-    claimed: 'Claimed',
   },
   balance: {
     title: 'Balance',
@@ -38,5 +37,10 @@ export const strings = {
   },
   withdraw: {
     button: 'Withdraw',
+  },
+  transaction: {
+    withdrawn: 'Withdrawn',
+    claimed: 'Claimed',
+    none: '',
   },
 };

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -14,3 +14,8 @@ declare module 'react-native-keychain' {
     results: rnKeychain.UserCredentials[];
   }>;
 }
+
+type OptionalUnion<T1, T2> = {
+  [P in keyof Omit<T1 & T2, keyof (T1 | T2)>]?: (T1 & T2)[P];
+} &
+  (T1 | T2);


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds the withdraw tx to rewards history section, next we should handle redirecting to blockscout on click and adding the from info, but I believe we will probably need to rethink the RewardRow's implementation in order to do that.



### Screenshots

<!-- Screenshots or animated GIFs included here -->

PS: the token amount not fixed is pending on #785 
<img width="300" alt="image" src="https://user-images.githubusercontent.com/20520102/163066646-256b73d8-cc00-4cf3-ad5f-9ff61d3528ad.png">

