### PR TITLE
Fix merchant claim 

### DIFF
--- a/cardstack/src/services/merchant/merchant-service.ts
+++ b/cardstack/src/services/merchant/merchant-service.ts
@@ -41,7 +41,7 @@ export const claimMerchantRevenue = async ({
 
     const claimAmount = new BigNumber(Web3.utils.toWei(token.balance.amount))
       .minus(new BigNumber(gasEstimate))
-      .toString();
+      .toFixed();
 
     await revenuePool.claim(
       merchantSafeAddress,

--- a/cardstack/src/services/merchant/merchant-service.ts
+++ b/cardstack/src/services/merchant/merchant-service.ts
@@ -30,7 +30,7 @@ export const claimMerchantRevenue = async ({
     // divide amount by 2 for estimate since we can't estimate the full amount
     // and the amount doesn't affect the gas price
     const claimEstimateAmount = Web3.utils.toWei(
-      new BigNumber(token.balance.amount).div(new BigNumber('2')).toString()
+      new BigNumber(token.balance.amount).div(new BigNumber('2')).toFixed()
     );
 
     const gasEstimate = await revenuePool.claimGasEstimate(

--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -169,7 +169,7 @@ export const estimateTransferNFTGas = async (
       params.id
     );
     if (!addPadding) {
-      return contractEstGas.toString();
+      return contractEstGas.toFixed();
     }
 
     return addPaddingToGasEstimate(contractEstGas, paddingFactor, provider);
@@ -245,7 +245,7 @@ export const estimateGasWithPadding = async (
  */
 export const toWei = ether => {
   const result = parseEther(ether);
-  return result.toString();
+  return result.toFixed();
 };
 
 /**

--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -169,7 +169,7 @@ export const estimateTransferNFTGas = async (
       params.id
     );
     if (!addPadding) {
-      return contractEstGas.toFixed();
+      return contractEstGas.toString();
     }
 
     return addPaddingToGasEstimate(contractEstGas, paddingFactor, provider);


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

Fix merchant claim that returns `invalid character` error 

### Description

The function of `toString` within `bignumber.js` is problematic. If an explicit config is not set, it will return a string representation in exponential notation.

```
const { BigNumber, isBigNumber } = require("bignumber.js");
const web3 = require("web3")
let o = "1000000000000000000000" // 21 decimal places it turns into exponential notation 
o = new BigNumber(o)
console.log(o.toString()) //1e+21
console.log(o.toFixed()) //1000000000000000000000
```

See [here](https://mikemcl.github.io/bignumber.js/#exponential-at). 

- [x] [Completes #(Linear ticket)](https://linear.app/cardstack/issue/CS-3719/invalid-character-revenue-claim#comment-54377b6a)



