### PR TITLE
[CS-3752, CS-3632] Disabling forceful dark mode on android

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowDisablePreview">true</item>
-        
+        <item name="android:forceDarkAllowed">false</item>
     </style>
     <style name="NoActionBar" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="colorPrimaryDark">@color/primary_dark</item>

--- a/cardstack/src/components/QRCode/StyledQRCode.tsx
+++ b/cardstack/src/components/QRCode/StyledQRCode.tsx
@@ -25,7 +25,7 @@ export const StyledQRCode = memo(({ value, addLogo = true }: QRCodeParam) => {
 
   return (
     <CenteredContainer
-      backgroundColor="white"
+      backgroundColor="grayCardBackground"
       borderRadius={crosshair.radius}
       borderWidth={1}
       borderColor="borderGray"


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Attempt to fix Xiaomi (MIUI) from forcing set dark mode. On tests, it did work on new installs but not on just updating.

Also, I noticed that this forceful dark mode only switches full white and full black colors, setting an off-white color to StyledQRCode will prevent the color switch even if the config change is bypassed.

- [x] Completes #(CS-3752)
- [x] Completes #(CS-3632)
