### PR TITLE
[CS-3662] Card drop banner on Wallet tab

### DIFF
--- a/cardstack/src/components/AssetList/AssetList.tsx
+++ b/cardstack/src/components/AssetList/AssetList.tsx
@@ -45,7 +45,7 @@ export const AssetList = () => {
     refreshing,
   } = useAssetList({ sectionListRef });
 
-  const renderPromoBanner = useMemo(() => {
+  const renderCtaBanners = useMemo(() => {
     const topPadding = isTabBarEnabled ? 2 : 0;
     return <RewardsPromoBanner paddingTop={topPadding} />;
   }, [isTabBarEnabled]);
@@ -98,7 +98,7 @@ export const AssetList = () => {
   return (
     <>
       <SectionList
-        ListHeaderComponent={renderPromoBanner}
+        ListHeaderComponent={renderCtaBanners}
         onScrollToIndexFailed={onScrollToIndexFailed}
         ref={sectionListRef}
         refreshControl={

--- a/cardstack/src/components/AssetList/AssetList.tsx
+++ b/cardstack/src/components/AssetList/AssetList.tsx
@@ -45,7 +45,7 @@ export const AssetList = () => {
     refreshing,
   } = useAssetList({ sectionListRef });
 
-  const renderCtaBanners = useMemo(() => {
+  const renderPromoBanner = useMemo(() => {
     const topPadding = isTabBarEnabled ? 2 : 0;
     return <RewardsPromoBanner paddingTop={topPadding} />;
   }, [isTabBarEnabled]);
@@ -98,7 +98,7 @@ export const AssetList = () => {
   return (
     <>
       <SectionList
-        ListHeaderComponent={renderCtaBanners}
+        ListHeaderComponent={renderPromoBanner}
         onScrollToIndexFailed={onScrollToIndexFailed}
         ref={sectionListRef}
         refreshControl={

--- a/cardstack/src/components/Button/Button.tsx
+++ b/cardstack/src/components/Button/Button.tsx
@@ -122,6 +122,7 @@ export const Button = ({
               color={disabled ? 'blueText' : 'black'}
               iconSize="medium"
               marginRight={iconPosition === 'left' ? 3 : 0}
+              marginLeft={iconPosition === 'right' ? 2 : 0}
               {...iconProps}
             />
           )}

--- a/cardstack/src/components/CtaBanner/CtaBanner.tsx
+++ b/cardstack/src/components/CtaBanner/CtaBanner.tsx
@@ -1,4 +1,3 @@
-// import { useNavigation } from '@react-navigation/core';
 import React, { memo } from 'react';
 
 import {
@@ -17,7 +16,7 @@ interface CtaBannerProps extends ContainerProps {
   description: string;
   ctaButtonTitle: string;
   ctaButtonIconName?: IconName;
-  onCtaPressed: () => void;
+  onPress: () => void;
   onDismissPressed?: () => void;
 }
 
@@ -27,7 +26,7 @@ export const CtaBanner = memo(
     description,
     ctaButtonTitle,
     ctaButtonIconName,
-    onCtaPressed,
+    onPress,
     onDismissPressed,
     ...rest
   }: CtaBannerProps) => (
@@ -44,12 +43,13 @@ export const CtaBanner = memo(
         >
           {description}
         </Text>
-        {!!onCtaPressed && (
+        {!!onPress && (
           <Button
             iconProps={ctaButtonIconName && { name: ctaButtonIconName }}
             iconPosition="right"
-            onPress={onCtaPressed}
+            onPress={onPress}
             variant="short"
+            testID="cta-onpress"
           >
             <Text fontSize={13} fontWeight="600">
               {ctaButtonTitle}
@@ -57,13 +57,13 @@ export const CtaBanner = memo(
           </Button>
         )}
       </CenteredContainer>
-
       {!!onDismissPressed && (
         <Touchable
           onPress={onDismissPressed}
           position="absolute"
           right={0}
           padding={4}
+          testID="cta-dismiss"
         >
           <Icon name="x" color="bannerText" size={16} />
         </Touchable>

--- a/cardstack/src/components/CtaBanner/CtaBanner.tsx
+++ b/cardstack/src/components/CtaBanner/CtaBanner.tsx
@@ -16,7 +16,7 @@ interface CtaBannerProps extends ContainerProps {
   title: string;
   description: string;
   ctaButtonTitle: string;
-  ctaButtonIconName: IconName;
+  ctaButtonIconName?: IconName;
   onCtaPressed: () => void;
   onDismissPressed?: () => void;
 }
@@ -46,12 +46,10 @@ export const CtaBanner = memo(
         </Text>
         {!!onCtaPressed && (
           <Button
-            iconProps={{ name: 'wallet' }}
+            iconProps={ctaButtonIconName && { name: ctaButtonIconName }}
             iconPosition="right"
             onPress={onCtaPressed}
-            // variant="small"
-            // height={30}
-            // width={224}
+            variant="short"
           >
             <Text fontSize={13} fontWeight="600">
               {ctaButtonTitle}

--- a/cardstack/src/components/CtaBanner/CtaBanner.tsx
+++ b/cardstack/src/components/CtaBanner/CtaBanner.tsx
@@ -1,0 +1,75 @@
+// import { useNavigation } from '@react-navigation/core';
+import React, { memo } from 'react';
+
+import {
+  Button,
+  Container,
+  ContainerProps,
+  CenteredContainer,
+  Icon,
+  IconName,
+  Text,
+  Touchable,
+} from '@cardstack/components';
+
+interface CtaBannerProps extends ContainerProps {
+  title: string;
+  description: string;
+  ctaButtonTitle: string;
+  ctaButtonIconName: IconName;
+  onCtaPressed: () => void;
+  onDismissPressed?: () => void;
+}
+
+export const CtaBanner = memo(
+  ({
+    title,
+    description,
+    ctaButtonTitle,
+    ctaButtonIconName,
+    onCtaPressed,
+    onDismissPressed,
+    ...rest
+  }: CtaBannerProps) => (
+    <Container backgroundColor="black" {...rest}>
+      <CenteredContainer padding={6}>
+        <Text variant="bannerTitle" color="bannerText" paddingBottom={2}>
+          {title}
+        </Text>
+        <Text
+          variant="bannerDescription"
+          color="bannerText"
+          textAlign="center"
+          paddingBottom={4}
+        >
+          {description}
+        </Text>
+        {!!onCtaPressed && (
+          <Button
+            iconProps={{ name: 'wallet' }}
+            iconPosition="right"
+            onPress={onCtaPressed}
+            // variant="small"
+            // height={30}
+            // width={224}
+          >
+            <Text fontSize={13} fontWeight="600">
+              {ctaButtonTitle}
+            </Text>
+          </Button>
+        )}
+      </CenteredContainer>
+
+      {!!onDismissPressed && (
+        <Touchable
+          onPress={onDismissPressed}
+          position="absolute"
+          right={0}
+          padding={4}
+        >
+          <Icon name="x" color="bannerText" size={16} />
+        </Touchable>
+      )}
+    </Container>
+  )
+);

--- a/cardstack/src/components/CtaBanner/WelcomeCtaBanner.tsx
+++ b/cardstack/src/components/CtaBanner/WelcomeCtaBanner.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
-import { Alert } from 'react-native';
+import { useNavigation } from '@react-navigation/core';
+import React, { useCallback } from 'react';
+
+import Routes from '@rainbow-me/navigation/routesNames';
 
 import { strings } from './strings';
 
@@ -9,6 +11,12 @@ const WELCOME_BANNER_KEY = 'WELCOME_BANNER_KEY';
 
 export const WelcomeCtaBanner = () => {
   const { showBanner, dismissBanner } = useCtaBanner(WELCOME_BANNER_KEY);
+  const { navigate } = useNavigation();
+
+  const onPress = useCallback(() => {
+    navigate(Routes.REQUEST_PREPAID_CARD);
+  }, [navigate]);
+
   if (!showBanner) return null;
 
   return (
@@ -17,7 +25,7 @@ export const WelcomeCtaBanner = () => {
       description={strings.welcome.description}
       ctaButtonTitle={strings.welcome.ctaButtonTitle}
       ctaButtonIconName="wallet"
-      onCtaPressed={() => Alert.alert('🚧 Under development')}
+      onPress={onPress}
       onDismissPressed={dismissBanner}
     />
   );

--- a/cardstack/src/components/CtaBanner/WelcomeCtaBanner.tsx
+++ b/cardstack/src/components/CtaBanner/WelcomeCtaBanner.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Alert } from 'react-native';
+
+import { strings } from './strings';
+
+import { CtaBanner, useCtaBanner } from '.';
+
+const WELCOME_BANNER_KEY = 'WELCOME_BANNER_KEY';
+
+export const WelcomeCtaBanner = () => {
+  const { showBanner, dismissBanner } = useCtaBanner(WELCOME_BANNER_KEY);
+  if (!showBanner) return null;
+
+  return (
+    <CtaBanner
+      title={strings.welcome.title}
+      description={strings.welcome.description}
+      ctaButtonTitle={strings.welcome.ctaButtonTitle}
+      ctaButtonIconName="wallet"
+      onCtaPressed={() => Alert.alert('Welcome')}
+      onDismissPressed={() => Alert.alert('Should dismiss')}
+    />
+  );
+};

--- a/cardstack/src/components/CtaBanner/WelcomeCtaBanner.tsx
+++ b/cardstack/src/components/CtaBanner/WelcomeCtaBanner.tsx
@@ -17,8 +17,8 @@ export const WelcomeCtaBanner = () => {
       description={strings.welcome.description}
       ctaButtonTitle={strings.welcome.ctaButtonTitle}
       ctaButtonIconName="wallet"
-      onCtaPressed={() => Alert.alert('Welcome')}
-      onDismissPressed={() => Alert.alert('Should dismiss')}
+      onCtaPressed={() => Alert.alert('🚧 Under development')}
+      onDismissPressed={dismissBanner}
     />
   );
 };

--- a/cardstack/src/components/CtaBanner/__tests__/useCtaBanner.test.ts
+++ b/cardstack/src/components/CtaBanner/__tests__/useCtaBanner.test.ts
@@ -1,11 +1,12 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { act, renderHook } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react-native';
-import { Linking } from 'react-native';
 
-import { SettingsExternalURLs } from '@cardstack/constants';
+import { SHOW_CTA_BANNER_KEY } from '@cardstack/utils';
 
 import { useCtaBanner } from '../useCtaBanner';
+
+const TEST_KEY = 'TEST_KEY';
 
 describe('useCtaBanner', () => {
   beforeEach(() => {
@@ -15,52 +16,40 @@ describe('useCtaBanner', () => {
 
   afterEach(() => jest.clearAllMocks());
 
-  it('should have showPromoBanner true as default', async () => {
-    const { result } = renderHook(() => useCtaBanner());
+  it('should have showBanner true as default', async () => {
+    const { result } = renderHook(() => useCtaBanner(TEST_KEY));
 
-    await waitFor(() => expect(result.current.showPromoBanner).toEqual(true));
+    await waitFor(() => expect(result.current.showBanner).toEqual(true));
   });
 
   it('should try to get storage item on initial render', async () => {
-    renderHook(() => useCtaBanner());
+    renderHook(() => useCtaBanner(TEST_KEY));
 
     const getItemSpy = jest.spyOn(AsyncStorage, 'getItem');
 
     await waitFor(() => expect(getItemSpy).toBeCalledTimes(1));
 
-    expect(getItemSpy).toBeCalledWith('showPromoBannerKey');
+    expect(getItemSpy).toBeCalledWith(SHOW_CTA_BANNER_KEY + TEST_KEY);
   });
 
-  it('should have showPromoBanner as false if its stored in asyncStorage', async () => {
+  it('should have showBanner as false if its stored in asyncStorage', async () => {
     AsyncStorage.getItem = jest.fn().mockResolvedValue('false');
 
-    const { result } = renderHook(() => useCtaBanner());
+    const { result } = renderHook(() => useCtaBanner(TEST_KEY));
 
-    await waitFor(() => expect(result.current.showPromoBanner).toEqual(false));
+    await waitFor(() => expect(result.current.showBanner).toEqual(false));
   });
 
-  it('should set showPromoBanner to false onPress', async () => {
+  it('should set showBanner to false on dismissBanner', async () => {
     const setItemSpy = jest.spyOn(AsyncStorage, 'setItem');
 
-    const { result } = renderHook(() => useCtaBanner());
+    const { result } = renderHook(() => useCtaBanner(TEST_KEY));
 
-    act(() => result.current.onPress());
+    act(() => result.current.dismissBanner());
 
     await waitFor(() => expect(setItemSpy).toBeCalledTimes(1));
 
-    expect(setItemSpy).toBeCalledWith('showPromoBannerKey', 'false');
-    expect(result.current.showPromoBanner).toEqual(false);
-  });
-
-  it('should open discord URL onPress', async () => {
-    const openURLSpy = jest.spyOn(Linking, 'openURL');
-
-    const { result } = renderHook(() => useCtaBanner());
-
-    act(() => result.current.onPress());
-
-    await waitFor(() => expect(result.current.showPromoBanner).toEqual(false));
-
-    expect(openURLSpy).toBeCalledWith(SettingsExternalURLs.discordInviteLink);
+    expect(setItemSpy).toBeCalledWith(SHOW_CTA_BANNER_KEY + TEST_KEY, 'false');
+    expect(result.current.showBanner).toEqual(false);
   });
 });

--- a/cardstack/src/components/CtaBanner/__tests__/useCtaBanner.test.ts
+++ b/cardstack/src/components/CtaBanner/__tests__/useCtaBanner.test.ts
@@ -2,9 +2,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { act, renderHook } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react-native';
 
+import { useCtaBanner } from '@cardstack/components';
 import { SHOW_CTA_BANNER_KEY } from '@cardstack/utils';
-
-import { useCtaBanner } from '../useCtaBanner';
 
 const TEST_KEY = 'TEST_KEY';
 

--- a/cardstack/src/components/CtaBanner/__tests__/useCtaBanner.test.ts
+++ b/cardstack/src/components/CtaBanner/__tests__/useCtaBanner.test.ts
@@ -1,0 +1,66 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react-native';
+import { Linking } from 'react-native';
+
+import { SettingsExternalURLs } from '@cardstack/constants';
+
+import { useCtaBanner } from '../useCtaBanner';
+
+describe('useCtaBanner', () => {
+  beforeEach(() => {
+    AsyncStorage.getItem = jest.fn().mockResolvedValue(undefined);
+    AsyncStorage.setItem = jest.fn().mockResolvedValue(null);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should have showPromoBanner true as default', async () => {
+    const { result } = renderHook(() => useCtaBanner());
+
+    await waitFor(() => expect(result.current.showPromoBanner).toEqual(true));
+  });
+
+  it('should try to get storage item on initial render', async () => {
+    renderHook(() => useCtaBanner());
+
+    const getItemSpy = jest.spyOn(AsyncStorage, 'getItem');
+
+    await waitFor(() => expect(getItemSpy).toBeCalledTimes(1));
+
+    expect(getItemSpy).toBeCalledWith('showPromoBannerKey');
+  });
+
+  it('should have showPromoBanner as false if its stored in asyncStorage', async () => {
+    AsyncStorage.getItem = jest.fn().mockResolvedValue('false');
+
+    const { result } = renderHook(() => useCtaBanner());
+
+    await waitFor(() => expect(result.current.showPromoBanner).toEqual(false));
+  });
+
+  it('should set showPromoBanner to false onPress', async () => {
+    const setItemSpy = jest.spyOn(AsyncStorage, 'setItem');
+
+    const { result } = renderHook(() => useCtaBanner());
+
+    act(() => result.current.onPress());
+
+    await waitFor(() => expect(setItemSpy).toBeCalledTimes(1));
+
+    expect(setItemSpy).toBeCalledWith('showPromoBannerKey', 'false');
+    expect(result.current.showPromoBanner).toEqual(false);
+  });
+
+  it('should open discord URL onPress', async () => {
+    const openURLSpy = jest.spyOn(Linking, 'openURL');
+
+    const { result } = renderHook(() => useCtaBanner());
+
+    act(() => result.current.onPress());
+
+    await waitFor(() => expect(result.current.showPromoBanner).toEqual(false));
+
+    expect(openURLSpy).toBeCalledWith(SettingsExternalURLs.discordInviteLink);
+  });
+});

--- a/cardstack/src/components/CtaBanner/index.ts
+++ b/cardstack/src/components/CtaBanner/index.ts
@@ -1,0 +1,3 @@
+export * from './CtaBanner';
+export * from './WelcomeCtaBanner';
+export * from './useCtaBanner';

--- a/cardstack/src/components/CtaBanner/strings.ts
+++ b/cardstack/src/components/CtaBanner/strings.ts
@@ -1,0 +1,8 @@
+export const strings = {
+  welcome: {
+    title: 'Welcome to Card Wallet',
+    description:
+      'To get started, request your first prepaid card to create your card.xyz profile.',
+    ctaButtonTitle: 'Request a Prepaid Card',
+  },
+};

--- a/cardstack/src/components/CtaBanner/useCtaBanner.ts
+++ b/cardstack/src/components/CtaBanner/useCtaBanner.ts
@@ -1,0 +1,30 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useEffect, useState } from 'react';
+
+import { SHOW_CTA_BANNER_KEY, useWorker } from '@cardstack/utils';
+
+export const useCtaBanner = (bannerKey: string) => {
+  const [showBanner, setShowBanner] = useState(true);
+
+  const { callback: getShowCtaFlag } = useWorker(async () => {
+    const flag =
+      (await AsyncStorage.getItem(SHOW_CTA_BANNER_KEY + bannerKey)) || 'true';
+
+    setShowBanner(JSON.parse(flag));
+  }, []);
+
+  useEffect(() => {
+    getShowCtaFlag();
+  }, [getShowCtaFlag]);
+
+  const { callback: dismissBanner } = useWorker(async () => {
+    await AsyncStorage.setItem(
+      SHOW_CTA_BANNER_KEY + bannerKey,
+      JSON.stringify(false)
+    );
+
+    setShowBanner(false);
+  }, []);
+
+  return { showBanner, dismissBanner };
+};

--- a/cardstack/src/components/Icon/custom-icons/wallet.tsx
+++ b/cardstack/src/components/Icon/custom-icons/wallet.tsx
@@ -3,7 +3,7 @@ import Svg, { SvgProps, G, Rect, Path } from 'react-native-svg';
 
 const SvgComponent = (props: SvgProps) => (
   <Svg width={20.85} height={15.6} {...props}>
-    <G data-name="icon V2" transform="translate(-.2 -3.2)">
+    <G data-name="icon V2">
       <Rect
         data-name="Rectangle 2869"
         width={18.5}
@@ -11,7 +11,7 @@ const SvgComponent = (props: SvgProps) => (
         rx={3}
         transform="translate(1 4)"
         fill="none"
-        stroke={props.color || '#afafb7'}
+        stroke={props.color || '#6c6cfd'}
         strokeLinecap="round"
         strokeLinejoin="round"
         strokeWidth={1.6}

--- a/cardstack/src/components/index.ts
+++ b/cardstack/src/components/index.ts
@@ -49,4 +49,5 @@ export * from './ProgressSteps';
 export * from './ChoosePrepaidCard';
 export * from './InfoBanner';
 export * from './TabHeader';
+export * from './CtaBanner';
 export { default as RewardsPromoBanner } from './RewardsPromoBanner/RewardsPromoBanner';

--- a/cardstack/src/screens/WalletScreen/WalletScreen.tsx
+++ b/cardstack/src/screens/WalletScreen/WalletScreen.tsx
@@ -29,7 +29,7 @@ export const WalletScreen = () => {
   return (
     <Container backgroundColor="backgroundDarkPurple" flex={1} height="100%">
       <MainHeader title="WALLET" />
-      <WelcomeCtaBanner />
+      {__DEV__ && <WelcomeCtaBanner />}
       <ServiceStatusNotice />
       <BusinessAccountBanner />
       <AssetList />

--- a/cardstack/src/screens/WalletScreen/WalletScreen.tsx
+++ b/cardstack/src/screens/WalletScreen/WalletScreen.tsx
@@ -6,6 +6,7 @@ import {
   Container,
   MainHeader,
   ServiceStatusNotice,
+  WelcomeCtaBanner,
 } from '@cardstack/components';
 import { BusinessAccountBanner } from '@cardstack/components/CollapsibleBanner';
 import { RouteType } from '@cardstack/navigation/types';
@@ -28,6 +29,7 @@ export const WalletScreen = () => {
   return (
     <Container backgroundColor="backgroundDarkPurple" flex={1} height="100%">
       <MainHeader title="WALLET" />
+      <WelcomeCtaBanner />
       <ServiceStatusNotice />
       <BusinessAccountBanner />
       <AssetList />

--- a/cardstack/src/theme/buttonVariants.ts
+++ b/cardstack/src/theme/buttonVariants.ts
@@ -1,5 +1,7 @@
 import { screenWidth } from '../utils/dimension-utils';
 
+import { fontFamilyVariants } from './fontFamilyVariants';
+
 const primary = {
   backgroundColor: 'transparent',
   borderColor: 'borderBlue',
@@ -47,6 +49,16 @@ const extraSmall = {
   textStyle: {
     variant: 'smallButton',
   },
+};
+
+const short = {
+  textStyle: {
+    fontSize: 13,
+    ...fontFamilyVariants.semiBold,
+  },
+  paddingHorizontal: 6,
+  height: 30,
+  width: undefined,
 };
 
 const tiny = {
@@ -157,6 +169,7 @@ export const buttonVariants = {
     },
   },
   small,
+  short,
   white,
   smallBlue: {
     ...small,

--- a/cardstack/src/theme/colors.ts
+++ b/cardstack/src/theme/colors.ts
@@ -106,6 +106,7 @@ export const colors = {
   greenColor: palette.greenColor,
   secondaryText: palette.slateGray,
   tertiaryText: palette.blueText,
+  bannerText: palette.white,
 };
 
 export const avatarColor = [

--- a/cardstack/src/theme/textVariants.ts
+++ b/cardstack/src/theme/textVariants.ts
@@ -47,4 +47,14 @@ export const textVariants = {
     textShadowColor: 'white',
     textShadowRadius: 0,
   },
+  bannerTitle: {
+    fontSize: 16,
+    letterSpacing: 0.4,
+    ...fontFamilyVariants.bold,
+  },
+  bannerDescription: {
+    fontSize: 13,
+    letterSpacing: 0.33,
+    ...fontFamilyVariants.regular,
+  },
 };

--- a/cardstack/src/utils/async-utils.ts
+++ b/cardstack/src/utils/async-utils.ts
@@ -1,3 +1,3 @@
 export const NOTIFICATION_KEY = 'notificationKey';
-export const SHOW_PROMO_BANNER_KEY = 'showPromoBannerKey';
+export const SHOW_CTA_BANNER_KEY = 'showCtaBannerKey';
 export const SHOW_BUSINESS_ACCOUNT_BANNER_KEY = 'showBusinessAccountBannerKey';


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

PR adds a new CtaBanner base component for any kind of simple CtbBanner, and WelcomeCtaBanner for the specific new use case.

It also fixes a padding issue in our custom Wallet SVG icon (looks better in the tab bar too) and adds a new variant to Button comp. called 'short' that can be used for buttons with the new common height of 30pts.

- [x] Completes #(CS-3662)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

https://user-images.githubusercontent.com/129619/164241402-6ded2665-3ee7-4805-a36f-80a051a052cb.mp4
