### PR TITLE
[CS-3702]: Fix loading and switching account profile bugs

### DIFF
--- a/cardstack/src/components/AssetList/useAssetList.ts
+++ b/cardstack/src/components/AssetList/useAssetList.ts
@@ -1,22 +1,15 @@
 import { getConstantByNetwork } from '@cardstack/cardpay-sdk';
 import { useRoute } from '@react-navigation/core';
-import {
-  useState,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  RefObject,
-} from 'react';
+import { useState, useCallback, useEffect, useMemo, RefObject } from 'react';
 import { SectionList } from 'react-native';
 
+import { useIsFetchingDataNewAccount } from '@cardstack/hooks';
 import { useGetServiceStatusQuery } from '@cardstack/services';
 import { isLayer1 } from '@cardstack/utils';
 
 import showWalletErrorAlert from '@rainbow-me/helpers/support';
 import {
   PinnedHiddenSectionOption,
-  useAccountProfile,
   useAccountSettings,
   useAssetListData,
   useRefreshAccountData,
@@ -44,21 +37,9 @@ export const useAssetList = ({
     isFetchingSafes,
   } = useAssetListData();
 
-  // Handle switch account
-  const prevAccount = useRef(null);
-
-  const { accountAddress } = useAccountProfile();
-
-  useEffect(() => {
-    if (accountAddress) {
-      prevAccount.current = accountAddress;
-    }
-  }, [accountAddress]);
-
-  // Account was switched so show loading skeleton
-  const isLoadingSafesDiffAccount = useMemo(
-    () => isFetchingSafes && prevAccount.current !== accountAddress,
-    [accountAddress, isFetchingSafes, prevAccount]
+  // Account changed, flag to load skeleton
+  const isLoadingSafesDiffAccount = useIsFetchingDataNewAccount(
+    isFetchingSafes
   );
 
   // Handle refresh

--- a/cardstack/src/hooks/index.ts
+++ b/cardstack/src/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './notifications-preferences/useUpdateNotificationPreferences';
 export * from './useMutationEffects';
 export * from './useCopyToast';
 export * from './useBooleanState';
+export * from './useIsFetchingDataNewAccount';

--- a/cardstack/src/hooks/useIsFetchingDataNewAccount.ts
+++ b/cardstack/src/hooks/useIsFetchingDataNewAccount.ts
@@ -1,0 +1,28 @@
+import { useRef, useMemo, useEffect } from 'react';
+
+import { useAccountProfile } from '@rainbow-me/hooks';
+
+/**
+ * This hook is helper for switching account states,
+ * where the initial loading UI behavior
+ * is expected even when the query is refetched
+ */
+export const useIsFetchingDataNewAccount = (isFetching: boolean) => {
+  const { accountAddress } = useAccountProfile();
+
+  const prevAccount = useRef(accountAddress);
+
+  // Account was switched but data is refreshing
+  const isFetchingDataNewAccount = useMemo(
+    () => isFetching && prevAccount.current !== accountAddress,
+    [accountAddress, isFetching, prevAccount]
+  );
+
+  useEffect(() => {
+    if (isFetchingDataNewAccount) {
+      prevAccount.current = accountAddress;
+    }
+  }, [accountAddress, isFetchingDataNewAccount]);
+
+  return isFetchingDataNewAccount;
+};

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -67,6 +67,8 @@ const tabBarOptions = (bottomInset = 0): BottomTabBarOptions => ({
   keyboardHidesTabBar: Device.isAndroid, // fix for TabBar shows above Android keyboard, but this option makes iOS flickering when keyboard toggles
 });
 
+const enableProfileTab = __DEV__;
+
 const TabNavigator = () => {
   const { bottom } = useSafeAreaInsets();
 
@@ -88,15 +90,17 @@ const TabNavigator = () => {
           ),
         }}
       />
-      <Tab.Screen
-        component={ProfileScreen}
-        name={RainbowRoutes.PROFILE_SCREEN}
-        options={{
-          tabBarIcon: ({ focused }) => (
-            <TabBarIcon iconName="user" label="PROFILE" focused={focused} />
-          ),
-        }}
-      />
+      {enableProfileTab && (
+        <Tab.Screen
+          component={ProfileScreen}
+          name={RainbowRoutes.PROFILE_SCREEN}
+          options={{
+            tabBarIcon: ({ focused }) => (
+              <TabBarIcon iconName="user" label="PROFILE" focused={focused} />
+            ),
+          }}
+        />
+      )}
       <Tab.Screen
         component={WalletScreen}
         name={RainbowRoutes.WALLET_SCREEN}

--- a/cardstack/src/redux/hooks/usePrimarySafe.ts
+++ b/cardstack/src/redux/hooks/usePrimarySafe.ts
@@ -6,7 +6,10 @@ import { MerchantSafeType } from '@cardstack/types';
 import { isLayer1 } from '@cardstack/utils';
 
 import { useAccountSettings } from '@rainbow-me/hooks';
-import { useNativeCurrencyAndConversionRates } from '@rainbow-me/redux/hooks';
+import {
+  useNativeCurrencyAndConversionRates,
+  useRainbowSelector,
+} from '@rainbow-me/redux/hooks';
 
 import {
   changePrimarySafe as setPrimarySafeAccount,
@@ -20,6 +23,8 @@ export const usePrimarySafe = () => {
 
   const primarySafeKey = useSelector(selectPrimarySafe(network, accountAddress))
     ?.address;
+
+  const walletReady = useRainbowSelector(state => state.appState.walletReady);
 
   const {
     merchantSafes = [],
@@ -38,8 +43,7 @@ export const usePrimarySafe = () => {
         merchantSafes: data?.merchantSafes,
         ...rest,
       }),
-      skip: isLayer1(network) || !accountAddress,
-      // refetchOnFocus: true,
+      skip: isLayer1(network) || !accountAddress || !walletReady,
     }
   );
 

--- a/cardstack/src/screens/ProfileScreen/ProfileScreen.tsx
+++ b/cardstack/src/screens/ProfileScreen/ProfileScreen.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useMemo, useCallback } from 'react';
+import { ActivityIndicator } from 'react-native';
 
 import {
   Button,
@@ -8,6 +9,7 @@ import {
   MerchantContent,
   Text,
 } from '@cardstack/components';
+import { useIsFetchingDataNewAccount } from '@cardstack/hooks';
 import { usePrimarySafe } from '@cardstack/redux/hooks/usePrimarySafe';
 import { isLayer1 } from '@cardstack/utils';
 
@@ -19,8 +21,19 @@ import { CreateProfile, strings } from './components';
 
 const ProfileScreen = () => {
   const { navigate } = useNavigation();
-  const { primarySafe, isFetching, refetch, safesCount } = usePrimarySafe();
+
+  const {
+    primarySafe,
+    isFetching,
+    refetch,
+    safesCount,
+    isLoading,
+    isUninitialized,
+  } = usePrimarySafe();
+
   const { network } = useAccountSettings();
+
+  const isRefreshingForNewAccount = useIsFetchingDataNewAccount(isFetching);
 
   const ProfileBody = useMemo(
     () =>
@@ -36,6 +49,11 @@ const ProfileScreen = () => {
         <CreateProfile isLoading={isFetching} />
       ),
     [primarySafe, isFetching, safesCount, refetch]
+  );
+
+  const showLoading = useMemo(
+    () => isLoading || isUninitialized || isRefreshingForNewAccount,
+    [isLoading, isRefreshingForNewAccount, isUninitialized]
   );
 
   const redirectToSwitchNetwork = useCallback(() => {
@@ -69,6 +87,8 @@ const ProfileScreen = () => {
               {strings.stepOne.switchNetwork}
             </Button>
           </>
+        ) : showLoading ? (
+          <ActivityIndicator size="large" />
         ) : (
           ProfileBody
         )}


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
This PR fixes the switch of accounts reseting the profile, and the loading states,  but while switching accounts, it doesn't keep the up-to-date the previous selected primary safe. Also once the profile is created is doesn't show a loading, so it seems like an error and then refreshes.  So we are not confident enough to release the profile so the tab is hidden for release, until is polished enough to be shipped. 

Completes CS-3703

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Simulator Screen Recording - iPhone 12 Pro - 2022-04-15 at 17 08 04](https://user-images.githubusercontent.com/20520102/163627216-17c79685-f6ad-4b41-ba4c-db842a2e4b74.gif)
![Simulator Screen Recording - iPhone 12 Pro - 2022-04-15 at 17 07 41](https://user-images.githubusercontent.com/20520102/163627217-131ce2a9-7ddf-44f6-9cab-23a3b97f7dec.gif)


