### PR TITLE
[CS-3555] OpenSea API Key

### DIFF
--- a/cardstack/src/services/opensea-api.ts
+++ b/cardstack/src/services/opensea-api.ts
@@ -1,6 +1,7 @@
 import { NativeCurrency } from '@cardstack/cardpay-sdk';
 import axios, { AxiosResponse } from 'axios';
 import { isNil, pick } from 'lodash';
+import { OPENSEA_API_KEY } from 'react-native-dotenv';
 
 import { CollectibleType } from '@cardstack/types';
 
@@ -14,6 +15,7 @@ export const OPENSEA_LIMIT_TOTAL = 2000;
 const api = axios.create({
   headers: {
     Accept: 'application/json',
+    'X-API-KEY': OPENSEA_API_KEY,
   },
   timeout: 20000, // 20 secs
 });

--- a/cardstack/src/types/react-native-dotenv.d.ts
+++ b/cardstack/src/types/react-native-dotenv.d.ts
@@ -21,4 +21,5 @@ declare module 'react-native-dotenv' {
   export const HUB_URL_STAGING: string;
   export const STATUS_API_BASE_URL: string;
   export const VERSION_TAP_COUNT: string;
+  export const OPENSEA_API_KEY: string;
 }


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds a new `OPENSEA_API_KEY` env var (already sync'd) and uses it in `opensea-api` calls. Hopefully, this will avoid issues while pulling collections from Opensea (several reports on sentry issue CARDWALLET-MOBILE-4Q).

- [x] Completes #(CS-3555)
