### PR TITLE
[Refactor] Removes toWei function in web3

### DIFF
--- a/cardstack/src/helpers/fallbackExplorerHelper.ts
+++ b/cardstack/src/helpers/fallbackExplorerHelper.ts
@@ -5,13 +5,13 @@ import {
   convertAmountToNativeDisplay,
 } from '@cardstack/cardpay-sdk';
 import { toLower } from 'lodash';
+import Web3 from 'web3';
 
 import { getNativeBalanceFromOracle } from '@cardstack/services';
 import { getOnChainAssetBalance } from '@cardstack/services/assets';
 import { AssetType, AssetWithNativeType, BalanceType } from '@cardstack/types';
 import { isCPXDToken } from '@cardstack/utils/cardpay-utils';
 
-import { toWei } from '@rainbow-me/handlers/web3';
 import { Network } from '@rainbow-me/helpers/networkTypes';
 
 interface Prices {
@@ -105,7 +105,7 @@ export const addPriceByCoingeckoIdOrOracle = async ({
     try {
       const priceUnit = await getNativeBalanceFromOracle({
         ...tokenInfo,
-        balance: toWei('1'),
+        balance: Web3.utils.toWei('1'),
       });
 
       const priceFromOracle = {

--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -15,9 +15,9 @@ import { isHexString as isEthersHexString } from '@ethersproject/bytes';
 import { Contract } from '@ethersproject/contracts';
 import { isValidMnemonic as ethersIsValidMnemonic } from '@ethersproject/hdnode';
 import { Web3Provider } from '@ethersproject/providers';
-import { parseEther } from '@ethersproject/units';
 import UnstoppableResolution from '@unstoppabledomains/resolution';
 import { get, startsWith } from 'lodash';
+import Web3 from 'web3';
 
 import AssetTypes from '../helpers/assetTypes';
 import NetworkTypes from '../helpers/networkTypes';
@@ -239,16 +239,6 @@ export const estimateGasWithPadding = async (
 };
 
 /**
- * @desc convert from ether to wei
- * @param  {String} value in ether
- * @return {String} value in wei
- */
-export const toWei = ether => {
-  const result = parseEther(ether);
-  return result.toString();
-};
-
-/**
  * @desc get transaction info
  * @param {String} hash
  * @return {Promise}
@@ -271,7 +261,9 @@ export const getTransactionCount = address =>
 export const getTxDetails = async transaction => {
   const { to } = transaction;
   const data = transaction.data ? transaction.data : '0x';
-  const value = transaction.amount ? toHex(toWei(transaction.amount)) : '0x00';
+  const value = transaction.amount
+    ? toHex(Web3.utils.toWei(transaction.amount))
+    : '0x00';
   const gasLimit = toHex(transaction.gasLimit) || undefined;
   const gasPrice = toHex(transaction.gasPrice) || undefined;
   const tx = {


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Removes function that was being used once in favor of `Web3.utils.toWei`, it also avoids issues with Wei toString conversions.
