### PR TITLE
[CS-3805]:  Use exchange-rates api instead of fixer

### DIFF
--- a/cardstack/src/helpers/__tests__/fallbackExplorerHelper.test.ts
+++ b/cardstack/src/helpers/__tests__/fallbackExplorerHelper.test.ts
@@ -1,3 +1,5 @@
+import { NativeCurrency } from '@cardstack/cardpay-sdk';
+
 import { reduceAssetsWithPriceChartAndBalances } from '@cardstack/helpers/fallbackExplorerHelper';
 
 import { Network } from '@rainbow-me/helpers/networkTypes';
@@ -53,7 +55,7 @@ describe('Fallback Explorer Helpers', () => {
       chartData,
       formattedNativeCurrency: 'usd',
       network: Network.sokol,
-      nativeCurrency: 'USD',
+      nativeCurrency: NativeCurrency.USD,
       accountAddress: '0x000000',
     });
 

--- a/cardstack/src/helpers/fallbackExplorerHelper.ts
+++ b/cardstack/src/helpers/fallbackExplorerHelper.ts
@@ -3,6 +3,7 @@
 import {
   convertAmountAndPriceToNativeDisplay,
   convertAmountToNativeDisplay,
+  NativeCurrency,
 } from '@cardstack/cardpay-sdk';
 import { toLower } from 'lodash';
 import Web3 from 'web3';
@@ -45,7 +46,7 @@ type AssetWithBalance = { asset: AssetType & BalanceObject };
 interface ReduceAssetsParams extends ReduceWithPriceChartBaseParams {
   assets: AssetWithBalance[];
   network: Network;
-  nativeCurrency: string;
+  nativeCurrency: NativeCurrency;
   accountAddress: string;
 }
 
