### PR TITLE
[CS-3669] - Handle submit request to email card drop

### DIFF
--- a/cardstack/src/screens/RequestPrepaidCardScreen/RequestPrepaidCardScreen.tsx
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/RequestPrepaidCardScreen.tsx
@@ -31,6 +31,7 @@ const RequestPrepaidCardScreen = () => {
     hasRequested,
     isAuthenticated,
     email,
+    isLoading,
   } = useRequestPrepaidCardScreen();
 
   const { goBack } = useNavigation();
@@ -81,12 +82,15 @@ const RequestPrepaidCardScreen = () => {
                 autoCapitalize="none"
                 returnKeyType="done"
                 value={email}
+                editable={!isLoading}
               />
               <Button
                 marginVertical={4}
                 variant={!canSubmit ? 'disabledBlack' : undefined}
                 onPress={onSubmitPress}
                 iconProps={!isAuthenticated ? iconProps : undefined}
+                disablePress={isLoading}
+                loading={isLoading}
               >
                 {strings.button.submit}
               </Button>

--- a/cardstack/src/services/hub/hub-api.ts
+++ b/cardstack/src/services/hub/hub-api.ts
@@ -3,11 +3,15 @@ import { createApi } from '@reduxjs/toolkit/query/react';
 import { CustodialWallet } from '@cardstack/types';
 import { transformObjKeysToCamelCase } from '@cardstack/utils';
 
-import { fetchHubBaseQuery } from './hub-service';
-import { GetCustodialWalletQueryResult } from './hub-types';
+import { fetchHubBaseQuery, hubBodyBuilder } from './hub-service';
+import {
+  GetCustodialWalletQueryResult,
+  RequestCardDropQueryParams,
+} from './hub-types';
 
 const routes = {
-  custodialWallet: '/api/custodial-wallet',
+  custodialWallet: '/custodial-wallet',
+  emailDrop: '/email-card-drop-requests',
 };
 
 export const hubApi = createApi({
@@ -24,7 +28,19 @@ export const hubApi = createApi({
         return attributes;
       },
     }),
+    requestEmailCardDrop: builder.mutation<void, RequestCardDropQueryParams>({
+      query: ({ email }) => ({
+        url: routes.emailDrop,
+        method: 'POST',
+        body: hubBodyBuilder(routes.emailDrop, {
+          email,
+        }),
+      }),
+    }),
   }),
 });
 
-export const { useGetCustodialWalletQuery } = hubApi;
+export const {
+  useGetCustodialWalletQuery,
+  useRequestEmailCardDropMutation,
+} = hubApi;

--- a/cardstack/src/services/hub/hub-service.ts
+++ b/cardstack/src/services/hub/hub-service.ts
@@ -21,16 +21,16 @@ export const fetchHubBaseQuery: BaseQueryFn<
   FetchBaseQueryError
 > = async (args, api, extraOptions) => {
   const network = await getNetwork();
-  const baseUrl = network === Network.xdai ? HUB_URL : HUB_URL_STAGING;
+  const hubUrl = network === Network.xdai ? HUB_URL : HUB_URL_STAGING;
 
   const result = await fetchBaseQuery({
-    baseUrl,
+    baseUrl: `${hubUrl}/api`,
     prepareHeaders: async (headers, { getState }) => {
       const walletAddress = (getState() as AppState).settings.accountAddress;
 
       if (walletAddress && network) {
         try {
-          const token = await getHubAuthToken(baseUrl, network, walletAddress);
+          const token = await getHubAuthToken(hubUrl, network, walletAddress);
 
           if (token) {
             headers.set('Authorization', `Bearer ${token}`);
@@ -58,3 +58,11 @@ export const fetchHubBaseQuery: BaseQueryFn<
 
   return result;
 };
+
+export const hubBodyBuilder = <Attrs>(path: string, attributes: Attrs) =>
+  JSON.stringify({
+    data: {
+      type: path.replace('/', ''),
+      attributes,
+    },
+  });

--- a/cardstack/src/services/hub/hub-types.ts
+++ b/cardstack/src/services/hub/hub-types.ts
@@ -3,3 +3,7 @@ import { KebabToCamelCaseKeys } from 'globals';
 import { CustodialWalletAttrs } from '@cardstack/types';
 
 export type GetCustodialWalletQueryResult = KebabToCamelCaseKeys<CustodialWalletAttrs>;
+
+export interface RequestCardDropQueryParams {
+  email: string;
+}


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds the mutation to request a card drop, also it adds the `hubBodyBuilder` 💪  helper to facilitate building the body on next requests.

Missing pieces, we still need to update the data after posting to this URL, but it's not so trivial since this is a different api than the safes, or hub-public one, so, still need to think what is the best way to do that, we could also think about adding some transition animation, but that's a nice to have we can add later.

### Screenshots

![Simulator Screen Recording - iPhone 11 - 2022-04-25 at 18 22 13](https://user-images.githubusercontent.com/20520102/165177288-17f3f315-a45a-4d90-9e64-9f4e87de5042.gif)

