### PR TITLE
[CS-3665]: Add structure and initial components for card-drop

### DIFF
--- a/cardstack/src/components/InfoBanner/InfoBanner.tsx
+++ b/cardstack/src/components/InfoBanner/InfoBanner.tsx
@@ -21,6 +21,7 @@ export const InfoBanner = ({
   message,
   iconName = 'info',
   iconColor = 'appleBlue',
+  children,
   ...rest
 }: Props) => (
   <Container width="100%" {...rest}>
@@ -38,6 +39,7 @@ export const InfoBanner = ({
       <Text size="xs" color="secondaryText">
         {message}
       </Text>
+      {children}
     </Container>
   </Container>
 );

--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -29,6 +29,7 @@ export const MainRoutes = {
   REWARD_WITHDRAW_CONFIRMATION: 'RewardWithdrawConfirmationScreen',
   TRANSACTION_CONFIRMATION_SHEET: 'TransactionConfirmationScreen',
   BACKUP_SHEET: 'BackupSheet',
+  REQUEST_PREPAID_CARD: 'RequestPrepaidCardScreen',
 } as const;
 
 export const GlobalRoutes = {

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -37,6 +37,7 @@ import {
   RewardsClaimSheet,
   TransactionConfirmationSheet,
   ColorPickerModal,
+  RequestPrepaidCardScreen,
 } from '@cardstack/screens';
 import {
   bottomSheetPreset,
@@ -210,6 +211,10 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
     component: BackupSheet,
     options: bottomSheetPreset as StackNavigationOptions,
     listeners: dismissAndroidKeyboardOnClose,
+  },
+  REQUEST_PREPAID_CARD: {
+    component: RequestPrepaidCardScreen,
+    options: horizontalInterpolator,
   },
 };
 

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -6,7 +6,10 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import {
+  BottomTabBarOptions,
+  createBottomTabNavigator,
+} from '@react-navigation/bottom-tabs';
 import {
   createStackNavigator,
   StackNavigationOptions,
@@ -39,18 +42,22 @@ import ChangeWalletSheet from '@rainbow-me/screens/ChangeWalletSheet';
 
 const Tab = createBottomTabNavigator();
 
-const tabBarOptions = (bottomInset = 0) => ({
+const tabBarOptions = (bottomInset = 0): BottomTabBarOptions => ({
   style: {
     backgroundColor: colors.backgroundBlue,
-    height: bottomInset + 70,
+    minHeight: 70,
     borderTopColor: Device.isIOS ? 'transparent' : colors.blackLightOpacity,
     shadowOffset: {
       width: 0,
-      height: -1,
+      height: 1,
     },
+
     shadowRadius: 5,
     shadowOpacity: 0.35,
     elevation: 9,
+  },
+  safeAreaInsets: {
+    bottom: bottomInset + 5,
   },
   showLabel: false,
   keyboardHidesTabBar: Device.isAndroid, // fix for TabBar shows above Android keyboard, but this option makes iOS flickering when keyboard toggles

--- a/cardstack/src/screens/RequestPrepaidCardScreen/RequestPrepaidCardScreen.tsx
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/RequestPrepaidCardScreen.tsx
@@ -1,16 +1,62 @@
-import React, { useMemo } from 'react';
+import React, { memo } from 'react';
+import { convertToSpend } from '@cardstack/cardpay-sdk';
 import { strings } from './strings';
 import { useRequestPrepaidCardScreen } from './useRequestPrepaidCardScreen';
-import { Container, NavigationStackHeader } from '@cardstack/components';
+import {
+  Container,
+  InfoBanner,
+  NavigationStackHeader,
+  Text,
+} from '@cardstack/components';
+import MediumPrepaidCard from '@cardstack/components/PrepaidCard/MediumPrepaidCard';
 
 const RequestPrepaidCardScreen = () => {
-  const {} = useRequestPrepaidCardScreen();
+  const { onSupportLinkPress } = useRequestPrepaidCardScreen();
 
   return (
     <Container backgroundColor="backgroundDarkPurple" flex={1}>
       <NavigationStackHeader title={strings.navigation.title} />
+      <Container paddingHorizontal={5} alignItems="center" flex={1}>
+        <CardPlaceholder />
+        <InfoBanner
+          title={strings.termsBanner.title}
+          message={strings.termsBanner.message}
+        >
+          <Text
+            textDecorationLine="underline"
+            color="blueOcean"
+            size="xs"
+            onPress={onSupportLinkPress}
+          >
+            {strings.termsBanner.link}
+          </Text>
+        </InfoBanner>
+      </Container>
     </Container>
   );
 };
 
 export default RequestPrepaidCardScreen;
+
+// TODO: Replace with correct design
+const CardPlaceholder = memo(() => (
+  <Container width="70%" justifyContent="center" paddingVertical={5}>
+    <MediumPrepaidCard
+      networkName="Gnosis Chain"
+      nativeCurrency="USD"
+      //@ts-expect-error no currency needed
+      currencyConversionRates=""
+      address="0xXXXX…XXXX"
+      spendFaceValue={convertToSpend(2, 'USD', 1)}
+      transferrable={false}
+      cardCustomization={{
+        background: 'linear-gradient(139.27deg, #00ebe5 34%, #c3fc33 70%)',
+        issuerName: 'Cardstack',
+        patternColor: 'white',
+        patternUrl:
+          'https://app.cardstack.com/images/prepaid-card-customizations/pattern-5.svg',
+        textColor: 'black',
+      }}
+    />
+  </Container>
+));

--- a/cardstack/src/screens/RequestPrepaidCardScreen/RequestPrepaidCardScreen.tsx
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/RequestPrepaidCardScreen.tsx
@@ -3,8 +3,10 @@ import { convertToSpend } from '@cardstack/cardpay-sdk';
 import { strings } from './strings';
 import { useRequestPrepaidCardScreen } from './useRequestPrepaidCardScreen';
 import {
+  Button,
   Container,
   InfoBanner,
+  Input,
   NavigationStackHeader,
   Text,
 } from '@cardstack/components';
@@ -16,8 +18,25 @@ const RequestPrepaidCardScreen = () => {
   return (
     <Container backgroundColor="backgroundDarkPurple" flex={1}>
       <NavigationStackHeader title={strings.navigation.title} />
-      <Container paddingHorizontal={5} alignItems="center" flex={1}>
+      <Container
+        paddingHorizontal={5}
+        alignItems="center"
+        justifyContent="space-between"
+        flex={0.5}
+        width="100%"
+      >
         <CardPlaceholder />
+        <Container width="100%">
+          <Input
+            borderWidth={1}
+            borderColor="white"
+            borderRadius={6}
+            paddingVertical={3}
+            paddingHorizontal={5}
+            fontSize={16}
+          />
+        </Container>
+        <Button marginVertical={4}>{strings.button.submit}</Button>
         <InfoBanner
           title={strings.termsBanner.title}
           message={strings.termsBanner.message}

--- a/cardstack/src/screens/RequestPrepaidCardScreen/RequestPrepaidCardScreen.tsx
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/RequestPrepaidCardScreen.tsx
@@ -1,0 +1,16 @@
+import React, { useMemo } from 'react';
+import { strings } from './strings';
+import { useRequestPrepaidCardScreen } from './useRequestPrepaidCardScreen';
+import { Container, NavigationStackHeader } from '@cardstack/components';
+
+const RequestPrepaidCardScreen = () => {
+  const {} = useRequestPrepaidCardScreen();
+
+  return (
+    <Container backgroundColor="backgroundDarkPurple" flex={1}>
+      <NavigationStackHeader title={strings.navigation.title} />
+    </Container>
+  );
+};
+
+export default RequestPrepaidCardScreen;

--- a/cardstack/src/screens/RequestPrepaidCardScreen/strings.ts
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/strings.ts
@@ -1,0 +1,5 @@
+export const strings = {
+  navigation: {
+    title: 'Request Prepaid Card',
+  },
+};

--- a/cardstack/src/screens/RequestPrepaidCardScreen/strings.ts
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/strings.ts
@@ -5,7 +5,10 @@ export const strings = {
   termsBanner: {
     title: 'Terms and Conditions',
     message:
-      'By using this service you agree to submit your email address and wallet address. You also agree to be sent an optional Cardstack Newsletter subscription confirmation email. Your email address is securely hashed in our database. For more details visit ',
-    link: 'https://support.cardstack.com',
+      'By clicking the “Submit” button, you are submitting your Card Wallet address and email address. You agree to receive a verification email and Cardstack newsletter opt-in request.\n\nFor more details visit',
+    link: 'https://support.cardstack.com/card-drop',
+  },
+  button: {
+    submit: 'Submit',
   },
 };

--- a/cardstack/src/screens/RequestPrepaidCardScreen/strings.ts
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/strings.ts
@@ -2,4 +2,10 @@ export const strings = {
   navigation: {
     title: 'Request Prepaid Card',
   },
+  termsBanner: {
+    title: 'Terms and Conditions',
+    message:
+      'By using this service you agree to submit your email address and wallet address. You also agree to be sent an optional Cardstack Newsletter subscription confirmation email. Your email address is securely hashed in our database. For more details visit ',
+    link: 'https://support.cardstack.com',
+  },
 };

--- a/cardstack/src/screens/RequestPrepaidCardScreen/useRequestPrepaidCardScreen.ts
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/useRequestPrepaidCardScreen.ts
@@ -1,0 +1,3 @@
+export const useRequestPrepaidCardScreen = () => {
+  return {};
+};

--- a/cardstack/src/screens/RequestPrepaidCardScreen/useRequestPrepaidCardScreen.ts
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/useRequestPrepaidCardScreen.ts
@@ -1,3 +1,13 @@
+import { useCallback } from 'react';
+import { Linking } from 'react-native';
+import { strings } from './strings';
+
 export const useRequestPrepaidCardScreen = () => {
-  return {};
+  const onSupportLinkPress = useCallback(() => {
+    Linking.openURL(strings.termsBanner.link);
+  }, []);
+
+  return {
+    onSupportLinkPress,
+  };
 };

--- a/cardstack/src/screens/index.ts
+++ b/cardstack/src/screens/index.ts
@@ -31,3 +31,4 @@ export { default as RewardsCenterScreen } from './RewardsCenterScreen/RewardsCen
 export { default as RewardsRegisterSheet } from './RewardsCenterScreen/RewardsRegisterSheet/RewardsRegisterSheet';
 export { default as RewardsClaimSheet } from './RewardsCenterScreen/RewardsClaimSheet/RewardsClaimSheet';
 export { default as TransactionConfirmationSheet } from './sheets/TransactionConfirmationSheet/TransactionConfirmationSheet';
+export { default as RequestPrepaidCardScreen } from './RequestPrepaidCardScreen/RequestPrepaidCardScreen';


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds the structure of request card screen, so we can start working on the other tickets, most components are just placeholders, for this task the InfoBanner is the only one completed, all the others have specific tickets to be handled. Also fixes the tabBar on iOS devices.

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

// Placeholders
<img width="200" alt="image" src="https://user-images.githubusercontent.com/20520102/163470755-2ab9553b-16da-409b-b523-11bd05e0f957.png">

