### PR TITLE
[CS-3668]: Add non auth icon to request submit btn

### DIFF
--- a/cardstack/src/components/Input/FormInput.tsx
+++ b/cardstack/src/components/Input/FormInput.tsx
@@ -1,11 +1,14 @@
 import React, { memo, useEffect, useMemo, useRef } from 'react';
 import { Animated } from 'react-native';
 
+import { Device } from '@cardstack/utils/device';
+
 import { Container } from '../Container';
 import { IconProps } from '../Icon';
 import { Text } from '../Text';
 
 import { Input, InputProps } from './Input';
+import { strings } from './strings';
 
 const baseInputProps: InputProps = {
   borderWidth: 1,
@@ -19,7 +22,7 @@ const baseInputProps: InputProps = {
 type InputVariants = 'valid' | 'error' | 'default';
 
 const baseIconProps: Partial<IconProps> = {
-  top: 12,
+  top: Device.isIOS ? 12 : 13,
   right: 10,
 };
 
@@ -98,7 +101,7 @@ const FormInput = ({
           {label}
         </Text>
         <Text color="borderGray" fontSize={12}>
-          {isRequired ? 'required' : ''}
+          {isRequired ? strings.required : ''}
         </Text>
       </Container>
       <Container backgroundColor="black">

--- a/cardstack/src/components/Input/strings.ts
+++ b/cardstack/src/components/Input/strings.ts
@@ -1,0 +1,3 @@
+export const strings = {
+  required: 'required',
+};

--- a/cardstack/src/hooks/useBiometricIconProps.ts
+++ b/cardstack/src/hooks/useBiometricIconProps.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+
+import { IconProps, IconName } from '@cardstack/components';
+
+import { useBiometryIconName } from '@rainbow-me/hooks';
+
+export const useBiometricIconProps = () => {
+  const iconName = useBiometryIconName();
+
+  const iconProps: IconProps | undefined = useMemo(
+    () => (iconName ? { name: iconName as IconName } : undefined),
+    [iconName]
+  );
+
+  return iconProps;
+};

--- a/cardstack/src/screens/RequestPrepaidCardScreen/RequestPrepaidCardScreen.tsx
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/RequestPrepaidCardScreen.tsx
@@ -12,6 +12,7 @@ import {
   ScrollView,
   Text,
 } from '@cardstack/components';
+import { useBiometricIconProps } from '@cardstack/hooks/useBiometricIconProps';
 
 import CardDropImage from '../../assets/email-drop-card.png';
 
@@ -28,9 +29,12 @@ const RequestPrepaidCardScreen = () => {
     canSubmit,
     inputHasError,
     hasRequested,
+    isAuthenticated,
   } = useRequestPrepaidCardScreen();
 
   const { goBack } = useNavigation();
+
+  const iconProps = useBiometricIconProps();
 
   const renderRequestedState = useMemo(
     () => (
@@ -82,6 +86,7 @@ const RequestPrepaidCardScreen = () => {
                 marginVertical={4}
                 variant={!canSubmit ? 'disabledBlack' : undefined}
                 onPress={onSubmitPress}
+                iconProps={!isAuthenticated ? iconProps : undefined}
               >
                 {strings.button.submit}
               </Button>

--- a/cardstack/src/screens/RequestPrepaidCardScreen/strings.ts
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/strings.ts
@@ -20,4 +20,8 @@ export const strings = {
     title: 'Request Submitted',
     subtitle: 'Check your inbox to verify this request.',
   },
+  input: {
+    label: 'Email address',
+    error: 'The email address is incorrect.',
+  },
 };

--- a/cardstack/src/screens/RequestPrepaidCardScreen/strings.ts
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/strings.ts
@@ -20,8 +20,4 @@ export const strings = {
     title: 'Request Submitted',
     subtitle: 'Check your inbox to verify this request.',
   },
-  input: {
-    label: 'Email address',
-    error: 'The email address is incorrect.',
-  },
 };

--- a/cardstack/src/screens/RequestPrepaidCardScreen/useRequestPrepaidCardScreen.ts
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/useRequestPrepaidCardScreen.ts
@@ -37,5 +37,6 @@ export const useRequestPrepaidCardScreen = () => {
     canSubmit,
     inputHasError,
     hasRequested: false,
+    isAuthenticated: false,
   };
 };

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawConfimation/RewardWithdrawConfimationScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawConfimation/RewardWithdrawConfimationScreen.tsx
@@ -5,18 +5,16 @@ import {
   Container,
   NavigationStackHeader,
   HorizontalDivider,
-  IconProps,
 } from '@cardstack/components';
 import { SectionCoinHeader } from '@cardstack/components/TransactionConfirmationSheet/displays/components/SectionCoinHeader';
 import { SectionHeaderText } from '@cardstack/components/TransactionConfirmationSheet/displays/components/SectionHeaderText';
 import { AmountSection } from '@cardstack/components/TransactionConfirmationSheet/displays/components/sections/AmountSection';
+import { useBiometricIconProps } from '@cardstack/hooks/useBiometricIconProps';
 
 import { SafeSelectionItem } from '../components/SafeSelectionItem';
 
 import { strings } from './strings';
 import { useRewardWithdrawConfimationScreen } from './useRewardWithdrawConfimationScreen';
-
-const iconProps: IconProps = { name: 'face-id' };
 
 const RewardWithdrawConfirmationScreen = () => {
   const {
@@ -27,6 +25,8 @@ const RewardWithdrawConfirmationScreen = () => {
     gasEstimateInEth,
     estimatedNetClaim,
   } = useRewardWithdrawConfimationScreen();
+
+  const iconProps = useBiometricIconProps();
 
   const amountData = useMemo(
     () => [
@@ -75,7 +75,7 @@ const RewardWithdrawConfirmationScreen = () => {
           paddingBottom={6}
         >
           <Button onPress={onCancelPress} variant="smallWhite">
-            Cancel
+            {strings.buttons.cancel}
           </Button>
           <Button
             onPress={onConfirmPress}
@@ -83,7 +83,7 @@ const RewardWithdrawConfirmationScreen = () => {
             iconProps={iconProps}
             disabled={isLoadingGasEstimate}
           >
-            Confirm
+            {strings.buttons.submit}
           </Button>
         </Container>
       </Container>

--- a/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawConfimation/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/flows/RewardWithdraw/RewardWithdrawConfimation/strings.ts
@@ -13,4 +13,8 @@ export const strings = {
     estNet: 'EST. NET WITHDRAW',
   },
   loading: 'Withdrawing reward funds',
+  buttons: {
+    submit: 'Confirm',
+    cancel: 'Cancel',
+  },
 };

--- a/src/hooks/useBiometryType.js
+++ b/src/hooks/useBiometryType.js
@@ -45,7 +45,7 @@ const mapBiometryTypeToIconName = {
   [BiometryTypes.Fingerprint]: 'thumbprint',
   [BiometryTypes.passcode]: 'lock',
   [BiometryTypes.TouchID]: 'thumbprint',
-  [BiometryTypes.none]: null,
+  [BiometryTypes.none]: 'lock',
 };
 
 export const useBiometryIconName = () => {


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds the icon based on the auth flag, also adds a helper to handle the iconProps based on biometry type and fixes a bug on the rewards withdraw where face-id was hardcoded.

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

<img width="500" alt="image" src="https://user-images.githubusercontent.com/20520102/164235832-f507bf2c-6847-4b7e-b22a-1510a7eaab22.png">