@@ -170,7 +171,7 @@ export const reduceAssetsWithPriceChartAndBalances = async ({
   formattedNativeCurrency,
   chartData,
   network,
-  nativeCurrency = '',
+  nativeCurrency = NativeCurrency.USD,
   accountAddress,
 }: ReduceAssetsParams) =>
   assets.reduce(async (updatedAssets, { asset }) => {

--- a/cardstack/src/hooks/prepaid-card/useBuyPrepaidCard.ts
+++ b/cardstack/src/hooks/prepaid-card/useBuyPrepaidCard.ts
@@ -10,6 +10,7 @@ import {
   getHubUrl,
   getInventories,
   getOrder,
+  getValueInNativeCurrency,
   getWyrePrice,
   makeReservation,
   updateOrder,
@@ -394,9 +395,10 @@ export default function useBuyPrepaidCard() {
   const handlePurchase = useCallback(async () => {
     setIsPurchaseInProgress(true);
 
-    const amount =
-      (card?.['source-currency-price'] || 0) *
-      currencyConversionRates[nativeCurrency];
+    const amount = await getValueInNativeCurrency(
+      card?.['source-currency-price'] || 0,
+      nativeCurrency
+    );
 
     let reservation: ReservationData | undefined;
     let wyreOrderIdData;

--- a/cardstack/src/screens/SendSheetDepot/useSendSheetDepotScreen.ts
+++ b/cardstack/src/screens/SendSheetDepot/useSendSheetDepotScreen.ts
@@ -13,7 +13,10 @@ import { SEND_TRANSACTION_ERROR_MESSAGE } from '@cardstack/constants';
 import { getSafesInstance } from '@cardstack/models/safes-providers';
 import { MainRoutes, useLoadingOverlay } from '@cardstack/navigation';
 import { RouteType } from '@cardstack/navigation/types';
-import { getUsdConverter } from '@cardstack/services/exchange-rate-service';
+import {
+  getValueInNativeCurrency,
+  getUsdConverter,
+} from '@cardstack/services/exchange-rate-service';
 import { DepotAsset, TokenType } from '@cardstack/types';
 import {
   reshapeDepotTokensToAssets,
@@ -30,7 +33,6 @@ import {
   useWallets,
 } from '@rainbow-me/hooks';
 import Navigation, { useNavigation } from '@rainbow-me/navigation/Navigation';
-import { useNativeCurrencyAndConversionRates } from '@rainbow-me/redux/hooks';
 import Routes from '@rainbow-me/routes';
 import logger from 'logger';
 
@@ -93,20 +95,15 @@ export const useSendSheetDepotScreen = () => {
   const isValidAddress = useSendAddressValidation(recipient);
   const [isAuthorizing, setIsAuthorizing] = useState(false);
 
-  const { accountAddress, network } = useAccountSettings();
-
-  const [
-    nativeCurrency,
-    currencyConversionRates,
-  ] = useNativeCurrencyAndConversionRates();
+  const { accountAddress, network, nativeCurrency } = useAccountSettings();
 
   const getNativeCurrencyAmount = useCallback(
-    (amount: string) => {
+    async (amount: string) => {
       const usdConvertedAmount = usdConverter.current?.(amount) || 0;
 
-      return currencyConversionRates[nativeCurrency] * usdConvertedAmount;
+      return await getValueInNativeCurrency(usdConvertedAmount, nativeCurrency);
     },
-    [currencyConversionRates, nativeCurrency]
+    [nativeCurrency]
   );
 
   // Gas Estimates
@@ -129,7 +126,9 @@ export const useSendSheetDepotScreen = () => {
           amountWei
         )) || '0';
 
-      const nativeCurrencyGasFee = getNativeCurrencyAmount(gasEstimate) || 0;
+      const nativeCurrencyGasFee =
+        (await getNativeCurrencyAmount(gasEstimate)) || 0;
+
       setGasEstimatedFee({
         amount: nativeCurrencyGasFee,
         nativeDisplay: `${Web3.utils.fromWei(gasEstimate)} ${

--- a/cardstack/src/services/gnosis-service.ts
+++ b/cardstack/src/services/gnosis-service.ts
@@ -259,7 +259,7 @@ export const updateSafeWithTokenPrices = async (
 
 export const addNativePriceToToken = async (
   tokenInfo: TokenInfo,
-  nativeCurrency: string
+  nativeCurrency: NativeCurrency
 ) => {
   const {
     balance,

--- a/cardstack/src/services/hub/hub-api.ts
+++ b/cardstack/src/services/hub/hub-api.ts
@@ -65,7 +65,7 @@ export const hubApi = createApi({
         );
       },
     }),
-    getExchangeRates: builder.query<Record<NativeCurrency, string>, void>({
+    getExchangeRates: builder.query<Record<NativeCurrency, number>, void>({
       query: () => routes.exchangeRates,
       extraOptions: { authenticate: false },
       transformResponse: ({
@@ -84,4 +84,5 @@ export const {
   useGetEoaClaimedQuery,
   useRequestEmailCardDropMutation,
   useCheckHubAuthQuery,
+  useGetExchangeRatesQuery,
 } = hubApi;

--- a/cardstack/src/services/hub/hub-api.ts
+++ b/cardstack/src/services/hub/hub-api.ts
@@ -1,3 +1,4 @@
+import { NativeCurrency } from '@cardstack/cardpay-sdk';
 import { createApi } from '@reduxjs/toolkit/query/react';
 
 import { CustodialWallet } from '@cardstack/types';
@@ -17,6 +18,7 @@ import {
 const routes = {
   custodialWallet: '/custodial-wallet',
   emailDrop: '/email-card-drop-requests',
+  exchangeRates: '/exchange-rates',
 };
 
 export const hubApi = createApi({
@@ -61,6 +63,17 @@ export const hubApi = createApi({
             errorLogMessage: 'Error checking hub auth',
           }
         );
+      },
+    }),
+    getExchangeRates: builder.query<Record<NativeCurrency, string>, void>({
+      query: () => routes.exchangeRates,
+      extraOptions: { authenticate: false },
+      transformResponse: ({
+        data: {
+          attributes: { rates },
+        },
+      }) => {
+        return { ...rates, SPD: 100 };
       },
     }),
   }),

--- a/cardstack/src/services/hub/hub-service.ts
+++ b/cardstack/src/services/hub/hub-service.ts
@@ -103,10 +103,14 @@ export const checkHubAuth = async ({
 
 // External Queries
 
+const cacheExpiration = {
+  tenMinutes: 60 * 10,
+};
+
 export const getExchangeRatesQuery = () => {
   const query = store.dispatch(
     hubApi.endpoints.getExchangeRates.initiate(undefined, {
-      forceRefetch: 60, // 1 minute
+      forceRefetch: cacheExpiration.tenMinutes,
     })
   );
 

--- a/cardstack/src/services/hub/hub-service.ts
+++ b/cardstack/src/services/hub/hub-service.ts
@@ -103,18 +103,12 @@ export const checkHubAuth = async ({
 
 // External Queries
 
-export const getExchangeRates = async () => {
+export const getExchangeRatesQuery = () => {
   const query = store.dispatch(
     hubApi.endpoints.getExchangeRates.initiate(undefined, {
       forceRefetch: 60, // 1 minute
     })
   );
 
-  const { data, error } = await query;
-
-  if (error) {
-    throw error;
-  }
-
-  return data;
+  return query;
 };

--- a/cardstack/src/services/hub/hub-service.ts
+++ b/cardstack/src/services/hub/hub-service.ts
@@ -9,7 +9,7 @@ import {
 import Web3Instance from '@cardstack/models/web3-instance';
 
 import { getNetwork } from '@rainbow-me/handlers/localstorage/globalSettings';
-import { AppState } from '@rainbow-me/redux/store';
+import store, { AppState } from '@rainbow-me/redux/store';
 import logger from 'logger';
 
 import {
@@ -19,6 +19,7 @@ import {
   getHubUrl,
 } from '../hub-service';
 
+import { hubApi } from './hub-api';
 import { BaseQueryExtraOptions, CheckHubAuthQueryParams } from './hub-types';
 
 // Helpers
@@ -98,4 +99,22 @@ export const checkHubAuth = async ({
   const isAuthenticated = await hubAuthInstance.checkValidAuth(authToken);
 
   return isAuthenticated;
+};
+
+// External Queries
+
+export const getExchangeRates = async () => {
+  const query = store.dispatch(
+    hubApi.endpoints.getExchangeRates.initiate(undefined, {
+      forceRefetch: 60, // 1 minute
+    })
+  );
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
 };

--- a/cardstack/src/transaction-mapping-strategies/base-strategy.ts
+++ b/cardstack/src/transaction-mapping-strategies/base-strategy.ts
@@ -1,3 +1,5 @@
+import { NativeCurrency } from '@cardstack/cardpay-sdk';
+
 import {
   AdvancedTransactionFragment,
   TransactionType,
@@ -7,7 +9,7 @@ import {
 interface BaseStrategyParams {
   transaction: AdvancedTransactionFragment;
   accountAddress: string;
-  nativeCurrency: string;
+  nativeCurrency: NativeCurrency;
   currencyConversionRates: CurrencyConversionRates;
   merchantSafeAddresses: string[];
   prepaidCardAddresses: string[];
@@ -16,7 +18,7 @@ interface BaseStrategyParams {
   isDepotTransaction?: boolean;
 }
 
-export abstract class BaseStrategy {
+export abstract class BaseStrategy implements BaseStrategyParams {
   abstract handlesTransaction(): boolean;
   abstract mapTransaction():
     | Promise<TransactionType | null>
@@ -24,12 +26,12 @@ export abstract class BaseStrategy {
 
   transaction: AdvancedTransactionFragment;
   accountAddress: string;
-  nativeCurrency: string;
+  nativeCurrency: NativeCurrency;
   currencyConversionRates: CurrencyConversionRates;
-  depotAddress: string;
   merchantSafeAddresses: string[];
   prepaidCardAddresses: string[];
   merchantSafeAddress?: string;
+  depotAddress: string;
   isDepotTransaction?: boolean;
 
   constructor({

--- a/cardstack/src/transaction-mapping-strategies/context.ts
+++ b/cardstack/src/transaction-mapping-strategies/context.ts
@@ -1,3 +1,4 @@
+import { NativeCurrency } from '@cardstack/cardpay-sdk';
 import { flatten } from 'lodash';
 
 import { CurrencyConversionRates, TransactionType } from '@cardstack/types';
@@ -44,7 +45,7 @@ export type TransactionMappingStrategy =
 interface TransactionData {
   transactions: (AdvancedTransactionFragment | undefined)[];
   accountAddress: string;
-  nativeCurrency: string;
+  nativeCurrency: NativeCurrency;
   currencyConversionRates: CurrencyConversionRates;
   transactionStrategies?: TransactionMappingStrategy[];
   depotAddress: string;

--- a/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/prepaid-card-transfer-strategy.test.ts
+++ b/cardstack/src/transaction-mapping-strategies/transaction-mapping-strategy-types/__tests__/prepaid-card-transfer-strategy.test.ts
@@ -1,3 +1,5 @@
+import { NativeCurrency } from '@cardstack/cardpay-sdk';
+
 import { PrepaidCardTransferStrategy } from '@cardstack/transaction-mapping-strategies/transaction-mapping-strategy-types/prepaid-card-transfer-strategy';
 import {
   PREPAID_CARD_TRANSFER_MOCK,
@@ -109,7 +111,7 @@ describe('PrepaidCardTransferStrategy', () => {
       '0x9Ed84407e5ed5B7c0323E5653A06F4528357e3B5',
       '0xcba12315cc838375F0e1E9a9f5b2aFE0196B07B6',
     ],
-    nativeCurrency: 'USD',
+    nativeCurrency: NativeCurrency.USD,
     prepaidCardAddresses: ['0x35Ae15dCEB6930756A59EfcC2169d2b834CdD371'],
     transaction: PREPAID_CARD_TRANSFER_MOCK,
   };

--- a/cardstack/src/types/react-native-dotenv.d.ts
+++ b/cardstack/src/types/react-native-dotenv.d.ts
@@ -16,7 +16,6 @@ declare module 'react-native-dotenv' {
   export const WYRE_ENDPOINT_TEST: string;
   export const WYRE_SECRET_KEY: string;
   export const WYRE_SECRET_KEY_TEST: string;
-  export const FIXER_API_KEY: string;
   export const HUB_URL: string;
   export const HUB_URL_STAGING: string;
   export const STATUS_API_BASE_URL: string;

--- a/cardstack/src/utils/__tests__/merchant-utils.test.ts
+++ b/cardstack/src/utils/__tests__/merchant-utils.test.ts
@@ -1,3 +1,4 @@
+import { NativeCurrency } from '@cardstack/cardpay-sdk';
 import { Share, Platform } from 'react-native';
 
 import {
@@ -79,7 +80,7 @@ describe('Merchant utils', () => {
       expect(
         await getMerchantClaimTransactionDetails(
           MERCHANT_CLAIM_MOCK_DATA,
-          'USD',
+          NativeCurrency.USD,
           '0xD7182E380b7dFa33C186358De7E1E5d0950fCAE7'
         )
       ).toStrictEqual({
@@ -96,7 +97,7 @@ describe('Merchant utils', () => {
       expect(
         await getMerchantEarnedTransactionDetails(
           MERCHANT_EARNED_MOCK_DATA,
-          'USD',
+          NativeCurrency.USD,
           'DAI'
         )
       ).toStrictEqual({

--- a/cardstack/src/utils/merchant-utils.ts
+++ b/cardstack/src/utils/merchant-utils.ts
@@ -2,6 +2,7 @@ import {
   convertAmountToNativeDisplay,
   convertRawAmountToBalance,
   MerchantSafe,
+  NativeCurrency,
   subtract,
 } from '@cardstack/cardpay-sdk';
 import { getResolver } from '@cardstack/did-resolver';
@@ -144,7 +145,7 @@ export const shareRequestPaymentLink = (
 
 export async function getMerchantClaimTransactionDetails(
   merchantClaimTransaction: MerchantClaimFragment,
-  nativeCurrency = 'USD',
+  nativeCurrency: NativeCurrency = NativeCurrency.USD,
   address?: string
 ): Promise<MerchantClaimTypeTxn> {
   const transactions = merchantClaimTransaction.transaction?.tokenTransfers;
@@ -197,7 +198,7 @@ export async function getMerchantClaimTransactionDetails(
 
 export async function getMerchantEarnedTransactionDetails(
   prepaidCardPaymentTransaction: PrepaidCardPaymentFragment,
-  nativeCurrency = 'USD',
+  nativeCurrency: NativeCurrency = NativeCurrency.USD,
   symbol: string
 ): Promise<MerchantEarnedRevenueTransactionTypeTxn> {
   const feeCollectedRaw =

--- a/src/hooks/useWalletManager.ts
+++ b/src/hooks/useWalletManager.ts
@@ -26,9 +26,8 @@ import useResetAccountState from './useResetAccountState';
 import { checkPushPermissionAndRegisterToken } from '@cardstack/models/firebase';
 import { useLoadingOverlay } from '@cardstack/navigation';
 import { appStateUpdate } from '@cardstack/redux/appState';
-import { getCurrencyConversionsRates } from '@cardstack/services';
+
 import { saveAccountEmptyState } from '@rainbow-me/handlers/localstorage/accountLocal';
-import { setCurrencyConversionRates } from '@rainbow-me/redux/currencyConversion';
 import logger from 'logger';
 
 interface initializeWalleOptions {
@@ -62,11 +61,6 @@ export default function useWalletManager() {
         // TODO: move to fallbackExplorer, shouldn't be related with initializating a wallet
         await loadCoingeckoCoins();
 
-        // TODO: move to rtk query
-        const conversionsRates = await getCurrencyConversionsRates();
-
-        await dispatch(setCurrencyConversionRates(conversionsRates));
-
         await dispatch(walletsLoadState());
 
         const walletAddress = await loadAddress();
@@ -76,7 +70,6 @@ export default function useWalletManager() {
           dispatch(appStateUpdate({ walletReady: true }));
           return null;
         }
-
         await dispatch(settingsUpdateAccountAddress(walletAddress));
 
         await loadGlobalData();

--- a/src/redux/fallbackExplorer.js
+++ b/src/redux/fallbackExplorer.js
@@ -12,7 +12,7 @@ import {
   UPDATE_BALANCE_AND_PRICE_FREQUENCY,
 } from '@cardstack/constants';
 import { reduceAssetsWithPriceChartAndBalances } from '@cardstack/helpers/fallbackExplorerHelper';
-import { getCurrencyConversionsRates } from '@cardstack/services';
+import { getExchangeRatesQuery } from '@cardstack/services/hub/hub-service';
 import { isLayer1, isMainnet } from '@cardstack/utils';
 import { setCurrencyConversionRates } from '@rainbow-me/redux/currencyConversion';
 import logger from 'logger';
@@ -398,6 +398,11 @@ export const fallbackExplorerInit = () => async (dispatch, getState) => {
   const { accountAddress, network } = getState().settings;
   const { latestTxBlockNumber, assets } = getState().fallbackExplorer;
   const coingeckoCoins = getState().coingecko.coins;
+
+  const { data: conversionsRates } = await getExchangeRatesQuery();
+
+  await dispatch(setCurrencyConversionRates(conversionsRates));
+
   // If mainnet, we need to get all the info
   // 1 - Coingecko ids
   // 2 - All tokens list
@@ -417,10 +422,6 @@ export const fallbackExplorerInit = () => async (dispatch, getState) => {
       type: FALLBACK_EXPLORER_SET_ASSETS,
     });
   }
-
-  const conversionsRates = await getCurrencyConversionsRates();
-
-  await dispatch(setCurrencyConversionRates(conversionsRates));
 
   return fetchAssetsBalancesAndPrices();
 };

--- a/src/redux/settings.js
+++ b/src/redux/settings.js
@@ -25,6 +25,7 @@ import { walletConnectUpdateSessions } from './walletconnect';
 import { collectiblesResetState } from '@cardstack/redux/collectibles';
 import { paymentChangeCurrency } from '@cardstack/redux/payment';
 import { requestsResetState } from '@cardstack/redux/requests';
+import { getExchangeRatesQuery } from '@cardstack/services/hub/hub-service';
 import logger from 'logger';
 // -- Constants ------------------------------------------------------------- //
 
@@ -41,6 +42,9 @@ const SETTINGS_UPDATE_NETWORK_SUCCESS =
 export const settingsLoadState = () => async (dispatch, getState) => {
   try {
     const nativeCurrency = await getNativeCurrency();
+
+    await getExchangeRatesQuery();
+
     const paymentCurrency = getState().payment.currency;
     dispatch({
       payload: nativeCurrency,


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds the exchange-rate path to the hubAPi which automatically controls the cache, there are some small improvements how we use conversionRates, I tried to remove everything at once from redux etc, but it's proven to be challenge so I'll be splitting into smaller PRs to be easier to review and test it. Fo now it's just the new api, and it sets on old redux state, upcoming PRs will make sure that we don't need need the old state anymore.
Also as an improvement the payMerchant flow will be changed a little, so we avoid the kind of issue were the nativeCurrency is EUR but the input defaults to USD.
The hub will cache the data for 15 min, caching on the app we are starting with 10 min, but we can evaluate if it needs less time
### Screenshots

<!-- Screenshots or animated GIFs included here -->


![Simulator Screen Recording - iPhone SE (3rd generation) - 2022-05-04 at 13 16 35](https://user-images.githubusercontent.com/20520102/166725531-4b001147-ed3f-4d0e-9cc3-d04a5f6e9919.gif)

