### PR TITLE
[CS-3027]: Fix assets not loading on fresh start and other issues

### DIFF
--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -312,3 +312,12 @@ export const navigationStateNewWallet = {
     },
   ],
 };
+
+export const navigationStateInit = {
+  index: 0,
+  routes: [
+    {
+      name: RainbowRoutes.WELCOME_SCREEN,
+    },
+  ],
+};

--- a/cardstack/src/screens/sheets/ImportSeed/useImportSeedSheet.tsx
+++ b/cardstack/src/screens/sheets/ImportSeed/useImportSeedSheet.tsx
@@ -195,9 +195,12 @@ const useImportFromProfileModal = (
           checkedWallet,
         });
 
-        dismissLoadingOverlay();
         // Early return to not dismiss the sheet on error
-        if (!wallet) return;
+        if (!wallet) {
+          dismissLoadingOverlay();
+
+          return;
+        }
 
         InteractionManager.runAfterInteractions(async () => {
           // Fresh imported wallet
@@ -244,7 +247,6 @@ const useImportFromProfileModal = (
     name => {
       navigate(Routes.MODAL_SCREEN, {
         actionType: 'Import',
-        additionalPadding: true,
         asset: [],
         isNewProfile: true,
         onCloseModal: handleImportAccountOnCloseModal,

--- a/src/components/change-wallet/WalletList.js
+++ b/src/components/change-wallet/WalletList.js
@@ -93,16 +93,16 @@ export default function WalletList({
     const sortedKeys = Object.keys(allWallets).sort();
     sortedKeys.forEach(key => {
       const wallet = allWallets[key];
-      const filteredAccounts = wallet.addresses.filter(
-        account => !!account.visible
-      );
-      filteredAccounts.forEach(account => {
+
+      const accounts = wallet.addresses;
+
+      accounts.forEach(account => {
         const row = {
           ...account,
           editMode,
           height: rowHeight,
           id: account.address,
-          isOnlyAddress: filteredAccounts.length === 1,
+          isOnlyAddress: accounts.length === 1,
           isReadOnly: wallet.type === WalletTypes.readOnly,
           isSelected:
             accountAddress === account.address &&

--- a/src/components/send/SendContactList.js
+++ b/src/components/send/SendContactList.js
@@ -68,7 +68,6 @@ export default function SendContactList({
   const handleEditContact = useCallback(
     ({ address, color, nickname }) => {
       navigate(Routes.MODAL_SCREEN, {
-        additionalPadding: true,
         address,
         color,
         contact: { address, color, nickname },

--- a/src/components/settings-menu/BackupSection/WalletSelectionView.js
+++ b/src/components/settings-menu/BackupSection/WalletSelectionView.js
@@ -61,9 +61,9 @@ const WalletSelectionView = () => {
         .filter(key => wallets[key].type !== WalletTypes.readOnly)
         .map(key => {
           const wallet = wallets[key];
-          const visibleAccounts = wallet.addresses.filter(a => a.visible);
-          const account = visibleAccounts[0];
-          const totalAccounts = visibleAccounts.length;
+          const accounts = wallet.addresses;
+          const account = accounts[0];
+          const totalAccounts = accounts.length;
           const { color, label, address } = account;
           if (wallet.backupType === WalletBackupTypes.cloud) {
             cloudBackedUpWallets += 1;

--- a/src/handlers/walletReadyEvents.js
+++ b/src/handlers/walletReadyEvents.js
@@ -24,19 +24,14 @@ export const runWalletBackupStatusChecks = () => {
   const state = store.getState();
   const { selected, wallets } = state.wallets;
 
-  // count how many visible, non-imported and non-readonly wallets are not backed up
-  const rainbowWalletsNotBackedUp = filter(wallets, wallet => {
-    const hasVisibleAccount = find(
-      wallet.addresses,
-      account => account.visible
-    );
-    return (
+  // count how many non-imported and non-readonly wallets are not backed up
+  const rainbowWalletsNotBackedUp = filter(
+    wallets,
+    wallet =>
       !wallet.imported &&
-      hasVisibleAccount &&
       wallet.type !== WalletTypes.readOnly &&
       !wallet.backedUp
-    );
-  });
+  );
 
   if (!rainbowWalletsNotBackedUp.length) return;
 

--- a/src/hooks/useWalletManager.ts
+++ b/src/hooks/useWalletManager.ts
@@ -31,6 +31,10 @@ import { saveAccountEmptyState } from '@rainbow-me/handlers/localstorage/account
 import { setCurrencyConversionRates } from '@rainbow-me/redux/currencyConversion';
 import logger from 'logger';
 
+interface initializeWalleOptions {
+  skipDismissOverlay?: boolean;
+}
+
 export default function useWalletManager() {
   const dispatch = useDispatch();
 
@@ -44,7 +48,7 @@ export default function useWalletManager() {
   const { dismissLoadingOverlay } = useLoadingOverlay();
 
   const initializeWallet = useCallback(
-    async (seedPhrase?: string) => {
+    async (seedPhrase?: string, options?: initializeWalleOptions) => {
       try {
         logger.sentry('Start wallet init');
 
@@ -68,6 +72,7 @@ export default function useWalletManager() {
         const walletAddress = await loadAddress();
 
         if (isNil(walletAddress)) {
+          logger.sentry('[initializeWallet] - walletAddress null');
           dispatch(appStateUpdate({ walletReady: true }));
           return null;
         }
@@ -92,7 +97,7 @@ export default function useWalletManager() {
 
         return null;
       } finally {
-        dismissLoadingOverlay();
+        if (!options?.skipDismissOverlay) dismissLoadingOverlay();
         dispatch(appStateUpdate({ walletReady: true }));
       }
     },
@@ -136,7 +141,7 @@ export default function useWalletManager() {
       try {
         const wallet = await createOrImportWallet(params);
 
-        await initializeWallet(params.seed);
+        await initializeWallet(params.seed, { skipDismissOverlay: true });
 
         return wallet;
       } catch (e) {

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -730,6 +730,9 @@ export const createOrImportWallet = async ({
     await saveAllWallets(allWallets);
     logger.sentry('[createWallet] - saveAllWallets');
 
+    await saveAddress(walletAddress);
+    logger.sentry('[createWallet] - saveAddress');
+
     if (walletResult && walletAddress) {
       // bip39 are derived from mnemioc
       const createdWallet =
@@ -959,7 +962,14 @@ export const generateAccount = async (
 };
 
 export const cleanUpWalletKeys = async (): Promise<boolean> => {
-  const keys = [addressKey, allWalletsKey, pinKey, selectedWalletKey];
+  const keys = [
+    addressKey,
+    allWalletsKey,
+    pinKey,
+    selectedWalletKey,
+    seedPhraseKey,
+    privateKeyKey,
+  ];
 
   try {
     await Promise.all(

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -109,7 +109,6 @@ interface RainbowAccount {
   address: EthereumAddress;
   avatar: null | string;
   color: number;
-  visible: boolean;
 }
 
 export interface RainbowWallet {
@@ -449,7 +448,7 @@ export const getWalletByAddress = ({
         someWallet.addresses,
         account =>
           toChecksumAddress(account.address) ===
-            toChecksumAddress(walletAddress) && account.visible
+          toChecksumAddress(walletAddress)
       )
   );
 
@@ -526,7 +525,7 @@ const addAccountsWithTxHistory = async (
     let label = '';
 
     if (discoveredAccount && discoveredWalletId) {
-      if (discoveredAccount.visible) {
+      if (discoveredAccount) {
         color = discoveredAccount.color;
         label = discoveredAccount.label ?? '';
       }
@@ -560,7 +559,6 @@ const addAccountsWithTxHistory = async (
         color,
         index,
         label,
-        visible: true,
       });
       index++;
     } else {
@@ -680,7 +678,6 @@ export const createOrImportWallet = async ({
       color: color ?? getRandomColor(),
       index: 0,
       label: name || '',
-      visible: true,
     });
 
     // For HDWallet we check to add derived accounts

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -48,7 +48,7 @@ const getWalletRowCount = wallets => {
   if (wallets) {
     Object.keys(wallets).forEach(key => {
       // Addresses
-      count += wallets[key].addresses.filter(account => account.visible).length;
+      count += wallets[key].addresses.length;
     });
   }
   return count;

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -31,7 +31,7 @@ import {
 import { getRandomColor } from '../styles/colors';
 import { Container, Sheet, Text, Touchable } from '@cardstack/components';
 import { removeFCMToken } from '@cardstack/models/firebase';
-import { useLoadingOverlay } from '@cardstack/navigation';
+import { navigationStateInit, useLoadingOverlay } from '@cardstack/navigation';
 import { getAddressPreview } from '@cardstack/utils';
 import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
 import {
@@ -59,7 +59,7 @@ export default function ChangeWalletSheet() {
   const [editMode, setEditMode] = useState(false);
   const { colors } = useTheme();
 
-  const { goBack, navigate, replace } = useNavigation();
+  const { goBack, navigate, reset } = useNavigation();
   const dispatch = useDispatch();
   const { accountAddress } = useAccountSettings();
   const {
@@ -133,32 +133,29 @@ export default function ChangeWalletSheet() {
   const deleteWallet = useCallback(
     async (walletId, address) => {
       try {
-        const newWallets = {
+        const allWallets = {
           ...wallets,
           [walletId]: {
             ...wallets[walletId],
-            addresses: wallets[walletId].addresses.map(account =>
-              toLower(account.address) === toLower(address)
-                ? { ...account, visible: false }
-                : account
+            addresses: wallets[walletId].addresses.filter(
+              account => toLower(account.address) !== toLower(address)
             ),
           },
         };
-        // If there are no visible wallets
-        // then delete the wallet
-        const hasVisibleAddresses = newWallets[walletId].addresses.some(
-          account => account.visible
-        );
+
+        const { [walletId]: currentWallet, ...otherWallets } = allWallets;
+
+        // If there are no accounts left on wallet
+        // remove the wallet
+        const isCurrentWalletEmpty = !currentWallet.addresses.length;
+
+        const updatedWallets = isCurrentWalletEmpty ? otherWallets : allWallets;
 
         // unregister in hub and remove fcm for this account from asyncStorage
         await removeFCMToken(address);
-        if (!hasVisibleAddresses) {
-          delete newWallets[walletId];
-          await dispatch(walletsUpdate(newWallets));
-        } else {
-          await dispatch(walletsUpdate(newWallets));
-        }
         await removeWalletData(address);
+
+        await dispatch(walletsUpdate(updatedWallets));
       } catch (e) {
         logger.sentry('Error deleting account', e);
       }
@@ -217,24 +214,7 @@ export default function ChangeWalletSheet() {
 
   const onEditWallet = useCallback(
     (walletId, address, label) => {
-      // If there's more than 1 account
-      // it's deletable
-      let isLastAvailableWallet = false;
-      for (let i = 0; i < Object.keys(wallets).length; i++) {
-        const key = Object.keys(wallets)[i];
-        const someWallet = wallets[key];
-        const otherAccount = someWallet.addresses.find(
-          account => account.visible && account.address !== address
-        );
-        if (otherAccount) {
-          isLastAvailableWallet = true;
-          break;
-        }
-      }
-
-      const buttons = ['Edit Account'];
-      buttons.push('Delete Account');
-      buttons.push('Cancel');
+      const buttons = ['Edit Account', 'Delete Account', 'Cancel'];
 
       showActionSheetWithOptions(
         {
@@ -262,32 +242,46 @@ export default function ChangeWalletSheet() {
                     title: WalletLoadingStates.DELETING_WALLET,
                   });
 
+                  const otherAccounts = Object.keys(wallets).reduce(
+                    (acc, walletKey) => {
+                      const account = wallets[walletKey].addresses.find(
+                        account => account.address !== address
+                      );
+                      if (account) {
+                        acc.push({ ...account, walletKey });
+                      }
+                      return acc;
+                    },
+                    []
+                  );
+
                   await deleteWallet(walletId, address);
+
                   ReactNativeHapticFeedback.trigger('notificationSuccess');
 
-                  if (!isLastAvailableWallet) {
+                  const isLastAvailableWallet = !otherAccounts.length;
+
+                  if (isLastAvailableWallet) {
                     await cleanUpWalletKeys();
+
                     dismissLoadingOverlay();
 
                     // Dismiss change wallet
                     goBack();
-                    replace(Routes.WELCOME_SCREEN);
+
+                    reset(navigationStateInit);
                   } else {
                     // If we're deleting the selected wallet
                     // we need to switch to another one
                     if (address === currentAddress) {
-                      for (let i = 0; i < Object.keys(wallets).length; i++) {
-                        const key = Object.keys(wallets)[i];
-                        const someWallet = wallets[key];
-                        const found = someWallet.addresses.find(
-                          account =>
-                            account.visible && account.address !== address
-                        );
+                      const eligibleAccount = otherAccounts[0];
 
-                        if (found) {
-                          await onChangeAccount(key, found.address, true);
-                          break;
-                        }
+                      if (eligibleAccount) {
+                        await onChangeAccount(
+                          eligibleAccount.walletKey,
+                          eligibleAccount.address,
+                          true
+                        );
                       }
                     }
                   }
@@ -307,7 +301,7 @@ export default function ChangeWalletSheet() {
       goBack,
       onChangeAccount,
       renameWallet,
-      replace,
+      reset,
       showLoadingOverlay,
       wallets,
     ]


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
This PR fixes some issues related to importing, deleting and loading a new account 

- Fixes keyboard delayed dismissal while importing an account from fresh state, by handling the dismissOverlay differently for this case
- Resets the navigation state after deleting all the wallets
- Improves the delete wallet code by iterating only once to found accounts,  and using spread to handle the proprieties instead of the delete operator 
- Removes 'visible' property of account, as it seems this was used only for "deleting" the accounts, so instead of deleting  they were hidden, now we truly delete the accounts 
- Fixes the Create account modal padding, as it was covering the status bar 
- Fixes missing deleting keys 
- Fixes assets not loading on fresh start, (the address was not being while creating the wallet, so the first time it ran though initializeWallet, the address was empty, and the wallet was not properly initialized)

I validate most of the scenarios on iOS, like deleting multiple accounts, multiple wallets, initial state, so I do recommend testing ,  especially on Android as I did just small tests.

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

Fresh assets import loading and keyboard handling:
![Simulator Screen Recording - iPhone SE (3rd generation) - 2022-04-27 at 19 08 19](https://user-images.githubusercontent.com/20520102/165639324-b16020c8-7393-41ae-b4dc-f7fa694b99ad.gif)

Create account modal, proper positioning:
<img width="250" alt="image" src="https://user-images.githubusercontent.com/20520102/165639469-60985472-a5fa-45c4-8b50-a2d6638266fa.png">
