### PR TITLE
[CS-3692] Improved font family usage | text on Tab Bar

### DIFF
--- a/cardstack/src/components/TabBarIcon/TabBarIcon.tsx
+++ b/cardstack/src/components/TabBarIcon/TabBarIcon.tsx
@@ -29,7 +29,12 @@ const TabBarIcon = ({ focused, iconName, label }: TabBarIconProps) => {
   );
 
   return (
-    <Container flex={1} alignItems="center">
+    <Container
+      flex={1}
+      width="100%"
+      minWidth={layouts.tabIndicatorDash.width}
+      alignItems="center"
+    >
       <Container
         height={layouts.tabIndicatorDash.height}
         width={layouts.tabIndicatorDash.width}
@@ -41,12 +46,7 @@ const TabBarIcon = ({ focused, iconName, label }: TabBarIconProps) => {
         color={styles.iconLabelColor}
         size={layouts.iconSize}
       />
-      <Text
-        color={styles.iconLabelColor}
-        paddingTop={2}
-        weight="bold"
-        fontSize={10}
-      >
+      <Text variant="tabBar" color={styles.iconLabelColor} paddingTop={2}>
         {label}
       </Text>
     </Container>

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -12,6 +12,7 @@ import {
   StackNavigationOptions,
 } from '@react-navigation/stack';
 import { NavigationContainer } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { InitialRouteContext } from '../../../src/context/initialRoute';
 import { useCardstackGlobalScreens, useCardstackMainScreens } from './hooks';
 import { linking } from './screens';
@@ -26,7 +27,7 @@ import RainbowRoutes from '@rainbow-me/navigation/routesNames';
 
 import { TabBarIcon } from '@cardstack/components';
 import { colors } from '@cardstack/theme';
-import { Device, screenHeight } from '@cardstack/utils';
+import { Device } from '@cardstack/utils';
 import ExpandedAssetSheet from '@rainbow-me/screens/ExpandedAssetSheet';
 import ModalScreen from '@rainbow-me/screens/ModalScreen';
 import RestoreSheet from '@rainbow-me/screens/RestoreSheet';
@@ -38,69 +39,74 @@ import ChangeWalletSheet from '@rainbow-me/screens/ChangeWalletSheet';
 
 const Tab = createBottomTabNavigator();
 
-const layouts = {
-  tabBarHeightSize: screenHeight * 0.1,
-};
-
-const tabBarOptions = {
+const tabBarOptions = (bottomInset = 0) => ({
   style: {
     backgroundColor: colors.backgroundBlue,
-    height: layouts.tabBarHeightSize,
+    height: bottomInset + 70,
     borderTopColor: Device.isIOS ? 'transparent' : colors.blackLightOpacity,
     shadowOffset: {
       width: 0,
-      height: 1,
+      height: -1,
     },
-    shadowOpacity: 0.5,
-    elevation: 3,
+    shadowRadius: 5,
+    shadowOpacity: 0.35,
+    elevation: 9,
   },
   showLabel: false,
   keyboardHidesTabBar: Device.isAndroid, // fix for TabBar shows above Android keyboard, but this option makes iOS flickering when keyboard toggles
-};
+});
 
-const TabNavigator = () => (
-  <Tab.Navigator
-    initialRouteName={RainbowRoutes.WALLET_SCREEN}
-    tabBarOptions={tabBarOptions}
-  >
-    <Tab.Screen
-      component={HomeScreen}
-      name={RainbowRoutes.HOME_SCREEN}
-      options={{
-        tabBarIcon: ({ focused }) => (
-          <TabBarIcon iconName="activity" label="ACTIVITY" focused={focused} />
-        ),
-      }}
-    />
-    <Tab.Screen
-      component={ProfileScreen}
-      name={RainbowRoutes.PROFILE_SCREEN}
-      options={{
-        tabBarIcon: ({ focused }) => (
-          <TabBarIcon iconName="user" label="PROFILE" focused={focused} />
-        ),
-      }}
-    />
-    <Tab.Screen
-      component={WalletScreen}
-      name={RainbowRoutes.WALLET_SCREEN}
-      options={{
-        tabBarIcon: ({ focused }) => (
-          <TabBarIcon iconName="wallet" label="WALLET" focused={focused} />
-        ),
-      }}
-    />
-    <Tab.Screen
-      component={QRScannerScreen}
-      name={RainbowRoutes.QR_SCANNER_SCREEN}
-      options={{
-        tabBarIcon: ({ focused }) => (
-          <TabBarIcon iconName="qr-code" label="PAY" focused={focused} />
-        ),
-      }}
-    />
-  </Tab.Navigator>
-);
+const TabNavigator = () => {
+  const { bottom } = useSafeAreaInsets();
+
+  return (
+    <Tab.Navigator
+      initialRouteName={RainbowRoutes.WALLET_SCREEN}
+      tabBarOptions={tabBarOptions(bottom)}
+    >
+      <Tab.Screen
+        component={HomeScreen}
+        name={RainbowRoutes.HOME_SCREEN}
+        options={{
+          tabBarIcon: ({ focused }) => (
+            <TabBarIcon
+              iconName="activity"
+              label="ACTIVITY"
+              focused={focused}
+            />
+          ),
+        }}
+      />
+      <Tab.Screen
+        component={ProfileScreen}
+        name={RainbowRoutes.PROFILE_SCREEN}
+        options={{
+          tabBarIcon: ({ focused }) => (
+            <TabBarIcon iconName="user" label="PROFILE" focused={focused} />
+          ),
+        }}
+      />
+      <Tab.Screen
+        component={WalletScreen}
+        name={RainbowRoutes.WALLET_SCREEN}
+        options={{
+          tabBarIcon: ({ focused }) => (
+            <TabBarIcon iconName="wallet" label="WALLET" focused={focused} />
+          ),
+        }}
+      />
+      <Tab.Screen
+        component={QRScannerScreen}
+        name={RainbowRoutes.QR_SCANNER_SCREEN}
+        options={{
+          tabBarIcon: ({ focused }) => (
+            <TabBarIcon iconName="qr-code" label="PAY" focused={focused} />
+          ),
+        }}
+      />
+    </Tab.Navigator>
+  );
+};
 
 const Stack = createStackNavigator();
 

--- a/cardstack/src/theme/fontFamilyVariants.ts
+++ b/cardstack/src/theme/fontFamilyVariants.ts
@@ -1,0 +1,32 @@
+export const fontFamilyVariants = {
+  light: {
+    fontFamily: 'OpenSans-Light',
+  },
+  lightItalic: {
+    fontFamily: 'OpenSans-LightItalic',
+  },
+  regular: {
+    fontFamily: 'OpenSans-Regular',
+  },
+  italic: {
+    fontFamily: 'OpenSans-Italic',
+  },
+  semiBold: {
+    fontFamily: 'OpenSans-SemiBold',
+  },
+  semiBoldItalic: {
+    fontFamily: 'OpenSans-SemiBoldItalic',
+  },
+  bold: {
+    fontFamily: 'OpenSans-Bold',
+  },
+  boldItalic: {
+    fontFamily: 'OpenSans-BoldItalic',
+  },
+  extraBold: {
+    fontFamily: 'OpenSans-ExtraBold',
+  },
+  extraBoldItalic: {
+    fontFamily: 'OpenSans-ExtraBoldItalic',
+  },
+};

--- a/cardstack/src/theme/fontWeights.ts
+++ b/cardstack/src/theme/fontWeights.ts
@@ -1,5 +1,6 @@
 import { Platform } from 'react-native';
 
+// Note: Prefer to use textVariants instead.
 export const fontWeights = Platform.select({
   ios: {
     regular: '400',

--- a/cardstack/src/theme/textVariants.ts
+++ b/cardstack/src/theme/textVariants.ts
@@ -1,18 +1,17 @@
+import { fontFamilyVariants } from './fontFamilyVariants';
+
 const baseText = {
-  fontFamily: 'OpenSans-Regular',
   fontSize: 16,
   color: 'black',
 };
 
 export const textVariants = {
-  defaults: baseText,
-  body: baseText,
-  shadowRoboto: {
-    fontFamily: 'RobotoMono-Regular',
-    fontSize: 18,
-    textShadowColor: 'white',
-    textShadowOffset: { width: 0, height: 1 },
-    textShadowRadius: 0,
+  defaults: { ...baseText, ...fontFamilyVariants.regular },
+  body: { ...baseText, ...fontFamilyVariants.regular },
+  tabBar: {
+    fontSize: 10,
+    letterSpacing: 0.1,
+    ...fontFamilyVariants.bold,
   },
   xsGrey: {
     color: 'grayText',
@@ -25,10 +24,6 @@ export const textVariants = {
   smallButton: {
     fontSize: 12,
   },
-  subHeader: {
-    color: 'blueText',
-    fontSize: 16,
-  },
   subText: {
     color: 'blueText',
     fontSize: 13,
@@ -36,13 +31,13 @@ export const textVariants = {
   subAddress: {
     color: 'blueText',
     fontSize: 14,
-    fontFamily: 'RobotoMono-Regular',
+    ...fontFamilyVariants.regular,
   },
   welcomeScreen: {
     color: 'white',
     fontSize: 24,
     fontWeight: '700',
-    fontFamily: 'OpenSans-Bold',
+    ...fontFamilyVariants.bold,
   },
   overGradient: {
     textShadowOffset: {


### PR DESCRIPTION
### Description

This PR adds a better implementation for font-family (and weight) usage by using restyle `textVariants`. That's preferable because with it we can keep a library of font styles used throughout the app, moving font styling from components to the Theme.

It also fixes Tab Bar's height by giving it a fixed height, plus padding depending on bottom insets from safe-area-context. That's preferable to having it proportional to the screen's height because tall devices could present too big bars.

- [x] Completes #(CS-3692)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots


OLD | NEW
--- | ---
![Screenshot_20220413-232001_Card Wallet](https://user-images.githubusercontent.com/129619/163302769-50ccc0d8-4d43-40f5-b79b-ad4c22724bcb.jpg) | ![Screenshot_20220413-232345_Card Wallet](https://user-images.githubusercontent.com/129619/163302785-fe03a74d-b86c-4c6d-9261-0a53e320c7b3.jpg)

OLD Tablet | NEW Tablet
--- | ---
![Screenshot_20220413-170132_Card Wallet](https://user-images.githubusercontent.com/129619/163303096-decfc1da-00cd-46b1-b50a-1b1aa91e8586.jpg) | ![Screenshot_20220413-231635_Card Wallet](https://user-images.githubusercontent.com/129619/163303120-9793e9be-0e42-4732-84b4-853877481d08.jpg)


