### PR TITLE
[Improvement]: Add new hub service structure

### DIFF
--- a/cardstack/src/services/hub-service.ts
+++ b/cardstack/src/services/hub-service.ts
@@ -94,6 +94,9 @@ const storeHubAuthToken = async (
   );
 };
 
+export const removeHubAuthToken = (network: Network) =>
+  removeLocal(hubTokenStorageKey(network));
+
 export const getHubAuthToken = async (
   hubURL: string,
   network: Network,

--- a/cardstack/src/services/hub-service.ts
+++ b/cardstack/src/services/hub-service.ts
@@ -7,7 +7,6 @@ import { getFCMToken } from '@cardstack/models/firebase';
 import HDProvider from '@cardstack/models/hd-provider';
 import {
   BusinessIDUniquenessResponse,
-  CustodialWallet,
   Inventory,
   ReservationData,
   OrderData,

--- a/cardstack/src/services/hub-service.ts
+++ b/cardstack/src/services/hub-service.ts
@@ -63,13 +63,17 @@ const hubTokenStorageKey = (network: string): string => {
   return `${HUBTOKEN_KEY}-${network}`;
 };
 
-const loadHubAuthToken = async (
-  tokenStorageKey: string,
-  walletAddress: string
+export const loadHubAuthToken = async (
+  walletAddress: string,
+  network: Network
 ): Promise<string | null> => {
   const {
     data: { authToken },
-  } = ((await getLocal(tokenStorageKey, undefined, walletAddress)) || {
+  } = ((await getLocal(
+    hubTokenStorageKey(network),
+    undefined,
+    walletAddress
+  )) || {
     data: { authToken: null },
   }) as any;
 
@@ -102,10 +106,7 @@ export const getHubAuthToken = async (
   const address = walletAddress || (await loadAddress()) || '';
 
   // Validate if authToken isn't already saved and use it.
-  const savedAuthToken = await loadHubAuthToken(
-    hubTokenStorageKey(network),
-    address
-  );
+  const savedAuthToken = await loadHubAuthToken(address, network);
 
   if (savedAuthToken) {
     return savedAuthToken;

--- a/cardstack/src/services/hub-service.ts
+++ b/cardstack/src/services/hub-service.ts
@@ -274,24 +274,6 @@ export const setNotificationsPreferences = async (
   }
 };
 
-export const getCustodialWallet = async (
-  hubURL: string,
-  authToken: string
-): Promise<CustodialWallet | undefined> => {
-  try {
-    const results = await axios.get(
-      `${hubURL}/api/custodial-wallet`,
-      axiosConfig(authToken)
-    );
-
-    if (results.data?.data) {
-      return await results.data?.data;
-    }
-  } catch (e) {
-    logger.sentry('Error while getting custodial wallet', e);
-  }
-};
-
 export const getInventories = async (
   hubURL: string,
   authToken: string,

--- a/cardstack/src/services/hub/hub-api.ts
+++ b/cardstack/src/services/hub/hub-api.ts
@@ -1,0 +1,30 @@
+import { createApi } from '@reduxjs/toolkit/query/react';
+
+import { CustodialWallet } from '@cardstack/types';
+import { transformObjKeysToCamelCase } from '@cardstack/utils';
+
+import { fetchHubBaseQuery } from './hub-service';
+import { GetCustodialWalletQueryResult } from './hub-types';
+
+const routes = {
+  custodialWallet: '/api/custodial-wallet',
+};
+
+export const hubApi = createApi({
+  reducerPath: 'hubApi',
+  baseQuery: fetchHubBaseQuery,
+  endpoints: builder => ({
+    getCustodialWallet: builder.query<GetCustodialWalletQueryResult, void>({
+      query: () => routes.custodialWallet,
+      transformResponse: (response: { data: CustodialWallet }) => {
+        const attributes = transformObjKeysToCamelCase(
+          response?.data?.attributes
+        );
+
+        return attributes;
+      },
+    }),
+  }),
+});
+
+export const { useGetCustodialWalletQuery } = hubApi;

--- a/cardstack/src/services/hub/hub-service.ts
+++ b/cardstack/src/services/hub/hub-service.ts
@@ -11,7 +11,7 @@ import { Network } from '@rainbow-me/helpers/networkTypes';
 import { AppState } from '@rainbow-me/redux/store';
 import logger from 'logger';
 
-import { getHubAuthToken } from '../hub-service';
+import { getHubAuthToken, removeHubAuthToken } from '../hub-service';
 
 // Helpers
 
@@ -37,14 +37,24 @@ export const fetchHubBaseQuery: BaseQueryFn<
             headers.set('Content-Type', 'application/vnd.api+json');
             headers.set('Accept', 'application/vnd.api+json');
           }
-        } catch (error) {
-          logger.sentry('Error getting hub token', error);
+        } catch (e) {
+          logger.sentry('Error getting hub token', e);
         }
       }
 
       return headers;
     },
   })(args, api, extraOptions);
+
+  const { error } = result;
+
+  if (error) {
+    logger.sentry('Error on hubApi', error);
+
+    if (error?.status === 401) {
+      removeHubAuthToken(network);
+    }
+  }
 
   return result;
 };

