### PR TITLE
[Fix] Padding issue when Notice not visible.

### DIFF
--- a/cardstack/src/components/Notice/Notice.tsx
+++ b/cardstack/src/components/Notice/Notice.tsx
@@ -71,6 +71,8 @@ export const Notice = ({
       {isVisible && (
         <Touchable onPress={onPress} testID="notice-pressable">
           <Container
+            marginHorizontal={4}
+            marginVertical={2}
             alignItems="center"
             flexDirection="row"
             paddingVertical={1}

--- a/cardstack/src/components/Notice/ServiceStatusNotice.tsx
+++ b/cardstack/src/components/Notice/ServiceStatusNotice.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { Linking } from 'react-native';
 
-import { Container, Notice } from '@cardstack/components';
+import { Notice } from '@cardstack/components';
 import { useGetServiceStatusQuery } from '@cardstack/services';
 
 export const ServiceStatusNotice = () => {
@@ -12,13 +12,11 @@ export const ServiceStatusNotice = () => {
   }, []);
 
   return (
-    <Container marginHorizontal={4} marginVertical={2}>
-      <Notice
-        isVisible={!!data}
-        description={data?.name || 'Information available.'}
-        type="warning"
-        onPress={handleOnPress}
-      />
-    </Container>
+    <Notice
+      isVisible={!!data}
+      description={data?.name || 'Information available.'}
+      type="warning"
+      onPress={handleOnPress}
+    />
   );
 };


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

On the last Service Notice update, the padding was moved and it was always present even when the banner wasn't visible.

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/168816987-5e8dc236-2315-41fe-b1a0-8ba684d1b25e.jpg">
