### PR TITLE
[CS-3861]: Create PinInput component

### DIFF
--- a/cardstack/src/components/Input/PinInput/CharCell.tsx
+++ b/cardstack/src/components/Input/PinInput/CharCell.tsx
@@ -1,0 +1,74 @@
+import React, { memo, useMemo } from 'react';
+
+import { CenteredContainer, Text } from '@cardstack/components';
+import { ColorTypes } from '@cardstack/theme';
+
+import { PinLayoutVariant } from './types';
+
+type ColorVariant = Record<PinLayoutVariant, ColorTypes>;
+
+type StyleProps = 'backgroundColor' | 'borderColor' | 'textColor';
+
+const cellStyle: Record<StyleProps, ColorVariant> = {
+  backgroundColor: {
+    light: 'grayLightBackground',
+    dark: 'backgroundDarkerPurple',
+  },
+  borderColor: {
+    light: 'buttonDarkBackground',
+    dark: 'secondaryText',
+  },
+  textColor: {
+    light: 'black',
+    dark: 'white',
+  },
+};
+
+const SECURE_CHAR = '●';
+
+export const cellLayout = {
+  height: 70,
+  width: 45,
+  radius: 8,
+};
+
+interface CharCellProps {
+  index: number;
+  inputValue: string;
+  variant: PinLayoutVariant;
+  secureText?: boolean;
+}
+
+const CharCell = ({
+  index,
+  inputValue,
+  secureText,
+  variant,
+}: CharCellProps) => {
+  const renderCharValue = useMemo(() => {
+    const char = inputValue.charAt(index);
+    const hasValue = !!char;
+    const shouldHide = hasValue && secureText;
+
+    return shouldHide ? SECURE_CHAR : char;
+  }, [index, inputValue, secureText]);
+
+  const isActive = index === inputValue.length;
+
+  return (
+    <CenteredContainer
+      borderWidth={1}
+      borderColor={isActive ? 'teal' : cellStyle.borderColor[variant]}
+      borderRadius={cellLayout.radius}
+      height={cellLayout.height}
+      width={cellLayout.width}
+      backgroundColor={cellStyle.backgroundColor[variant]}
+    >
+      <Text color={cellStyle.textColor[variant]} weight="bold" fontSize={24}>
+        {renderCharValue}
+      </Text>
+    </CenteredContainer>
+  );
+};
+
+export default memo(CharCell);

--- a/cardstack/src/components/Input/PinInput/PinInput.tsx
+++ b/cardstack/src/components/Input/PinInput/PinInput.tsx
@@ -1,0 +1,75 @@
+import React, { memo, useMemo, useRef } from 'react';
+import { StyleSheet, TextInput } from 'react-native';
+
+import { Container, Input, InputProps } from '@cardstack/components';
+
+import CharCell, { cellLayout } from './CharCell';
+import { PinLayoutVariant } from './types';
+
+const DEFAULT_PIN_LENGTH = 6;
+const PIN_LENGTH = new Array(DEFAULT_PIN_LENGTH).fill('');
+
+const styles = StyleSheet.create({
+  hiddenInput: {
+    ...StyleSheet.absoluteFillObject,
+    height: cellLayout.height,
+    top: -cellLayout.height,
+    opacity: 0,
+  },
+});
+
+interface PinInputProps extends InputProps {
+  variant: PinLayoutVariant;
+  value: string;
+}
+
+const PinInput = ({
+  variant,
+  value = '',
+  onChangeText,
+  secureTextEntry = true,
+  ...inputProps
+}: PinInputProps) => {
+  const inputRef = useRef<TextInput>();
+
+  const renderCells = useMemo(
+    () =>
+      PIN_LENGTH.map((_, index) => (
+        <CharCell
+          index={index}
+          inputValue={value}
+          secureText={secureTextEntry}
+          variant={variant}
+        />
+      )),
+    [secureTextEntry, value, variant]
+  );
+
+  return (
+    <Container width="85%">
+      <Container justifyContent="space-between" flexDirection="row">
+        {renderCells}
+      </Container>
+      <Input
+        autoFocus
+        secureTextEntry
+        caretHidden
+        contextMenuHidden
+        ref={inputRef}
+        fontSize={1}
+        value={value}
+        onChangeText={onChangeText}
+        style={styles.hiddenInput}
+        maxLength={DEFAULT_PIN_LENGTH}
+        spellCheck={false}
+        autoCorrect={false}
+        blurOnSubmit={false}
+        underlineColorAndroid="transparent"
+        keyboardType="number-pad"
+        {...inputProps}
+      />
+    </Container>
+  );
+};
+
+export default memo(PinInput);

--- a/cardstack/src/components/Input/PinInput/types.ts
+++ b/cardstack/src/components/Input/PinInput/types.ts
@@ -1,0 +1,1 @@
+export type PinLayoutVariant = 'dark' | 'light';

--- a/cardstack/src/components/Input/index.ts
+++ b/cardstack/src/components/Input/index.ts
@@ -2,3 +2,4 @@ export * from './Input';
 export * from './InputAmount/InputAmount';
 export * from './InputAmount/useInputAmountHelper';
 export { default as FormInput } from './FormInput';
+export { default as PinInput } from './PinInput/PinInput';

--- a/cardstack/src/theme/colors.ts
+++ b/cardstack/src/theme/colors.ts
@@ -41,6 +41,7 @@ export const palette = {
   appleBlue: '#0E76FD',
   yellow: '#F9D849',
   darkPurple: '#272330',
+  darkerPurpleShade: '#1C1A21',
   darkGrayOpacity: 'rgba(39, 35, 48, 0.75)',
   mintDark: '#00E0A9',
   blueGreyDark: '#00E0A9',
@@ -50,6 +51,7 @@ export const palette = {
 
 export const colors = {
   backgroundDarkPurple: palette.darkPurple,
+  backgroundDarkerPurple: palette.darkerPurpleShade,
   backgroundGray: palette.grayBackground,
   backgroundLightGray: palette.grayBackgroundLight,
   backgroundBlue: palette.blueDark,


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
This PR adds the PinInput component, with "theme"  options dark | light, since it's a PIN component, we are keeping it simple, without handing paste/coping  nor handling the edition of a single cell. 

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->

![Simulator Screen Recording - iPhone 11 - 2022-05-18 at 16 31 19](https://user-images.githubusercontent.com/20520102/169141222-d2865e3e-a38b-44b9-81e9-3dff9fc02fc3.gif)

// Example: 
```tsx
  const [value, setValue] = useState('');

  return (
    <>
      <CenteredContainer flex={0.3} backgroundColor="white">
        <PinInput
          variant="light"
          value={value}
          onChangeText={setValue}
          secureTextEntry={false}
        />
      </CenteredContainer>
      <CenteredContainer flex={0.3} backgroundColor="backgroundDarkPurple">
        <PinInput variant="dark" value={value} onChangeText={setValue} />
      </CenteredContainer>
    </>
  );
```