### PR TITLE
[CS-3865] Add Change Pin item on Settings menu

### DIFF
--- a/globalVariables.js
+++ b/globalVariables.js
@@ -7,15 +7,12 @@ import {
   useState,
 } from 'react';
 import { Platform } from 'react-native';
-import { ENABLE_DEV_MODE } from 'react-native-dotenv';
 import { useTheme } from './src/context/ThemeContext';
 import magicMemo from '@rainbow-me/utils/magicMemo';
 
 export default {
   android: Platform.OS === 'android',
   ios: Platform.OS === 'ios',
-  IS_DEV:
-    (typeof __DEV__ === 'boolean' && __DEV__) || !!Number(ENABLE_DEV_MODE),
   magicMemo,
   useCallback,
   useContext,

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -2,7 +2,6 @@ import * as rnKeychain from 'react-native-keychain';
 
 // @ts-ignore
 declare let __DEV__: boolean;
-declare let IS_DEV: boolean;
 declare let akd: boolean;
 
 /* Rainbow uses a rn-keychain patch with these two custom methods

--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -83,6 +83,10 @@ export default function SettingsSection({
     [wallets]
   );
 
+  const onPressChangePin = useCallback(() => {
+    console.log('Go to Change Pin screen');
+  }, []);
+
   return (
     <ScrollView backgroundColor="white">
       <ColumnWithDividers dividerRenderer={ListItemDivider} marginTop={7}>
@@ -144,6 +148,16 @@ export default function SettingsSection({
         >
           <ListItemArrowGroup />
         </ListItem>
+        {__DEV__ && (
+          <ListItem
+            icon={<Icon color="settingsTeal" name="lock" />}
+            label="Change Pin"
+            onPress={onPressChangePin}
+            testID="changePin-section"
+          >
+            <ListItemArrowGroup />
+          </ListItem>
+        )}
       </ColumnWithDividers>
       <ListFooter />
       <ColumnWithDividers dividerRenderer={ListItemDivider}>
@@ -174,7 +188,7 @@ export default function SettingsSection({
           testID="feedback-section"
         />
       </ColumnWithDividers>
-      {IS_DEV && (
+      {__DEV__ && (
         <>
           <ListFooter height={10} />
           <ListItem

--- a/src/screens/SettingsModal.js
+++ b/src/screens/SettingsModal.js
@@ -75,12 +75,12 @@ export const SettingsPages = {
     title: 'Settings',
   },
   dev: {
-    component: IS_DEV ? DeveloperSettings : null,
+    component: __DEV__ ? DeveloperSettings : null,
     key: 'DevSection',
     title: 'Dev',
   },
   designSystem: {
-    component: IS_DEV ? DesignSystemScreen : null,
+    component: __DEV__ ? DesignSystemScreen : null,
     key: 'DesignSystem',
     title: 'Design System',
   },


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds the Change Pin option to the Settings Menu. Right now, we don't have a route to redirect when tapping the item, so I've left a `console.log`.

While on the area, I noticed that we have two flags for development mode: `IS_DEV` and `__DEV__`. Seems that the latter is the approach the team decided to use moving forward, so I replaced the instances where we were using `IS_DEV` and removed it from the `globals.d.ts` file.

- [x] Completes #CS-3865

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<img width="370" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/169892852-0285f52e-5a78-4be7-8015-5a3e9a0c9b96.png"> 

<img width="370" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/169892858-92d468c2-3637-4dc4-ac54-73f42f772a37.png"> 

