### PR TITLE
[CS-2378] Remove fixed face-id icon in favor of BiometryType icon

### DIFF
--- a/cardstack/src/components/TransactionConfirmationSheet/TransactionConfirmationSheet.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/TransactionConfirmationSheet.tsx
@@ -12,6 +12,7 @@ import {
   Text,
   Touchable,
 } from '@cardstack/components';
+import { useBiometricIconProps } from '@cardstack/hooks/useBiometricIconProps';
 import { TransactionConfirmationData } from '@cardstack/types';
 import { layoutEasingAnimation } from '@cardstack/utils';
 
@@ -19,6 +20,7 @@ import {
   DisplayInformation,
   transactionTypeMap,
 } from './displays/DisplayInformation';
+import { strings } from './strings';
 
 export interface TransactionConfirmationDisplayProps {
   dappUrl?: string;
@@ -124,6 +126,8 @@ const SheetFooter = ({
   onCancel,
   onConfirmLoading = false,
 }: TransactionConfirmationDisplayProps) => {
+  const iconProps = useBiometricIconProps();
+
   return (
     <Container
       width="100%"
@@ -141,15 +145,15 @@ const SheetFooter = ({
         justifyContent="space-between"
       >
         <Button variant="smallWhite" onPress={onCancel}>
-          Cancel
+          {strings.buttons.cancel}
         </Button>
         <Button
           loading={onConfirmLoading}
           variant="small"
           onPress={onConfirm}
-          iconProps={{ name: 'face-id' }}
+          iconProps={iconProps}
         >
-          Confirm
+          {strings.buttons.submit}
         </Button>
       </Container>
     </Container>

--- a/cardstack/src/components/TransactionConfirmationSheet/strings.ts
+++ b/cardstack/src/components/TransactionConfirmationSheet/strings.ts
@@ -29,4 +29,8 @@ export const strings = {
       },
     },
   },
+  buttons: {
+    submit: 'Confirm',
+    cancel: 'Cancel',
+  },
 };

--- a/src/components/secret-display/SecretDisplaySection.js
+++ b/src/components/secret-display/SecretDisplaySection.js
@@ -9,6 +9,7 @@ import { ColumnWithMargins } from '../layout';
 import SecretDisplayCard from './SecretDisplayCard';
 import { Button, Text } from '@cardstack/components';
 import { useCopyToast } from '@cardstack/hooks';
+import { useBiometricIconProps } from '@cardstack/hooks/useBiometricIconProps';
 import WalletTypes from '@rainbow-me/helpers/walletTypes';
 import { useWallets } from '@rainbow-me/hooks';
 import logger from 'logger';
@@ -66,6 +67,8 @@ export default function SecretDisplaySection({
     customCopyLabel: 'Secret Recovery Phrase',
   });
 
+  const iconProps = useBiometricIconProps();
+
   return (
     <>
       <ColumnWithMargins
@@ -99,11 +102,7 @@ export default function SecretDisplaySection({
             <Text textAlign="center">
               {`You need to authenticate in order to access your recovery ${typeLabel}`}
             </Text>
-            <Button
-              iconProps={{ name: 'face-id' }}
-              onPress={loadSeed}
-              variant="white"
-            >
+            <Button iconProps={iconProps} onPress={loadSeed} variant="white">
               Show Secret Recovery Phrase
             </Button>
           </Fragment>


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR removes the hardcoded `face-id` icon from both the `TransactionConfirmationSheet` component and the SecretDisplay sheet in favor of using the icons mapped by the `BiometricType` enum. Devices with no FaceID, like the iPhone SE in the screenshot, show the touch ID icon. While in the area, I moved the button text into the `strings` file.

There's a known issue with `react-native-keychain` where, in some devices with facial recognition but no actual FaceID capability, the library returns `face-id` as supported biometric type (tested this with a Moto G8: the device doesn't use face as auth but has face recognition capabilities). Will be dealing with that in another PR since it will probably involve trying to update both `react-native-keychain` and `react-native-device-info` or maybe use [Expo Local Authentication](https://github.com/expo/expo/tree/main/packages/expo-local-authentication). Let me know if y'all have tried this before and if it's a path worth exploring :)

- [x] Completes #CS-2378

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<img width="400" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/169100745-9e40bfd9-f00f-4f2b-8e2b-49a1d60bd96d.png">

