### PR TITLE
[CS-3871]: Add SecureStore package and initial models

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+SECURE_STORE_KEY=mock-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .env.*
+!*.test
 ios/Frameworks/GoogleService-Info.plist
 .eslintcache
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -35,6 +35,7 @@ module.exports = function (api) {
         whitelist: null,
         safe: false,
         allowUndefined: true,
+        envName: 'APP_ENV',
       },
     ],
   ];

--- a/cardstack/src/models/__tests__/secure-storage.test.ts
+++ b/cardstack/src/models/__tests__/secure-storage.test.ts
@@ -1,0 +1,92 @@
+import * as SecureStore from 'expo-secure-store';
+
+import logger from 'logger';
+
+import { deletePin, getPin, savePin } from '../secure-storage';
+
+const mockKey = `mock-key`;
+const mockPin = '123456';
+const pinKey = `${mockKey}_AUTH_PIN`;
+
+const localSecureStorage: any = {};
+
+describe('secure-storage', () => {
+  let mockSetItemAsync: jest.SpyInstance<Promise<void>>;
+  let mockGetItemAsync: jest.SpyInstance<Promise<string | null>>;
+  let mockDeleteItemAsync: jest.SpyInstance<Promise<void>>;
+
+  beforeAll(() => {
+    logger.sentry = jest.fn();
+  });
+
+  beforeEach(() => {
+    mockSetItemAsync = jest
+      .spyOn(SecureStore, 'setItemAsync')
+      .mockImplementation(
+        (key: string, pin: string): Promise<void> => {
+          localSecureStorage[key] = pin;
+
+          return Promise.resolve();
+        }
+      );
+
+    mockGetItemAsync = jest
+      .spyOn(SecureStore, 'getItemAsync')
+      .mockImplementation(
+        (key: string): Promise<string | null> => {
+          const storedValue = localSecureStorage[key];
+
+          if (storedValue) return Promise.resolve(storedValue);
+
+          return Promise.reject(new Error('Invalid key'));
+        }
+      );
+
+    mockDeleteItemAsync = jest
+      .spyOn(SecureStore, 'deleteItemAsync')
+      .mockImplementation(
+        (key: string): Promise<void> => {
+          delete localSecureStorage[key];
+
+          return Promise.resolve();
+        }
+      );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('Pin storage', () => {
+    it('should save pin', async () => {
+      await savePin(mockPin);
+
+      expect(mockSetItemAsync).toBeCalledWith(pinKey, mockPin);
+    });
+
+    it('should return stored pin', async () => {
+      const storedPin = await getPin();
+
+      expect(mockGetItemAsync).toBeCalledWith(pinKey, undefined);
+      expect(storedPin).toEqual(mockPin);
+    });
+
+    it('delete stored pin', async () => {
+      await deletePin();
+
+      expect(mockDeleteItemAsync).toBeCalledWith(pinKey);
+      expect(localSecureStorage[pinKey]).toBeUndefined();
+    });
+
+    it('should error if no pin is found', async () => {
+      const storedPin = await getPin();
+
+      expect(mockGetItemAsync).toBeCalledWith(pinKey, undefined);
+      expect(storedPin).toBeNull();
+      expect(logger.sentry).toBeCalledWith(
+        'No value for key: AUTH_PIN',
+        new Error('Invalid key')
+      );
+    });
+  });
+});

--- a/cardstack/src/models/auth.ts
+++ b/cardstack/src/models/auth.ts
@@ -1,0 +1,22 @@
+import { getPin } from './secure-storage';
+
+const authenticate = async (pin?: string, isBiometricAuthValid?: string) => {
+  const storedPin = await getPin();
+
+  if (!storedPin) {
+    // TODO: Handle prompt pin screen
+    return;
+  }
+
+  if (isBiometricAuthValid) {
+    return storedPin;
+  }
+
+  if (pin && pin === storedPin) {
+    return pin;
+  }
+
+  return null;
+};
+
+export { authenticate };

--- a/cardstack/src/models/secure-storage.ts
+++ b/cardstack/src/models/secure-storage.ts
@@ -1,6 +1,7 @@
 import * as SecureStore from 'expo-secure-store';
 import { SECURE_STORE_KEY } from 'react-native-dotenv';
 
+import AesEncryptor from '@rainbow-me/handlers/aesEncryption';
 import logger from 'logger';
 
 const keys = {
@@ -36,4 +37,58 @@ const getPin = () => getSecureValue(keys.AUTH_PIN);
 
 const deletePin = () => SecureStore.deleteItemAsync(keys.AUTH_PIN);
 
-export { savePin, getPin, deletePin };
+const encryptor = new AesEncryptor();
+
+// SEED
+const getSeedKey = (walletId: string) => `${keys.SEED}_${walletId}`;
+
+const saveSeedPhrase = async (seed: string, walletId: string) => {
+  try {
+    const pin = await getPin();
+    console.log({ pin });
+
+    if (pin) {
+      const encryptedSeed = await encryptor.encrypt(pin, seed);
+
+      if (encryptedSeed) {
+        console.log({ encryptedSeed });
+        const seedKey = getSeedKey(walletId);
+
+        await SecureStore.setItemAsync(seedKey, encryptedSeed);
+      }
+    }
+  } catch (e) {
+    logger.sentry('Error saving seed', e);
+  }
+};
+
+const getSeedPhrase = async (walletId: string, pin: string) => {
+  const seedKey = getSeedKey(walletId);
+
+  try {
+    const encryptedSeed = await getSecureValue(seedKey as Keys);
+
+    if (encryptedSeed) {
+      const seed = await encryptor.decrypt(pin, encryptedSeed);
+
+      return seed;
+    }
+  } catch (e) {
+    logger.sentry('Error retrieving seed', e);
+  }
+};
+
+const deleteSeedPhrase = async (walletId: string) => {
+  const seedKey = getSeedKey(walletId);
+
+  await SecureStore.deleteItemAsync(seedKey);
+};
+
+export {
+  savePin,
+  getPin,
+  deletePin,
+  deleteSeedPhrase,
+  getSeedPhrase,
+  saveSeedPhrase,
+};

--- a/cardstack/src/models/secure-storage.ts
+++ b/cardstack/src/models/secure-storage.ts
@@ -1,0 +1,39 @@
+import * as SecureStore from 'expo-secure-store';
+import { SECURE_STORE_KEY } from 'react-native-dotenv';
+
+import logger from 'logger';
+
+const keys = {
+  AUTH_PIN: `${SECURE_STORE_KEY}_AUTH_PIN`,
+  SEED: `${SECURE_STORE_KEY}_SEED`,
+} as const;
+
+type KeysType = typeof keys;
+
+type Keys = KeysType[keyof KeysType];
+
+const getSecureValue = async (
+  key: Keys,
+  options?: SecureStore.SecureStoreOptions
+) => {
+  try {
+    const result = await SecureStore.getItemAsync(key, options);
+
+    return result;
+  } catch (e) {
+    const secureKey = key.replace(`${SECURE_STORE_KEY}_`, '');
+
+    logger.sentry(`No value for key: ${secureKey}`, e);
+
+    return null;
+  }
+};
+
+// PIN
+const savePin = (pin: string) => SecureStore.setItemAsync(keys.AUTH_PIN, pin);
+
+const getPin = () => getSecureValue(keys.AUTH_PIN);
+
+const deletePin = () => SecureStore.deleteItemAsync(keys.AUTH_PIN);
+
+export { savePin, getPin, deletePin };

--- a/cardstack/src/models/secure-storage.ts
+++ b/cardstack/src/models/secure-storage.ts
@@ -45,13 +45,11 @@ const getSeedKey = (walletId: string) => `${keys.SEED}_${walletId}`;
 const saveSeedPhrase = async (seed: string, walletId: string) => {
   try {
     const pin = await getPin();
-    console.log({ pin });
 
     if (pin) {
       const encryptedSeed = await encryptor.encrypt(pin, seed);
 
       if (encryptedSeed) {
-        console.log({ encryptedSeed });
         const seedKey = getSeedKey(walletId);
 
         await SecureStore.setItemAsync(seedKey, encryptedSeed);

--- a/cardstack/src/types/react-native-dotenv.d.ts
+++ b/cardstack/src/types/react-native-dotenv.d.ts
@@ -21,4 +21,5 @@ declare module 'react-native-dotenv' {
   export const STATUS_API_BASE_URL: string;
   export const VERSION_TAP_COUNT: string;
   export const OPENSEA_API_KEY: string;
+  export const SECURE_STORE_KEY: string;
 }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -19,6 +19,8 @@ PODS:
   - ExpoModulesCore (0.9.2):
     - React-Core
     - ReactCommon/turbomodule/core
+  - EXSecureStore (11.2.0):
+    - ExpoModulesCore
   - FBLazyVector (0.65.1)
   - FBReactNativeSpec (0.65.1):
     - RCT-Folly (= 2021.04.26.00)
@@ -636,6 +638,7 @@ DEPENDENCIES:
   - Expo (from `../node_modules/expo/ios`)
   - ExpoKeepAwake (from `../node_modules/expo-keep-awake/ios`)
   - ExpoModulesCore (from `../node_modules/expo-modules-core/ios`)
+  - EXSecureStore (from `../node_modules/expo-secure-store/ios`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
   - FLAnimatedImage
@@ -801,6 +804,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-keep-awake/ios"
   ExpoModulesCore:
     :path: "../node_modules/expo-modules-core/ios"
+  EXSecureStore:
+    :path: "../node_modules/expo-secure-store/ios"
   FBLazyVector:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
   FBReactNativeSpec:
@@ -980,6 +985,7 @@ SPEC CHECKSUMS:
   Expo: 64d52669fa3b9342919b5b44b2b4f15f19b0cf76
   ExpoKeepAwake: c0c494b442ecd8122974c13b93ccfb57bd408e88
   ExpoModulesCore: e4278a668e8c13c0269ed8b8a4200989deea2973
+  EXSecureStore: aaae919d83aec2faf031e99398807edac0313285
   FBLazyVector: 33c82491102f20ecddb6c6a2c273696ace3191e0
   FBReactNativeSpec: df8f81d2a7541ee6755a047b398a5cb5a72acd0e
   Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
   ],
   coverageDirectory: '.coverage',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  preset: 'react-native',
+  preset: 'jest-expo',
   setupFilesAfterEnv: ['<rootDir>/cardstack/src/test-utils/jest-setup.js'],
   testMatch: [
     '<rootDir>/cardstack/**/*.test.ts',
@@ -26,7 +26,7 @@ module.exports = {
     '<rootDir>/cardstack/**/*.test.tsx',
   ],
   transformIgnorePatterns: [
-    'node_modules/(?!(jest-)?react-native|react-native|@react-native|@cardstack|@sentry/.*|@react-navigation)',
+    'node_modules/(?!((jest-)?react-native|@sentry|@cardstack|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)',
   ],
   moduleNameMapper: {
     ...pathsToModuleNameMapper(compilerOptions.paths, {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "ethers": "^5.6.4",
     "events": "^1.1.1",
     "expo": "^45.0.0",
+    "expo-secure-store": "~11.2.0",
     "global": "^4.3.2",
     "grapheme-splitter": "^1.0.4",
     "graphql-tag": "^2.10.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "postinstall": "./scripts/postinstall.sh",
     "start": "yarn prestorybook && react-native start",
     "start:clean": "watchman watch-del-all && rm -rf $TMPDIR/react-* && rm -rf $TMPDIR/metro-* && rm -rf $TMPDIR/haste-map-* && react-native start -- --reset-cache",
-    "test": "jest --coverage",
+    "test": "APP_ENV=test jest --coverage",
     "ci": "yarn lint && yarn ts-check",
     "android-reverse-ports": "adb reverse tcp:8097 tcp:8097 && adb reverse tcp:8081 tcp:8081",
     "update-token-list": "./scripts/update-token-list.sh",
@@ -115,6 +115,7 @@
     "imgix-core-js": "^2.3.2",
     "immer": "^8.0.1",
     "inherits": "^2.0.3",
+    "jest-expo": "^45.0.1",
     "lint-staged": "^10.0.7",
     "lodash": "^4.17.19",
     "lottie-ios": "^3.2.3",
@@ -128,6 +129,7 @@
     "patch-package": "^6.2.0",
     "path-browserify": "0.0.0",
     "prop-types": "^15.7.2",
+    "punycode": "^1.2.4",
     "querystring-es3": "^0.2.1",
     "rainbow-token-list": "rainbow-me/token-lists#092bd84fac3b2032b94f05a1a49899252e5eb923",
     "react": "17.0.2",
@@ -211,8 +213,7 @@
     "vm-browserify": "0.0.4",
     "web3": "1.5.2",
     "web3-core": "^1.5.2",
-    "zxcvbn": "^4.4.2",
-    "punycode": "^1.2.4"
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4293,6 +4293,18 @@
     jest-util "^26.6.2"
     slash "^3.0.0"
 
+"@jest/console@^27.5.1":
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.5.1.tgz#260fe7239602fe5130a94f1aa386eff54b014bba"
+  integrity sha512-kZ/tNpS3NXn0mlXXXPNuDZnb4c0oZ20r4K5eemM2k30ZC3G0T02nXUvyhf5YdbXWHPEJLc9qGLxEZ216MdL+Zg==
+  dependencies:
+    "@jest/types" "^27.5.1"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    jest-message-util "^27.5.1"
+    jest-util "^27.5.1"
+    slash "^3.0.0"
+
 "@jest/core@^26.6.3":
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/@jest/core/-/core-26.6.3.tgz#7639fcb3833d748a4656ada54bde193051e45fad"
@@ -4466,6 +4478,16 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
+"@jest/test-result@^27.5.1":
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.5.1.tgz#56a6585fa80f7cdab72b8c5fc2e871d03832f5bb"
+  integrity sha512-EW35l2RYFUcUQxFJz5Cv5MTOxlJIQs4I7gxzi2zVU7PJhOwfYq1MdC5nhSmYjX1gmMmLPvB3sIaC+BkcHRBfag==
+  dependencies:
+    "@jest/console" "^27.5.1"
+    "@jest/types" "^27.5.1"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
+
 "@jest/test-sequencer@^26.5.3":
   version "26.5.3"
   resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-26.5.3.tgz#9ae0ab9bc37d5171b28424029192e50229814f8d"
@@ -4586,6 +4608,17 @@
   version "27.4.2"
   resolved "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz#96536ebd34da6392c2b7c7737d693885b5dd44a5"
   integrity sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^27.5.1":
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.5.1.tgz#3c79ec4a8ba61c170bf937bcf9e98a9df175ec80"
+  integrity sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
@@ -7002,6 +7035,13 @@ ansi-escapes@^3.0.0, ansi-escapes@^3.1.0, ansi-escapes@^3.2.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
+ansi-escapes@^4.3.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
+  dependencies:
+    type-fest "^0.21.3"
+
 ansi-fragments@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansi-fragments/-/ansi-fragments-0.2.1.tgz#24409c56c4cc37817c3d7caa99d8969e2de5a05e"
@@ -8860,7 +8900,7 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ci-info@^3.3.0:
+ci-info@^3.2.0, ci-info@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.1.tgz#58331f6f472a25fe3a50a351ae3052936c2c7f32"
   integrity sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==
@@ -13238,6 +13278,11 @@ graceful-fs@^4.2.3:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
+graceful-fs@^4.2.9:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
 grapheme-splitter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
@@ -14915,6 +14960,21 @@ jest-environment-node@^26.6.2:
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
 
+jest-expo@^45.0.1:
+  version "45.0.1"
+  resolved "https://registry.yarnpkg.com/jest-expo/-/jest-expo-45.0.1.tgz#59b26f30cb2198d7b5aa17886f08b31b38482ad1"
+  integrity sha512-45+QiO6FRnYgJKavhUly53NRBtld68SGAsHUGUOgL3XkAcwfDLqnaWyeWwbuqT1BjKp99lisg7Iaw5mUlB/WYw==
+  dependencies:
+    "@expo/config" "^6.0.14"
+    "@jest/create-cache-key-function" "^27.0.1"
+    babel-jest "^26.6.3"
+    find-up "^5.0.0"
+    jest-watch-select-projects "^2.0.0"
+    jest-watch-typeahead "0.6.4"
+    json5 "^2.1.0"
+    lodash "^4.17.19"
+    react-test-renderer "~17.0.2"
+
 jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
@@ -15095,6 +15155,21 @@ jest-message-util@^26.6.2:
     slash "^3.0.0"
     stack-utils "^2.0.2"
 
+jest-message-util@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.5.1.tgz#bdda72806da10d9ed6425e12afff38cd1458b6cf"
+  integrity sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^27.5.1"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^27.5.1"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
 jest-mock@^26.5.2:
   version "26.5.2"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.5.2.tgz#c9302e8ef807f2bfc749ee52e65ad11166a1b6a1"
@@ -15120,6 +15195,11 @@ jest-regex-util@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-26.0.0.tgz#d25e7184b36e39fd466c3bc41be0971e821fee28"
   integrity sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==
+
+jest-regex-util@^27.0.0:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-27.5.1.tgz#4da143f7e9fd1e542d4aa69617b38e4a78365b95"
+  integrity sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==
 
 jest-resolve-dependencies@^26.6.3:
   version "26.6.3"
@@ -15364,6 +15444,18 @@ jest-util@^26.5.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
+jest-util@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.5.1.tgz#3ba9771e8e31a0b85da48fe0b0891fb86c01c2f9"
+  integrity sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==
+  dependencies:
+    "@jest/types" "^27.5.1"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
 jest-validate@^26.5.2, jest-validate@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-26.6.2.tgz#23d380971587150467342911c3d7b4ac57ab20ec"
@@ -15388,6 +15480,28 @@ jest-validate@^26.5.3:
     leven "^3.1.0"
     pretty-format "^26.5.2"
 
+jest-watch-select-projects@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jest-watch-select-projects/-/jest-watch-select-projects-2.0.0.tgz#4373d7e4de862aae28b46e036b669a4c913ea867"
+  integrity sha512-j00nW4dXc2NiCW6znXgFLF9g8PJ0zP25cpQ1xRro/HU2GBfZQFZD0SoXnAlaoKkIY4MlfTMkKGbNXFpvCdjl1w==
+  dependencies:
+    ansi-escapes "^4.3.0"
+    chalk "^3.0.0"
+    prompts "^2.2.1"
+
+jest-watch-typeahead@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-0.6.4.tgz#ea70bf1bec34bd4f55b5b72d471b02d997899c3e"
+  integrity sha512-tGxriteVJqonyrDj/xZHa0E2glKMiglMLQqISLCjxLUfeueRBh9VoRF2FKQyYO2xOqrWDTg7781zUejx411ZXA==
+  dependencies:
+    ansi-escapes "^4.3.1"
+    chalk "^4.0.0"
+    jest-regex-util "^27.0.0"
+    jest-watcher "^27.0.0"
+    slash "^3.0.0"
+    string-length "^4.0.1"
+    strip-ansi "^6.0.0"
+
 jest-watcher@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-26.6.2.tgz#a5b683b8f9d68dbcb1d7dae32172d2cca0592975"
@@ -15399,6 +15513,19 @@ jest-watcher@^26.6.2:
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
     jest-util "^26.6.2"
+    string-length "^4.0.1"
+
+jest-watcher@^27.0.0:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-27.5.1.tgz#71bd85fb9bde3a2c2ec4dc353437971c43c642a2"
+  integrity sha512-z676SuD6Z8o8qbmEGhoEUFOM1+jfEiL3DXHK/xgEiG2EyNYfFG60jluWcupY6dATjfEsKQuibReS1djInQnoVw==
+  dependencies:
+    "@jest/test-result" "^27.5.1"
+    "@jest/types" "^27.5.1"
+    "@types/node" "*"
+    ansi-escapes "^4.2.1"
+    chalk "^4.0.0"
+    jest-util "^27.5.1"
     string-length "^4.0.1"
 
 jest-worker@^26.0.0, jest-worker@^26.6.2:
@@ -15679,6 +15806,11 @@ json5@^1.0.1:
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+json5@^2.1.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
+  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
 json5@^2.1.2:
   version "2.1.3"
@@ -18697,7 +18829,7 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
-picomatch@^2.3.1:
+picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -19061,6 +19193,15 @@ pretty-format@^27.0.0, pretty-format@^27.3.1:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
+pretty-format@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 pretty-ms@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-7.0.1.tgz#7d903eaab281f7d8e03c66f867e239dc32fb73e8"
@@ -19135,7 +19276,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prompts@^2.3.2:
+prompts@^2.2.1, prompts@^2.3.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
   integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
@@ -20038,7 +20179,7 @@ react-syntax-highlighter@^13.5.0:
     prismjs "^1.21.0"
     refractor "^3.1.0"
 
-react-test-renderer@17.0.2:
+react-test-renderer@17.0.2, react-test-renderer@~17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.2.tgz#4cd4ae5ef1ad5670fc0ef776e8cc7e1231d9866c"
   integrity sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==
@@ -21598,6 +21739,13 @@ stack-utils@^2.0.2:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stack-utils@^2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.5.tgz#d25265fca995154659dbbfba3b49254778d2fdd5"
+  integrity sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+
 stackframe@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
@@ -22808,6 +22956,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-fest@^0.3.1:
   version "0.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12021,6 +12021,11 @@ expo-modules-core@0.9.2:
     compare-versions "^3.4.0"
     invariant "^2.2.4"
 
+expo-secure-store@~11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/expo-secure-store/-/expo-secure-store-11.2.0.tgz#c2c8fdcac39c5e1828a8fea45765028a11625575"
+  integrity sha512-PlmDplx9QNqaTVKNLgqSurRhzYf6YbVTTiSKX5JlEMWgOiBTz77Nh6mpMMjI1jwrvtz9grD+CT2AlDEGXe+Ovg==
+
 expo@^45.0.0:
   version "45.0.4"
   resolved "https://registry.yarnpkg.com/expo/-/expo-45.0.4.tgz#a34d250605d5603e3cea4acf169aedd288df477b"


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds the SecureStore package with Pin and seedPhrase models.

- Configured jest to work with expo
- Setup new env var to secure keys, remember to sync app_vars 
- Setup test env to be able to mock implementation 
- Added test to Pin model
- Added initial auth model (lot's of todo still, will add test later)

PS: Didn't add tests to the seedPhrase piece, bc I'm having some issues mocking the encryptor, will do on following up PRs
