### PR TITLE
 [CS-3696]: Fix crash on withdrawTo screen

### DIFF
--- a/cardstack/src/components/Depot/Depot.tsx
+++ b/cardstack/src/components/Depot/Depot.tsx
@@ -11,7 +11,7 @@ import { DepotType } from '@cardstack/types';
 import { useNavigation } from '@rainbow-me/navigation';
 import Routes from '@rainbow-me/routes';
 
-interface DepotProps extends DepotType {
+interface DepotProps extends Omit<DepotType, 'type'> {
   networkName: string;
 }
 

--- a/cardstack/src/components/TransactionConfirmationSheet/displays/PrepaidCard/IssuePrepaidCardDisplay.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/displays/PrepaidCard/IssuePrepaidCardDisplay.tsx
@@ -2,6 +2,12 @@ import { convertRawAmountToBalance } from '@cardstack/cardpay-sdk';
 import React from 'react';
 import { ActivityIndicator } from 'react-native';
 import { SectionHeaderText } from '../components/SectionHeaderText';
+import {
+  MerchantOrDepotSafe,
+  IssuePrepaidCardDecodedData,
+  DepotType,
+  MerchantSafeType,
+} from '@cardstack/types';
 import { ContactAvatar } from '@rainbow-me/components/contacts';
 import {
   Container,
@@ -11,11 +17,7 @@ import {
   Text,
   TransactionConfirmationDisplayProps,
 } from '@cardstack/components';
-import {
-  IssuePrepaidCardDecodedData,
-  DepotType,
-  MerchantSafeType,
-} from '@cardstack/types';
+
 import {
   getSafeTokenByAddress,
   convertSpendForBalanceDisplay,
@@ -48,6 +50,11 @@ export const IssuePrepaidCardDisplay = (
   );
 };
 
+interface SelectedResult {
+  fromSafe?: MerchantOrDepotSafe;
+  isLoadingSafe: boolean;
+}
+
 const FromSection = ({
   safeAddress,
   tokenAddress,
@@ -67,20 +74,24 @@ const FromSection = ({
   const { fromSafe, isLoadingSafe } = useGetSafesDataQuery(
     { address: accountAddress, nativeCurrency },
     {
-      selectFromResult: ({ data, isLoading, isUninitialized }) => ({
+      selectFromResult: ({
+        data,
+        isLoading,
+        isUninitialized,
+      }): SelectedResult => ({
         fromSafe: [
           ...(data?.merchantSafes || []),
           ...(data?.depots || []),
-        ].find(safe => safe && safe.address === safeAddress),
+        ].find(safe => safe?.address === safeAddress),
         isLoadingSafe: isLoading || isUninitialized,
       }),
     }
   );
 
   const safeTypeText =
-    fromSafe?.merchantInfo?.name || fromSafe?.type.toUpperCase();
+    fromSafe?.merchantInfo?.name || fromSafe?.type?.toUpperCase();
 
-  const token = getSafeTokenByAddress(fromSafe, tokenAddress);
+  const token = getSafeTokenByAddress(fromSafe?.tokens || [], tokenAddress);
   const tokenBalance = token ? token.balance.display : 'Insufficient Funds';
 
   return (

--- a/cardstack/src/components/TransactionConfirmationSheet/displays/components/sections/PrepaidCardTransactionSection.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/displays/components/sections/PrepaidCardTransactionSection.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { PrepaidCardSafe } from '@cardstack/cardpay-sdk';
 import MiniPrepaidCard from '../../../../PrepaidCard/MiniPrepaidCard';
 import TransactionListItem from '../TransactionListItem';
 import { Container, Text } from '@cardstack/components';
@@ -26,8 +25,8 @@ export const PrepaidCardTransactionSection = ({
     { address: accountAddress, nativeCurrency },
     {
       selectFromResult: ({ data }) => ({
-        prepaidCard: data?.prepaidCards.find(
-          (card: PrepaidCardSafe) => card.address === prepaidCardAddress
+        prepaidCard: data?.prepaidCards?.find(
+          card => card.address === prepaidCardAddress
         ),
       }),
     }

--- a/cardstack/src/hooks/transactions/use-transaction-sections.tsx
+++ b/cardstack/src/hooks/transactions/use-transaction-sections.tsx
@@ -94,10 +94,12 @@ export const useTransactionSections = ({
 
         try {
           const merchantSafeAddresses = merchantSafes?.map(
-            safe => safe.address
+            (safe: { address: string }) => safe.address
           );
 
-          const prepaidCardAddresses = prepaidCards?.map(safe => safe.address);
+          const prepaidCardAddresses = prepaidCards?.map(
+            (safe: { address: string }) => safe.address
+          );
 
           const transactionMappingContext = new TransactionMappingContext({
             transactions: merchantSafeAddress

--- a/cardstack/src/redux/hooks/usePrimarySafe.ts
+++ b/cardstack/src/redux/hooks/usePrimarySafe.ts
@@ -10,10 +10,6 @@ import { useNativeCurrencyAndConversionRates } from '@rainbow-me/redux/hooks';
 import { MerchantSafeType } from '@cardstack/types';
 import { isLayer1 } from '@cardstack/utils';
 
-const safesInitialState = {
-  merchantSafes: [],
-};
-
 export const usePrimarySafe = () => {
   const dispatch = useDispatch();
   const [nativeCurrency] = useNativeCurrencyAndConversionRates();
@@ -22,7 +18,7 @@ export const usePrimarySafe = () => {
   const primarySafe = useSelector(selectPrimarySafe(network, accountAddress));
 
   const {
-    data = safesInitialState,
+    merchantSafes = [],
     error,
     isFetching,
     refetch,
@@ -32,11 +28,13 @@ export const usePrimarySafe = () => {
       nativeCurrency,
     },
     {
+      selectFromResult: ({ data, ...rest }) => ({
+        merchantSafes: data?.merchantSafes,
+        ...rest,
+      }),
       skip: isLayer1(network) || !accountAddress,
     }
   );
-
-  const { merchantSafes } = data;
 
   const changePrimarySafe = useCallback(
     (merchant: MerchantSafeType) =>

--- a/cardstack/src/screens/MerchantScreen/useMerchantScreen.tsx
+++ b/cardstack/src/screens/MerchantScreen/useMerchantScreen.tsx
@@ -27,7 +27,7 @@ export const useMerchantScreen = () => {
       skip: isLayer1(network) || !accountAddress,
       refetchOnMountOrArgChange: 60,
       selectFromResult: ({ data, isFetching }) => ({
-        updatedMerchantSafe: data?.merchantSafes.find(
+        updatedMerchantSafe: data?.merchantSafes?.find(
           (safe: MerchantSafeType) =>
             safe.address === merchantSafeFallback.address
         ),

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawTo/RewardWithdrawToScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawTo/RewardWithdrawToScreen.tsx
@@ -1,19 +1,34 @@
 import React, { memo } from 'react';
+import { ActivityIndicator } from 'react-native';
 import { SafeSelectionList } from '../components';
 import { strings } from './strings';
 import { useRewardWithdrawToScreen } from './useRewardWithdrawToScreen';
-import { Container, NavigationStackHeader } from '@cardstack/components';
+import {
+  CenteredContainer,
+  Container,
+  NavigationStackHeader,
+} from '@cardstack/components';
 
 const RewardWithdrawToScreen = () => {
-  const { onSafePress, availableSafesToWithdraw } = useRewardWithdrawToScreen();
+  const {
+    onSafePress,
+    availableSafesToWithdraw,
+    isLoading,
+  } = useRewardWithdrawToScreen();
 
   return (
     <Container backgroundColor="white" flex={1}>
       <NavigationStackHeader title={strings.headerTitle} />
-      <SafeSelectionList
-        safes={availableSafesToWithdraw}
-        onSafePress={onSafePress}
-      />
+      {isLoading ? (
+        <CenteredContainer flex={1}>
+          <ActivityIndicator />
+        </CenteredContainer>
+      ) : (
+        <SafeSelectionList
+          safes={availableSafesToWithdraw}
+          onSafePress={onSafePress}
+        />
+      )}
     </Container>
   );
 };

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawTo/useRewardWithdrawToScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawTo/useRewardWithdrawToScreen.ts
@@ -11,6 +11,7 @@ import { MainRoutes } from '@cardstack/navigation';
 
 interface SafeResultType {
   availableSafesToWithdraw: MerchantOrDepotSafe[];
+  isLoading: boolean;
 }
 
 export const useRewardWithdrawToScreen = () => {
@@ -22,14 +23,15 @@ export const useRewardWithdrawToScreen = () => {
 
   const { accountAddress, nativeCurrency } = useAccountSettings();
 
-  const { availableSafesToWithdraw = [] } = useGetSafesDataQuery(
+  const { availableSafesToWithdraw = [], isLoading } = useGetSafesDataQuery(
     { address: accountAddress, nativeCurrency },
     {
-      selectFromResult: ({ data }): SafeResultType => ({
+      selectFromResult: ({ data, ...rest }): SafeResultType => ({
         availableSafesToWithdraw: [
           ...(data?.merchantSafes || []),
           ...(data?.depots || []),
         ].filter(Boolean),
+        ...rest,
       }),
     }
   );
@@ -48,5 +50,6 @@ export const useRewardWithdrawToScreen = () => {
   return {
     onSafePress,
     availableSafesToWithdraw,
+    isLoading,
   };
 };

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawTo/useRewardWithdrawToScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawTo/useRewardWithdrawToScreen.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useNavigation, useRoute } from '@react-navigation/core';
+import { MerchantOrDepotSafe } from '@cardstack/types';
 import { RouteType } from '@cardstack/navigation/types';
 import { useAccountSettings } from '@rainbow-me/hooks';
 
@@ -7,6 +8,10 @@ import { useGetSafesDataQuery } from '@cardstack/services';
 
 import { TokenWithSafeAddress } from '@cardstack/screens/RewardsCenterScreen/components';
 import { MainRoutes } from '@cardstack/navigation';
+
+interface SafeResultType {
+  availableSafesToWithdraw: MerchantOrDepotSafe[];
+}
 
 export const useRewardWithdrawToScreen = () => {
   const {
@@ -17,13 +22,13 @@ export const useRewardWithdrawToScreen = () => {
 
   const { accountAddress, nativeCurrency } = useAccountSettings();
 
-  const { availableSafesToWithdraw } = useGetSafesDataQuery(
+  const { availableSafesToWithdraw = [] } = useGetSafesDataQuery(
     { address: accountAddress, nativeCurrency },
     {
-      selectFromResult: ({ data }) => ({
+      selectFromResult: ({ data }): SafeResultType => ({
         availableSafesToWithdraw: [
-          ...data?.merchantSafes,
-          ...data?.depots,
+          ...(data?.merchantSafes || []),
+          ...(data?.depots || []),
         ].filter(Boolean),
       }),
     }

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/components/SafeSelectionItem.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/components/SafeSelectionItem.tsx
@@ -1,8 +1,7 @@
 import React, { memo, useCallback, useMemo } from 'react';
 import { StyleSheet } from 'react-native';
-import { DepotSafe } from '@cardstack/cardpay-sdk';
-import { OptionalUnion } from 'globals';
 import { strings } from './strings';
+import { MerchantOrDepotSafe } from '@cardstack/types';
 import { getAddressPreview } from '@cardstack/utils';
 import {
   CardPressable,
@@ -12,10 +11,7 @@ import {
   IconName,
 } from '@cardstack/components';
 import { ContactAvatar } from '@rainbow-me/components/contacts';
-import { MerchantSafeType } from '@cardstack/types';
 import { palette } from '@cardstack/theme';
-
-type MerchantOrDepotSafe = OptionalUnion<MerchantSafeType, DepotSafe>;
 
 export interface SafeSelectionItemProps {
   safe: MerchantOrDepotSafe;

--- a/cardstack/src/services/safes-api.ts
+++ b/cardstack/src/services/safes-api.ts
@@ -22,7 +22,6 @@ export const safesApi = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
   tagTypes: [...Object.values(CacheTags)],
   endpoints: builder => ({
-    // TODO: Add right return type
     getSafesData: builder.query<
       GetSafesQueryResult,
       { address: string; nativeCurrency: NativeCurrency }

--- a/cardstack/src/services/safes-api.ts
+++ b/cardstack/src/services/safes-api.ts
@@ -1,12 +1,20 @@
 import { NativeCurrency } from '@cardstack/cardpay-sdk';
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { fetchSafes } from './gnosis-service';
+import { DepotType, MerchantSafeType, PrepaidCardType } from '@cardstack/types';
 
 export enum CacheTags {
   SAFES = 'SAFES',
   PREPAID_CARDS = 'PREPAID_CARDS',
   REWARDS_SAFE = 'REWARDS_SAFE',
   REWARDS_POOL = 'REWARDS_POOL',
+}
+
+interface GetSafesQueryResult {
+  prepaidCards?: PrepaidCardType[];
+  depots?: DepotType[];
+  merchantSafes?: MerchantSafeType[];
+  timestamp: string;
 }
 
 export const safesApi = createApi({
@@ -16,7 +24,7 @@ export const safesApi = createApi({
   endpoints: builder => ({
     // TODO: Add right return type
     getSafesData: builder.query<
-      any,
+      GetSafesQueryResult,
       { address: string; nativeCurrency: NativeCurrency }
     >({
       async queryFn({ address, nativeCurrency = NativeCurrency.USD }) {

--- a/cardstack/src/types/DepotType.ts
+++ b/cardstack/src/types/DepotType.ts
@@ -2,6 +2,8 @@ import { TokenType, AssetType } from '.';
 export interface DepotType {
   address: string;
   tokens: Array<TokenType>;
+  type: 'depot';
+  infoDID?: string;
 }
 
 export type DepotAsset = Omit<

--- a/cardstack/src/types/index.ts
+++ b/cardstack/src/types/index.ts
@@ -12,3 +12,4 @@ export * from './transaction-types';
 export * from './NoticeType';
 export * from './IncidentType';
 export * from './NotificationsPreferenceDataType';
+export * from './safes';

--- a/cardstack/src/types/safes.ts
+++ b/cardstack/src/types/safes.ts
@@ -1,0 +1,5 @@
+import { OptionalUnion } from 'globals';
+import { DepotType } from './DepotType';
+import { MerchantSafeType } from '.';
+
+export type MerchantOrDepotSafe = OptionalUnion<MerchantSafeType, DepotType>;

--- a/cardstack/src/utils/safe-utils.ts
+++ b/cardstack/src/utils/safe-utils.ts
@@ -1,11 +1,8 @@
-import { AssetWithTokensType } from '@cardstack/types';
+import { TokenType } from '@cardstack/types';
 
-export const getSafeTokenByAddress = (
-  asset: AssetWithTokensType,
-  address?: string
-) =>
-  address && asset
-    ? asset.tokens.find(
+export const getSafeTokenByAddress = (tokens: TokenType[], address?: string) =>
+  address
+    ? tokens?.find(
         t => t.tokenAddress?.toLowerCase() === address?.toLowerCase()
       )
     : undefined;

--- a/src/hooks/useAssetListData.tsx
+++ b/src/hooks/useAssetListData.tsx
@@ -160,13 +160,6 @@ const useCollectiblesSection = (): AssetListSectionItem<CollectibleType> => {
   };
 };
 
-const safesInitialState = {
-  prepaidCards: [],
-  depots: [],
-  merchantSafes: [],
-  timestamp: '',
-};
-
 export const useAssetListData = () => {
   const [nativeCurrency] = useNativeCurrencyAndConversionRates();
   const { network, accountAddress } = useAccountSettings();
@@ -176,16 +169,25 @@ export const useAssetListData = () => {
     isFetching: isFetchingSafes,
     isLoading,
     refetch: refetchSafes,
-    data = safesInitialState,
+    prepaidCards,
+    depots,
+    merchantSafes,
+    timestamp,
     isUninitialized,
   } = useGetSafesDataQuery(
     { address: accountAddress, nativeCurrency },
+
     {
+      selectFromResult: ({ data, ...rest }) => ({
+        prepaidCards: data?.prepaidCards || [],
+        depots: data?.depots || [],
+        merchantSafes: data?.merchantSafes || [],
+        timestamp: data?.timestamp || '',
+        ...rest,
+      }),
       skip: isLayer1(network) || !accountAddress || !walletReady,
     }
   );
-
-  const { prepaidCards, depots, merchantSafes, timestamp } = data;
 
   const prepaidCardSection = usePrepaidCardSection(prepaidCards, timestamp);
   const depotSection = useDepotSection(depots, timestamp);


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Safes query was not properly typed which could lead to undefined errors, specifically this error was on the withdrawaTo screen, I updated the types to avoid any upcoming issues, we could of course improve the selectFromResult, or even make the safe query keys default to `[]`, but it's safer and easier to do this way, considering we will move to persona safe soon and have a single data structure within safes.
The issue was happening when safes were not fully loaded while trying to withdraw, I added a loading state, not the best UI, but should do for now.

Completes CS-3694

![Simulator Screen Recording - iPhone SE (2nd generation) - 2022-04-14 at 15 00 39](https://user-images.githubusercontent.com/20520102/163449992-9ed4ff7d-bdaa-40d7-894e-c9d10c34f3fb.gif)


