### PR TITLE
[CS-3809] Re-enable max send button

### DIFF
--- a/cardstack/src/screens/SendSheetDepot/__tests__/useSendSheetDepotScreen.test.ts
+++ b/cardstack/src/screens/SendSheetDepot/__tests__/useSendSheetDepotScreen.test.ts
@@ -194,27 +194,4 @@ describe('useSendSheetDepotScreen', () => {
       expect(result.current.selectedGasPrice).toEqual(SelectedGasPrice)
     );
   });
-
-  // it('should enable max balance state if tap on max button', () => {});
-
-  it('should sendTokens with undefined amount if max enabled', () => {
-    (useAccountSettings as jest.Mock).mockImplementation(() => ({
-      accountAddress: '0x0000000000000000000',
-    }));
-
-    const mockSendTokens = jest.fn();
-
-    (getSafesInstance as jest.Mock).mockResolvedValue({
-      sendTokens: mockSendTokens,
-    });
-
-    expect(mockSendTokens).toBeCalledWith(
-      safeAddress,
-      selected?.address || '',
-      recipient,
-      undefined,
-      undefined,
-      { from: accountAddress }
-    );
-  });
 });

--- a/cardstack/src/screens/SendSheetDepot/__tests__/useSendSheetDepotScreen.test.ts
+++ b/cardstack/src/screens/SendSheetDepot/__tests__/useSendSheetDepotScreen.test.ts
@@ -194,4 +194,27 @@ describe('useSendSheetDepotScreen', () => {
       expect(result.current.selectedGasPrice).toEqual(SelectedGasPrice)
     );
   });
+
+  // it('should enable max balance state if tap on max button', () => {});
+
+  it('should sendTokens with undefined amount if max enabled', () => {
+    (useAccountSettings as jest.Mock).mockImplementation(() => ({
+      accountAddress: '0x0000000000000000000',
+    }));
+
+    const mockSendTokens = jest.fn();
+
+    (getSafesInstance as jest.Mock).mockResolvedValue({
+      sendTokens: mockSendTokens,
+    });
+
+    expect(mockSendTokens).toBeCalledWith(
+      safeAddress,
+      selected?.address || '',
+      recipient,
+      undefined,
+      undefined,
+      { from: accountAddress }
+    );
+  });
 });

--- a/cardstack/src/screens/SendSheetDepot/useSendSheetDepotScreen.ts
+++ b/cardstack/src/screens/SendSheetDepot/useSendSheetDepotScreen.ts
@@ -321,10 +321,10 @@ export const useSendSheetDepotScreen = () => {
   const { signerParams } = useWallets();
 
   const sendTokenFromDepot = useCallback(async () => {
+    let amountInWei;
+
     try {
       const safes = await getSafesInstance(signerParams);
-
-      let amountInWei;
 
       if (!isMaxEnabled) {
         amountInWei = Web3.utils.toWei(amountDetails.assetAmount);
@@ -344,7 +344,7 @@ export const useSendSheetDepotScreen = () => {
         args: {
           safeAddress,
           recipient,
-          amountInWei: Web3.utils.toWei(amountDetails.assetAmount),
+          amountInWei,
           accountAddress,
           token: selected?.address,
         },
@@ -357,6 +357,7 @@ export const useSendSheetDepotScreen = () => {
     safeAddress,
     selected,
     signerParams,
+    isMaxEnabled,
   ]);
 
   const canSubmit = useMemo(() => {


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

PR re-enables MAX send button in Depot send screen and uses new undefined `amount` parameter in SDK's `sendTokens` function to send full balance. 

- [x] Completes #(CS-3809)

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/169854250-25b1c8af-2cc5-4f0f-a00b-4b739ed88012.jpg">

Co-authored by @paulinhapenedo 👏 