### PR TITLE
[Bug]: Fix missing color picker route

### DIFF
--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -129,9 +129,6 @@ const StackNavigator = () => {
 
   // TODO: Create a navigator for each flow and split auth/non-auth
 
-  // Remove last item aka LoadingOverlay, to avoid dupe (on iOS)
-  Device.isIOS && cardstackGlobalScreens.pop();
-
   return (
     <Stack.Navigator
       // On Android theres an issue with navigation trying to focus


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

After updating the loadingOverlay to the new nav, the last route (ColorPickr) was being popped

<!-- Use this tag to format the screenshot size
<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->
![Simulator Screen Recording - iPhone SE (3rd generation) - 2022-05-11 at 15 39 27](https://user-images.githubusercontent.com/20520102/167922268-1bff8df8-cfee-4ba2-af7b-a36c149a9368.gif)


