### PR TITLE
[CS-3937] Prepaid Card: disable Submit button if both email and checkbox are not valid

### DIFF
--- a/cardstack/src/screens/RequestPrepaidCardScreen/RequestPrepaidCardScreen.tsx
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/RequestPrepaidCardScreen.tsx
@@ -96,7 +96,7 @@ const RequestPrepaidCardScreen = () => {
                 variant={!canSubmit ? 'disabledBlack' : undefined}
                 onPress={onSubmitPress}
                 iconProps={!isAuthenticated ? iconProps : undefined}
-                disablePress={isLoading}
+                disablePress={isLoading || !canSubmit}
                 loading={isLoading}
               >
                 {strings.button.submit}

--- a/cardstack/src/screens/RequestPrepaidCardScreen/RequestPrepaidCardScreen.tsx
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/RequestPrepaidCardScreen.tsx
@@ -96,7 +96,7 @@ const RequestPrepaidCardScreen = () => {
                 variant={!canSubmit ? 'disabledBlack' : undefined}
                 onPress={onSubmitPress}
                 iconProps={!isAuthenticated ? iconProps : undefined}
-                disablePress={isLoading || !canSubmit}
+                disablePress={isLoading}
                 loading={isLoading}
               >
                 {strings.button.submit}

--- a/cardstack/src/screens/RequestPrepaidCardScreen/useRequestPrepaidCardScreen.ts
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/useRequestPrepaidCardScreen.ts
@@ -70,14 +70,20 @@ export const useRequestPrepaidCardScreen = () => {
   }, [termsAccepted]);
 
   const onSubmitPress = useCallback(() => {
-    if (!canSubmit) {
+    // error message should only be triggered with email validation
+    if (!inputValid) {
       setHasError(true);
 
       return;
     }
 
+    // handles the validation combo of email + checkbox
+    if (!canSubmit) {
+      return;
+    }
+
     requestCardDrop({ email });
-  }, [canSubmit, email, requestCardDrop]);
+  }, [canSubmit, inputValid, email, requestCardDrop]);
 
   const onSupportLinkPress = useCallback(() => {
     Linking.openURL(strings.termsBanner.link.url);


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

This PR enhances the `disablePress` prop from the Submit button on the request prepaid card screen. The button should be disabled, both visually and in functionality, until the user enters a valid email and checks the checkbox. 

<!-- Include a summary of the changes. -->

- [x] Completes #CS-3937

### Checklist

- [x] All UI changes have been tested on a small device




