### PR TITLE
[FIX] Removes useMemo for featurePrepaidCardDrop config value in useWelcomeCtaBanner hook.

### DIFF
--- a/cardstack/src/components/CtaBanner/useWelcomeCtaBanner.ts
+++ b/cardstack/src/components/CtaBanner/useWelcomeCtaBanner.ts
@@ -44,9 +44,9 @@ export const useWelcomeCtaBanner = () => {
   );
 
   // Card Drop banner is only visible if feature FLAG is enabled for current user.
-  const featurePrepaidCardDrop = useMemo(
-    () => getRemoteConfigAsBoolean(ConfigKey.featurePrepaidCardDrop),
-    []
+  // Since theres no hook dependency for this call we can't memoize it.
+  const featurePrepaidCardDrop = getRemoteConfigAsBoolean(
+    ConfigKey.featurePrepaidCardDrop
   );
 
   const showBanner = useMemo(


### PR DESCRIPTION
### Description

Removes useMemo from featurePrepaidCardDrop remote config get call, so config value is not cached in the hook. Since this memo doesn't have a dependency to update itself, it was holding to an old value.
