### PR TITLE
[CS-3531] Tags network on Sentry when initializing or switching networks.

### DIFF
--- a/src/redux/settings.js
+++ b/src/redux/settings.js
@@ -59,6 +59,10 @@ export const settingsLoadNetwork = () => async dispatch => {
     const network = await getNetwork();
     const chainId = ethereumUtils.getChainIdFromNetwork(network);
     await etherWeb3SetHttpProvider(network);
+
+    // Creates tag on Sentry labeling the current network.
+    logger.setTag('network', network);
+
     dispatch({
       payload: { chainId, network },
       type: SETTINGS_UPDATE_NETWORK_SUCCESS,
@@ -92,6 +96,8 @@ export const settingsUpdateNetwork = network => async dispatch => {
   try {
     await saveNetwork(network);
     await resetAccountState(dispatch);
+    // Creates tag on Sentry labeling the current network.
+    logger.setTag('network', network);
     RNRestart.Restart(); // restart app so it reloads with updated network
   } catch (error) {
     logger.log('Error updating network settings', error);

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -52,6 +52,7 @@ const Logger = {
       console.warn(...args);
     }
   },
+  setTag: sentryUtils.setTag,
 };
 
 const safelyStringifyWithFormat = data => {

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -1,4 +1,4 @@
-import { addBreadcrumb } from '@sentry/react-native';
+import { addBreadcrumb, setTag } from '@sentry/react-native';
 
 const addInfoBreadcrumb = message =>
   addBreadcrumb({
@@ -24,4 +24,5 @@ export default {
   addDataBreadcrumb,
   addInfoBreadcrumb,
   addNavBreadcrumb,
+  setTag,
 };


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

PR exposes `Sentry.setTag` call through Logger so on wallet initialization and network switching we set the current network, for better debugging in Sentry.

- [x] Completes #(CS-3531)

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/163873531-de2df676-6261-4515-a0e4-b53f69097069.png">

<img width="300" alt="Screen Shot 2022-04-18 at 17 28 38" src="https://user-images.githubusercontent.com/129619/163873550-079e3bf5-b782-41cb-92d4-4c40ec951514.png">

