### PR TITLE
[CS-3729] Fixes gesture transparency issue on android

### DIFF
--- a/cardstack/src/components/LoadingOverlay/LoadingOverlay.tsx
+++ b/cardstack/src/components/LoadingOverlay/LoadingOverlay.tsx
@@ -12,6 +12,8 @@ import { neverRerender } from '@rainbow-me/utils';
 const styles = StyleSheet.create({
   overlayWrapper: {
     flex: 1,
+    // Note: Workaround for android gesture transparency issue.
+    backgroundColor: '#00000001',
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -74,7 +74,6 @@ const nativeStackiOSLoadingConfig = {
   transitionDuration: 0,
   onWillDismiss: null,
   dismissable: false,
-  gesturedEnabled: false,
 };
 
 // Shareable component,

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -64,35 +64,14 @@ export interface ScreenNavigation {
   listeners?: ScreenListeners<NavigationState, StackNavigationEventMap>;
 }
 
-// Native iOS custom option, should be removed after deleting NativeStack
-const nativeStackiOSLoadingConfig = {
-  customStack: true,
-  onAppear: null,
-  allowsDragToDismiss: false,
-  allowsTapToDismiss: false,
-  onTouchTop: null,
-  transitionDuration: 0,
-  onWillDismiss: null,
-  dismissable: false,
-};
-
-// Shareable component,
-// for now android/ios needs on MainStack
-// and iOS only on GlobalStack
-// the navigator looks for the nearest route
-const LoadingOverlayComponent = {
+export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
   LOADING_OVERLAY: {
     component: LoadingOverlayScreen,
     options: {
       ...overlayPreset,
       gestureEnabled: false,
-
-      ...(Device.isIOS ? nativeStackiOSLoadingConfig : {}),
     } as StackNavigationOptions,
   },
-};
-
-export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
   DEPOT_SCREEN: { component: DepotScreen, options: horizontalInterpolator },
   MERCHANT_SCREEN: {
     component: MerchantScreen,
@@ -163,7 +142,6 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
       ? bottomSheetPreset
       : wcPromptPreset) as StackNavigationOptions,
   },
-  ...LoadingOverlayComponent,
   SETTINGS_MODAL: {
     component: SettingsModal,
     options: { ...slideLeftToRightPreset, gestureEnabled: false },
@@ -245,9 +223,6 @@ export const GlobalScreens: Record<
       interactWithScrollView: false,
     } as StackNavigationOptions,
   },
-
-  // Needs to be the last item of the object, until we move to a single navigator
-  ...(Device.isIOS ? LoadingOverlayComponent : {}),
 };
 
 // TODO: Merge paths once, navigation redesign happens


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

PR adds a workaround for an Android issue with gestures being relayed on modals that are fully transparent. It adds a tiny bit of black to the background so the view can capture touches.

- [x] Completes #(CS-3729)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

https://user-images.githubusercontent.com/129619/167418610-050d5911-9f36-488b-a5f8-5452e858f0f3.mp4