--- a/cardstack/src/services/hub/hub-service.ts
+++ b/cardstack/src/services/hub/hub-service.ts
@@ -1,0 +1,50 @@
+import {
+  BaseQueryFn,
+  FetchArgs,
+  fetchBaseQuery,
+  FetchBaseQueryError,
+} from '@reduxjs/toolkit/query/react';
+import { HUB_URL, HUB_URL_STAGING } from 'react-native-dotenv';
+
+import { getNetwork } from '@rainbow-me/handlers/localstorage/globalSettings';
+import { Network } from '@rainbow-me/helpers/networkTypes';
+import { AppState } from '@rainbow-me/redux/store';
+import logger from 'logger';
+
+import { getHubAuthToken } from '../hub-service';
+
+// Helpers
+
+export const fetchHubBaseQuery: BaseQueryFn<
+  string | FetchArgs,
+  unknown,
+  FetchBaseQueryError
+> = async (args, api, extraOptions) => {
+  const network = await getNetwork();
+  const baseUrl = network === Network.xdai ? HUB_URL : HUB_URL_STAGING;
+
+  const result = await fetchBaseQuery({
+    baseUrl,
+    prepareHeaders: async (headers, { getState }) => {
+      const walletAddress = (getState() as AppState).settings.accountAddress;
+
+      if (walletAddress && network) {
+        try {
+          const token = await getHubAuthToken(baseUrl, network, walletAddress);
+
+          if (token) {
+            headers.set('Authorization', `Bearer ${token}`);
+            headers.set('Content-Type', 'application/vnd.api+json');
+            headers.set('Accept', 'application/vnd.api+json');
+          }
+        } catch (error) {
+          logger.sentry('Error getting hub token', error);
+        }
+      }
+
+      return headers;
+    },
+  })(args, api, extraOptions);
+
+  return result;
+};

--- a/cardstack/src/services/hub/hub-types.ts
+++ b/cardstack/src/services/hub/hub-types.ts
@@ -1,0 +1,5 @@
+import { KebabToCamelCaseKeys } from 'globals';
+
+import { CustodialWalletAttrs } from '@cardstack/types';
+
+export type GetCustodialWalletQueryResult = KebabToCamelCaseKeys<CustodialWalletAttrs>;

