### PR TITLE
[CS-3926]: Share same tags across remote-config

### DIFF
--- a/cardstack/src/components/AppRequirementsCheck/AppRequirementsCheck.tsx
+++ b/cardstack/src/components/AppRequirementsCheck/AppRequirementsCheck.tsx
@@ -4,11 +4,7 @@ import VersionNumber from 'react-native-version-number';
 
 import { MinimumVersion } from '@cardstack/components/MinimumVersion';
 import { useLoadRemoteConfigs } from '@cardstack/hooks';
-import {
-  ConfigKey,
-  getRemoteConfigAsBoolean,
-  getRemoteConfigAsString,
-} from '@cardstack/services/remote-config';
+import { remoteFlags } from '@cardstack/services/remote-config';
 
 import { useHideSplashScreen } from '@rainbow-me/hooks';
 import MaintenanceMode from '@rainbow-me/screens/MaintenanceMode';
@@ -22,30 +18,18 @@ export const AppRequirementsCheck = ({ children }: Props) => {
   const { isReady } = useLoadRemoteConfigs();
   const hideSplashScreen = useHideSplashScreen();
 
-  const maintenanceActive = useMemo(
-    () => isReady && getRemoteConfigAsBoolean(ConfigKey.maintenanceActive),
-    [isReady]
-  );
-
-  const maintenanceMessage = useMemo(
-    () => isReady && getRemoteConfigAsString(ConfigKey.maintenanceMessage),
-    [isReady]
-  );
-
   const forceUpdate = useMemo(() => {
     if (!isReady) return false;
 
     const appVersion = VersionNumber.appVersion;
 
-    const minVersion = getRemoteConfigAsString(
-      ConfigKey.requiredMinimumVersion
-    );
+    const minVersion = remoteFlags().requiredMinimumVersion;
 
     return compareVersions(minVersion, appVersion) > 0;
   }, [isReady]);
 
-  if (maintenanceActive) {
-    return <MaintenanceMode message={maintenanceMessage} />;
+  if (isReady && remoteFlags().maintenanceActive) {
+    return <MaintenanceMode message={remoteFlags().maintenanceMessage} />;
   }
 
   if (forceUpdate) {

--- a/cardstack/src/components/CtaBanner/useWelcomeCtaBanner.ts
+++ b/cardstack/src/components/CtaBanner/useWelcomeCtaBanner.ts
@@ -3,10 +3,7 @@ import { useCallback, useMemo } from 'react';
 
 import { Routes } from '@cardstack/navigation';
 import { useGetEoaClaimedQuery } from '@cardstack/services/hub/hub-api';
-import {
-  ConfigKey,
-  getRemoteConfigAsBoolean,
-} from '@cardstack/services/remote-config';
+import { remoteFlags } from '@cardstack/services/remote-config';
 import { isLayer2 } from '@cardstack/utils';
 
 import { useWallets, useAccountSettings } from '@rainbow-me/hooks';
@@ -43,22 +40,15 @@ export const useWelcomeCtaBanner = () => {
     [selectedAccount]
   );
 
-  // Card Drop banner is only visible if feature FLAG is enabled for current user.
-  // Since theres no hook dependency for this call we can't memoize it.
-  const featurePrepaidCardDrop = getRemoteConfigAsBoolean(
-    ConfigKey.featurePrepaidCardDrop
-  );
-
   const showBanner = useMemo(
     () =>
       isLayer2(network) &&
-      featurePrepaidCardDrop &&
+      remoteFlags().featurePrepaidCardDrop &&
       showBannerUserDecision &&
       isFirstAddressForCurrentWallet &&
       !emailDropGetData?.claimed &&
       !emailDropGetData?.rateLimited,
     [
-      featurePrepaidCardDrop,
       showBannerUserDecision,
       isFirstAddressForCurrentWallet,
       network,

--- a/cardstack/src/services/remote-config/remote-config-service.ts
+++ b/cardstack/src/services/remote-config/remote-config-service.ts
@@ -1,15 +1,12 @@
 import remoteConfig from '@react-native-firebase/remote-config';
 
-import remoteConfigDefaults from './remote_config_defaults.json';
+import { remoteConfigDefaults } from './remoteConfigDefaults';
 
 const CACHE_INTERVAL_MILLIS = __DEV__ ? 60000 : 21600000; // 21600000ms == 6hrs.
 
-export enum ConfigKey {
-  requiredMinimumVersion = 'requiredMinimumVersion',
-  maintenanceActive = 'maintenanceActive',
-  maintenanceMessage = 'maintenanceMessage',
-  featurePrepaidCardDrop = 'featurePrepaidCardDrop',
-}
+type RemoteConfigValues = typeof remoteConfigDefaults;
+
+type ConfigKey = keyof RemoteConfigValues;
 
 export const loadRemoteConfigs = async () => {
   await remoteConfig().setConfigSettings({
@@ -25,8 +22,15 @@ export const forceFetch = async () => {
   await remoteConfig().activate();
 };
 
-export const getRemoteConfigAsBoolean = (key: ConfigKey) =>
+const getRemoteConfigAsBoolean = (key: ConfigKey) =>
   remoteConfig().getValue(key).asBoolean();
 
-export const getRemoteConfigAsString = (key: ConfigKey) =>
+const getRemoteConfigAsString = (key: ConfigKey) =>
   remoteConfig().getValue(key).asString();
+
+export const remoteFlags = (): { [K in ConfigKey]: RemoteConfigValues[K] } => ({
+  requiredMinimumVersion: getRemoteConfigAsString('requiredMinimumVersion'),
+  maintenanceActive: getRemoteConfigAsBoolean('maintenanceActive'),
+  maintenanceMessage: getRemoteConfigAsString('maintenanceMessage'),
+  featurePrepaidCardDrop: getRemoteConfigAsBoolean('featurePrepaidCardDrop'),
+});

--- a/cardstack/src/services/remote-config/remoteConfigDefaults.ts
+++ b/cardstack/src/services/remote-config/remoteConfigDefaults.ts
@@ -1,0 +1,7 @@
+export const remoteConfigDefaults = {
+  requiredMinimumVersion: '1.1.1',
+  maintenanceActive: false,
+  maintenanceMessage:
+    'Card Wallet is going through scheduled maintenance, please try again later.',
+  featurePrepaidCardDrop: false,
+};

--- a/cardstack/src/services/remote-config/remote_config_defaults.json
+++ b/cardstack/src/services/remote-config/remote_config_defaults.json
@@ -1,6 +1,0 @@
-{
-  "requiredMinimumVersion": "1.1.1",
-  "maintenanceActive": "false",
-  "maintenanceMessage": "Card Wallet is going through scheduled maintenance, please try again later.",
-  "featurePrepaidCardDrop": "false"
-}


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Updates the firebase remote-config module to use the same tag, types, from default value, so we don't forget to update anywhere in case of a new flag etc, also adds a function that returns all the values, so it's easier to access. 
We could also improve the remoteFlags function in the future, to automatically map if it's a string, number, or boolean, and return the correct flag.
