### PR TITLE
[CS-3818] UX improvements on Asset Lists and assorted screens on Tab bar

### DIFF
--- a/cardstack/src/components/AssetList/AssetList.tsx
+++ b/cardstack/src/components/AssetList/AssetList.tsx
@@ -1,10 +1,5 @@
 import React, { useCallback, createRef, useMemo } from 'react';
-import {
-  RefreshControl,
-  SectionList,
-  ActivityIndicator,
-  StyleSheet,
-} from 'react-native';
+import { RefreshControl, SectionList, ActivityIndicator } from 'react-native';
 
 import { Container, Text, RewardsPromoBanner } from '@cardstack/components';
 import { PinHideOptionsFooter } from '@cardstack/components/PinnedHiddenSection';

--- a/cardstack/src/components/AssetList/AssetList.tsx
+++ b/cardstack/src/components/AssetList/AssetList.tsx
@@ -19,12 +19,6 @@ import AssetSectionHeader from './components/AssetSectionHeader';
 import { strings } from './strings';
 import { useAssetList } from './useAssetList';
 
-const styles = StyleSheet.create({
-  contentContainer: {
-    paddingBottom: 180,
-  },
-});
-
 // We need to pass this prop if the section to scrollTo is not on viewport
 const onScrollToIndexFailed = () => {
   logger.log('onScrollToIndexFailed');
@@ -112,7 +106,6 @@ export const AssetList = () => {
         renderItem={renderItem}
         renderSectionFooter={renderSectionFooter}
         renderSectionHeader={renderSectionHeader}
-        contentContainerStyle={styles.contentContainer}
       />
       <PinHideOptionsFooter />
     </>

--- a/cardstack/src/components/MerchantContent/MerchantContent.tsx
+++ b/cardstack/src/components/MerchantContent/MerchantContent.tsx
@@ -111,12 +111,6 @@ export const MerchantContent = memo(
             emptyText={strings.noAvailableBalance}
             tokens={merchantSafe.tokens}
           />
-          <MerchantTokensList
-            title={strings.availableBalance}
-            onPress={onPressGoTo(ExpandedMerchantRoutes.availableBalances)}
-            emptyText={strings.noAvailableBalance}
-            tokens={merchantSafe.tokens}
-          />
           <Container paddingBottom={4} />
         </ScrollView>
       </Container>

--- a/cardstack/src/components/MerchantContent/MerchantContent.tsx
+++ b/cardstack/src/components/MerchantContent/MerchantContent.tsx
@@ -17,11 +17,6 @@ import Routes from '@rainbow-me/routes';
 
 import { strings } from './strings';
 
-const HORIZONTAL_PADDING = 5;
-// For avoiding occlusing the network tag.
-// This needs to be removed once we're good with the new tab bar.
-const BOTTOM_PADDING = 260;
-
 export enum ExpandedMerchantRoutes {
   lifetimeEarnings = 'lifetimeEarnings',
   availableBalances = 'availableBalances',
@@ -78,12 +73,10 @@ export const MerchantContent = memo(
     );
 
     return (
-      <Container height="100%" justifyContent="flex-end" paddingBottom={4}>
+      <Container flex={1} justifyContent="flex-end">
         <ScrollView
-          width="100%"
+          flex={1}
           contentContainerStyle={styles.contentContainer}
-          paddingHorizontal={HORIZONTAL_PADDING}
-          horizontal={false}
           refreshControl={
             <RefreshControl
               tintColor="blueText"
@@ -118,6 +111,13 @@ export const MerchantContent = memo(
             emptyText={strings.noAvailableBalance}
             tokens={merchantSafe.tokens}
           />
+          <MerchantTokensList
+            title={strings.availableBalance}
+            onPress={onPressGoTo(ExpandedMerchantRoutes.availableBalances)}
+            emptyText={strings.noAvailableBalance}
+            tokens={merchantSafe.tokens}
+          />
+          <Container paddingBottom={4} />
         </ScrollView>
       </Container>
     );
@@ -127,6 +127,6 @@ export const MerchantContent = memo(
 const styles = StyleSheet.create({
   contentContainer: {
     alignItems: 'center',
-    paddingBottom: BOTTOM_PADDING,
+    paddingHorizontal: 16,
   },
 });

--- a/cardstack/src/components/TransactionList/TransactionList.tsx
+++ b/cardstack/src/components/TransactionList/TransactionList.tsx
@@ -41,18 +41,6 @@ export const TransactionList = memo(({ Header }: TransactionListProps) => {
 
   const { isTabBarEnabled } = useTabBarFlag();
 
-  // TODO: Remove condition after tab is official
-  // useBottomTabBarHeight throws error if it's not inside tabNav
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const tabBarHeight = isTabBarEnabled ? useBottomTabBarHeight() : 0;
-
-  const contentContainerStyle = useMemo(
-    () => ({
-      paddingBottom: 40 + tabBarHeight,
-    }),
-    [tabBarHeight]
-  );
-
   const renderSectionHeader = useCallback(
     ({ section: { title } }: { section: { title: string } }) => (
       <Container
@@ -102,7 +90,6 @@ export const TransactionList = memo(({ Header }: TransactionListProps) => {
       ListFooterComponent={
         isFetchingMore ? <ActivityIndicator color="white" /> : null
       }
-      contentContainerStyle={contentContainerStyle}
       renderItem={renderItem}
       sections={sections}
       renderSectionHeader={renderSectionHeader}

--- a/cardstack/src/components/TransactionList/TransactionList.tsx
+++ b/cardstack/src/components/TransactionList/TransactionList.tsx
@@ -1,6 +1,5 @@
-import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { useFocusEffect } from '@react-navigation/native';
-import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { memo, useCallback, useEffect, useRef } from 'react';
 import { RefreshControl, SectionList, ActivityIndicator } from 'react-native';
 
 import {

--- a/cardstack/src/screens/HomeScreen/HomeScreen.tsx
+++ b/cardstack/src/screens/HomeScreen/HomeScreen.tsx
@@ -10,7 +10,7 @@ const HomeScreen = () => {
   return (
     <Container backgroundColor="backgroundDarkPurple" flex={1}>
       <MainHeader title="ACTIVITY" />
-      <Container>
+      <Container flex={1}>
         <TransactionList accountAddress={accountAddress} />
       </Container>
     </Container>

--- a/cardstack/src/screens/MerchantScreen/MerchantScreen.tsx
+++ b/cardstack/src/screens/MerchantScreen/MerchantScreen.tsx
@@ -17,7 +17,7 @@ const MerchantScreen = () => {
   } = useMerchantScreen();
 
   return (
-    <Container top={0} width="100%" backgroundColor="white">
+    <Container flex={1} width="100%" backgroundColor="white">
       <StatusBar barStyle="light-content" />
       <NavBarHeader
         address={merchantSafe.address}

--- a/cardstack/src/screens/ProfileScreen/ProfileScreen.tsx
+++ b/cardstack/src/screens/ProfileScreen/ProfileScreen.tsx
@@ -72,7 +72,7 @@ const ProfileScreen = () => {
       <MainHeader title={strings.header.profile} />
       <Container
         justifyContent="center"
-        flexGrow={1}
+        flex={1}
         paddingHorizontal={isLayer1(network) ? 5 : 0}
       >
         {isLayer1(network) ? (

--- a/src/hooks/useAssetListData.tsx
+++ b/src/hooks/useAssetListData.tsx
@@ -1,6 +1,5 @@
 import { getConstantByNetwork } from '@cardstack/cardpay-sdk';
 import { orderBy } from 'lodash';
-import { useEffect } from 'react';
 import { BalanceCoinRowWrapper } from '../components/coin-row';
 import useAccountSettings from './useAccountSettings';
 import {

--- a/src/hooks/useAssetListData.tsx
+++ b/src/hooks/useAssetListData.tsx
@@ -1,5 +1,6 @@
 import { getConstantByNetwork } from '@cardstack/cardpay-sdk';
 import { orderBy } from 'lodash';
+import { useEffect } from 'react';
 import { BalanceCoinRowWrapper } from '../components/coin-row';
 import useAccountSettings from './useAccountSettings';
 import {
@@ -197,10 +198,12 @@ export const useAssetListData = () => {
 
   const isUninitializedOnLayer2 = !isLayer1(network) && isUninitialized;
 
-  const isLoadingSafes = isLoading || isUninitializedOnLayer2;
+  const isLoadingRainbowAssets = useRainbowSelector(
+    state => state.data.isLoadingAssets
+  );
 
   const isLoadingAssets =
-    useRainbowSelector(state => state.data.isLoadingAssets) || isLoadingSafes;
+    isLoadingRainbowAssets || isUninitializedOnLayer2 || isLoading;
 
   // order of sections in asset list
   const orderedSections = [

--- a/src/hooks/useLoadAccountData.js
+++ b/src/hooks/useLoadAccountData.js
@@ -11,7 +11,7 @@ import { walletConnectLoadState } from '../redux/walletconnect';
 import { promiseUtils } from '../utils';
 import { collectiblesLoadState } from '@cardstack/redux/collectibles';
 import { requestsLoadState } from '@cardstack/redux/requests';
-import { isMainnet } from '@cardstack/utils';
+import { isLayer1, isMainnet } from '@cardstack/utils';
 import logger from 'logger';
 
 export default function useLoadAccountData() {
@@ -22,7 +22,11 @@ export default function useLoadAccountData() {
       logger.sentry('Load wallet account data');
       await dispatch(openStateSettingsLoadState());
       await dispatch(coinListLoadState());
-      await dispatch(dataLoadState());
+      if (isLayer1(network)) {
+        // Update data state on wallet initializion for layer1.
+        // This is performed in layer2 when loading gnosis safes.
+        await dispatch(dataLoadState());
+      }
       const promises = [];
       if (isMainnet(network)) {
         const p2 = dispatch(collectiblesLoadState());

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -98,7 +98,6 @@ export const DATA_UPDATE_PREPAIDCARDS = 'data/DATA_UPDATE_PREPAIDCARDS';
 
 // -- Actions ---------------------------------------- //
 export const dataLoadState = () => async (dispatch, getState) => {
-  console.log(':::dataLoadState');
   const { accountAddress, network } = getState().settings;
   try {
     const assetPricesFromUniswap = await getAssetPricesFromUniswap(
@@ -157,7 +156,6 @@ export const dataResetState = () => (dispatch, getState) => {
 };
 
 export const dataUpdateAssets = assets => (dispatch, getState) => {
-  console.log(':::dataUpdateAssets');
   const { accountAddress, network } = getState().settings;
   if (assets.length) {
     saveAssets(assets, accountAddress, network);
@@ -254,7 +252,6 @@ export const addressAssetsReceived = (
   change = false,
   removed = false
 ) => async (dispatch, getState) => {
-  console.log(':::addressAssetsReceived');
   const isValidMeta = dispatch(checkMeta(message));
   if (!isValidMeta) return;
 

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -77,7 +77,6 @@ const DATA_UPDATE_UNISWAP_PRICES_SUBSCRIPTION =
   'data/DATA_UPDATE_UNISWAP_PRICES_SUBSCRIPTION';
 const DATA_UPDATE_GNOSIS_DATA = 'data/DATA_UPDATE_GNOSIS_DATA';
 
-const DATA_LOAD_ASSETS_REQUEST = 'data/DATA_LOAD_ASSETS_REQUEST';
 const DATA_LOAD_ASSETS_SUCCESS = 'data/DATA_LOAD_ASSETS_SUCCESS';
 const DATA_LOAD_ASSETS_FAILURE = 'data/DATA_LOAD_ASSETS_FAILURE';
 
@@ -99,6 +98,7 @@ export const DATA_UPDATE_PREPAIDCARDS = 'data/DATA_UPDATE_PREPAIDCARDS';
 
 // -- Actions ---------------------------------------- //
 export const dataLoadState = () => async (dispatch, getState) => {
+  console.log(':::dataLoadState');
   const { accountAddress, network } = getState().settings;
   try {
     const assetPricesFromUniswap = await getAssetPricesFromUniswap(
@@ -112,7 +112,6 @@ export const dataLoadState = () => async (dispatch, getState) => {
     // eslint-disable-next-line no-empty
   } catch (error) {}
   try {
-    dispatch({ type: DATA_LOAD_ASSETS_REQUEST });
     const [
       assets,
       { prepaidCards },
@@ -158,6 +157,7 @@ export const dataResetState = () => (dispatch, getState) => {
 };
 
 export const dataUpdateAssets = assets => (dispatch, getState) => {
+  console.log(':::dataUpdateAssets');
   const { accountAddress, network } = getState().settings;
   if (assets.length) {
     saveAssets(assets, accountAddress, network);
@@ -254,6 +254,7 @@ export const addressAssetsReceived = (
   change = false,
   removed = false
 ) => async (dispatch, getState) => {
+  console.log(':::addressAssetsReceived');
   const isValidMeta = dispatch(checkMeta(message));
   if (!isValidMeta) return;
 
@@ -698,6 +699,7 @@ export default (state = INITIAL_STATE, action) => {
         break;
       case DATA_UPDATE_ASSETS:
         draft.assets = action.payload;
+        draft.isLoadingAssets = false;
         break;
       case DATA_UPDATE_GNOSIS_DATA:
         draft.depots = action.payload.depots;
@@ -717,9 +719,6 @@ export default (state = INITIAL_STATE, action) => {
         break;
       case DATA_LOAD_TRANSACTIONS_FAILURE:
         draft.isLoadingTransactions = false;
-        break;
-      case DATA_LOAD_ASSETS_REQUEST:
-        draft.isLoadingAssets = true;
         break;
       case DATA_LOAD_ASSET_PRICES_FROM_UNISWAP_SUCCESS:
         draft.assetPricesFromUniswap = action.payload;

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -698,7 +698,6 @@ export default (state = INITIAL_STATE, action) => {
         break;
       case DATA_UPDATE_ASSETS:
         draft.assets = action.payload;
-        draft.isLoadingAssets = false;
         break;
       case DATA_UPDATE_GNOSIS_DATA:
         draft.depots = action.payload.depots;
@@ -733,7 +732,7 @@ export default (state = INITIAL_STATE, action) => {
         draft.isLoadingAssets = false;
         break;
       case DATA_LOAD_ASSETS_FAILURE:
-        draft.isLoadingAssets = true;
+        draft.isLoadingAssets = false;
         break;
       case DATA_ADD_NEW_TRANSACTION_SUCCESS:
         draft.transactions = action.payload;


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR improves the loading state of assets, occurring especially on Android, by not updating the loading state on `DATA_UPDATE_ASSETS` reducer and by not calling dataLoadState twice if not on layer 1.

It also fixes some general screen paddings that were wrong after the switch to tabbar (Activity, Wallet, MerchantContent).

- [x] Completes #(CS-3818)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

https://user-images.githubusercontent.com/129619/166613041-86e580fb-25a1-4a72-8858-1fa66a522712.mp4