--- a/cardstack/src/utils/__tests__/formatting-utils.test.ts
+++ b/cardstack/src/utils/__tests__/formatting-utils.test.ts
@@ -1,6 +1,7 @@
 import {
   normalizeTxHash,
   fromWeiToFixedEth,
+  transformObjKeysToCamelCase,
 } from '@cardstack/utils/formatting-utils';
 
 describe('formatting utils', () => {
@@ -36,5 +37,34 @@ describe('formatting utils', () => {
         expect(fromWeiToFixedEth(wei)).toEqual(formatted);
       }
     );
+  });
+
+  describe('transformObjKeysToCamelCase', () => {
+    it('should return object with camelCase keys', () => {
+      const kebabObj = {
+        'first-attr': 'foo',
+        'second-attr': 'bar',
+      };
+
+      const camelCaseObjResult = {
+        firstAttr: 'foo',
+        secondAttr: 'bar',
+      };
+
+      const result = transformObjKeysToCamelCase(kebabObj);
+
+      expect(result).toStrictEqual(camelCaseObjResult);
+    });
+
+    it('should return same object if there is no case difference', () => {
+      const obj = {
+        first: 'foo',
+        second: 'bar',
+      };
+
+      const result = transformObjKeysToCamelCase(obj);
+
+      expect(result).toStrictEqual(obj);
+    });
   });
 });

--- a/cardstack/src/utils/formatting-utils.ts
+++ b/cardstack/src/utils/formatting-utils.ts
@@ -1,5 +1,7 @@
 import { formatCurrencyAmount, fromWei } from '@cardstack/cardpay-sdk';
+import { KebabToCamelCaseKeys } from 'globals';
 import GraphemeSplitter from 'grapheme-splitter';
+import _ from 'lodash';
 
 export const numberWithCommas = (number: string) =>
   number.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
@@ -73,3 +75,8 @@ export const getValidColorHexString = (color?: string) => {
 
 export const fromWeiToFixedEth = (amountInWei: string) =>
   formatCurrencyAmount(fromWei(amountInWei), 2);
+
+export const transformObjKeysToCamelCase = <ObjType>(obj: ObjType) =>
+  Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [_.camelCase(key), value])
+  ) as KebabToCamelCaseKeys<ObjType>;

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -19,3 +19,13 @@ type OptionalUnion<T1, T2> = {
   [P in keyof Omit<T1 & T2, keyof (T1 | T2)>]?: (T1 & T2)[P];
 } &
   (T1 | T2);
+
+type KebabToCamelCase<
+  DashType
+> = DashType extends `${infer First}-${infer Rest}`
+  ? `${First}${KebabToCamelCase<Capitalize<Rest>>}`
+  : DashType;
+
+type KebabToCamelCaseKeys<T> = {
+  [K in keyof T as K extends string ? KebabToCamelCase<K> : K]: T[K];
+};

--- a/package.json
+++ b/package.json
@@ -314,7 +314,7 @@
     "stylelint-processor-styled-components": "^1.10.0",
     "stylelint-react-native": "^2.4.0",
     "ts-jest": "^26.5.5",
