### PR TITLE
[CS-3913] Handle /email-card-drop request failure for 503 status

### DIFF
--- a/cardstack/src/screens/RequestPrepaidCardScreen/strings.ts
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/strings.ts
@@ -27,4 +27,9 @@ export const strings = {
     title: 'Request Submitted',
     subtitle: 'Check your inbox to verify this request.',
   },
+  customError: {
+    title: 'Error',
+    message:
+      'Complimentary prepaid cards are not available at this time. Please try back later.',
+  },
 };

--- a/cardstack/src/screens/RequestPrepaidCardScreen/useRequestPrepaidCardScreen.ts
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/useRequestPrepaidCardScreen.ts
@@ -1,3 +1,4 @@
+import { FetchBaseQueryError } from '@reduxjs/toolkit/dist/query/fetchBaseQuery';
 import { useCallback, useMemo, useState, useEffect } from 'react';
 import { Linking } from 'react-native';
 
@@ -33,18 +34,24 @@ export const useRequestPrepaidCardScreen = () => {
 
   const [
     requestCardDrop,
-    { isError, isSuccess, isLoading },
+    { isError, isSuccess, isLoading, error },
   ] = useRequestEmailCardDropMutation();
+
+  const errorMessage = useMemo(() => {
+    const { status } = error as FetchBaseQueryError;
+
+    return status === 503 ? strings.customError : defaultErrorAlert;
+  }, [error]);
 
   useMutationEffects(
     useMemo(
       () => ({
         error: {
           status: isError,
-          callback: () => Alert(defaultErrorAlert),
+          callback: () => Alert(errorMessage),
         },
       }),
-      [isError]
+      [isError, errorMessage]
     )
   );
 


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds a custom error handling for the `POST` request to the `/email-card-drop` endpoint. Because this is a particular error, it's being treated in the component itself not on the `fetchHubBaseQuery` function.

Let me know if there's a need to cover this use case with a test 🙂

- [x] Completes #CS-3913

### Checklist

- [x] All UI changes have been tested on a small device