-    "typescript": "4.2.3"
+    "typescript": "4.5.5"
   },
   "resolutions": {
     "**/tunnel-agent": "0.6.0",

--- a/src/components/sheet/SlackSheet.js
+++ b/src/components/sheet/SlackSheet.js
@@ -58,7 +58,7 @@ const Whitespace = styled.View`
 
 export default function SlackSheet({
   additionalTopPadding = false,
-  backgroundColor = undefined,
+  backgroundColor = '',
   borderRadius = 30,
   contentHeight = undefined,
   deferredHeight = false,

--- a/src/hooks/useWalletCloudBackup.ts
+++ b/src/hooks/useWalletCloudBackup.ts
@@ -114,7 +114,7 @@ export default function useWalletCloudBackup() {
       // We have the password and we need to add it to an existing backup
       logger.log('password fetched correctly');
 
-      let updatedBackupFile = null;
+      let updatedBackupFile: string | null = null;
       try {
         if (!latestBackup) {
           logger.log(`backing up to ${cloudPlatform}`, wallets[walletId]);

--- a/src/model/backup.ts
+++ b/src/model/backup.ts
@@ -117,7 +117,7 @@ export async function addWalletToCloudBackup(
   password: BackupPassword,
   wallet: RainbowWallet,
   filename: string
-): Promise<boolean> {
+) {
   const backup = await getDataFromCloud(password, filename);
   assert(backup, 'No backup found');
   const now = Date.now();
@@ -135,7 +135,8 @@ export async function addWalletToCloudBackup(
     password,
     filename
   );
-  return !!savedFilename;
+
+  return savedFilename;
 }
 
 export function findLatestBackUp(wallets: AllRainbowWallets): string | null {

--- a/src/raps/actions/unlock.ts
+++ b/src/raps/actions/unlock.ts
@@ -85,6 +85,7 @@ const unlock = async (
       contractAddress,
       gasLimit,
       gasPrice,
+      //@ts-expect-error js function doesn't know walletType
       wallet
     );
     approval = result?.approval;

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -443,7 +443,7 @@ export const assetPricesChanged = message => (dispatch, getState) => {
 
 export const dataAddNewTransaction = (
   txDetails,
-  accountAddressToUpdate = null,
+  accountAddressToUpdate = '',
   disableTxnWatcher = false
 ) => async (dispatch, getState) => {
   const { transactions } = getState().data;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -4,6 +4,7 @@ import { setupListeners } from '@reduxjs/toolkit/dist/query';
 import { persistReducer, persistStore } from 'redux-persist';
 import reducers from './reducers';
 import { primarySafeSliceName } from '@cardstack/redux/primarySafeSlice';
+import { hubApi } from '@cardstack/services/hub/hub-api';
 import { safesApi } from '@cardstack/services/safes-api';
 import { serviceStatusApi } from '@cardstack/services/service-status-api';
 
@@ -19,6 +20,7 @@ const persistConfig = {
 const rootReducer = combineReducers({
   ...reducers,
   [safesApi.reducerPath]: safesApi.reducer,
+  [hubApi.reducerPath]: hubApi.reducer,
   [serviceStatusApi.reducerPath]: serviceStatusApi.reducer,
 });
 
@@ -35,8 +37,9 @@ const store = configureStore({
       serializableCheck: false, // we are currently storing some non-serializable objects in the store including wallet connect objects. it would be nice to fix this.
       immutableCheck: false, // without disabling this, we get a max call stack exceeded when switching from mainnet to xdai. It is likely due to storing an object in redux that has a circular reference to itself.
     });
-    middlewares.push(safesApi.middleware);
-    middlewares.push(serviceStatusApi.middleware);
+    middlewares.push(
+      ...[safesApi.middleware, serviceStatusApi.middleware, hubApi.middleware]
+    );
 
     if (__DEV__) {
       if (enableReduxFlipper) {

--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -134,11 +134,10 @@ export const setIsWalletLoading = val => dispatch => {
   });
 };
 
-export const setWalletBackedUp = (
-  walletId,
-  method,
-  backupFile = null
-) => async (dispatch, getState) => {
+export const setWalletBackedUp = (walletId, method, backupFile = '') => async (
+  dispatch,
+  getState
+) => {
   const { wallets, selected } = getState().wallets;
   const newWallets = { ...wallets };
   newWallets[walletId] = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -91,7 +91,8 @@
       "react-native-shadow-stack": ["src/react-native-shadow-stack"]
     },
     "resolveJsonModule": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "useUnknownInCatchVariables": false
   },
   "exclude": [
     "ios",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20780,10 +20780,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
-  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+typescript@4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 typescript@^3.0.3, typescript@^3.8.3, typescript@^3.9.5, typescript@^3.9.7:
   version "3.9.7"


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds the initial new structure of the hub api using RTK Query, automatically handling token headers and auth errors. It migrates one of the services as example, CustodialWallet, most of the keys from the api are kebab case, which might make accessing the properties a bit annoying, so I added some type and function helpers to transform kebab to camel case, we can discuss it if it helps or it's just over engineering but, the custodialWallet was refactored with those helpers. In order to have the recursive types, a typescript update was needed, which probably fixes CS-3695 (Ts caught that we were passing a boolean where it should actually be a filename, so hopefully this issue is fixed).

