### PR TITLE
[CS-3976]: Add custom config to android switch on light theme 

### DIFF
--- a/cardstack/src/components/BiometricSwitch/BiometricSwitch.tsx
+++ b/cardstack/src/components/BiometricSwitch/BiometricSwitch.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Switch } from 'react-native';
 
 import { Container, Text, Icon } from '@cardstack/components';
+import { colors } from '@cardstack/theme';
 import {
   colorStyleVariants,
   ThemeVariant,
 } from '@cardstack/theme/colorStyleVariants';
+import { Device } from '@cardstack/utils';
 
 import { strings } from './strings';
 import { useBiometricSwitch } from './useBiometricSwitch';
@@ -13,6 +15,11 @@ import { useBiometricSwitch } from './useBiometricSwitch';
 interface BiometricSwitchProps {
   variant: ThemeVariant;
 }
+
+const androidSwitchLightConfig = {
+  false: colors.backgroundLightGray,
+  true: '', // empty to use default value
+};
 
 export const BiometricSwitch = ({ variant }: BiometricSwitchProps) => {
   const {
@@ -22,6 +29,14 @@ export const BiometricSwitch = ({ variant }: BiometricSwitchProps) => {
     biometryAvailable,
     toggleBiometrySwitch,
   } = useBiometricSwitch();
+
+  const trackColor = useMemo(
+    () =>
+      Device.isAndroid && variant === 'light'
+        ? androidSwitchLightConfig
+        : undefined,
+    [variant]
+  );
 
   // iconProps is undefined until biometry is ready.
   if (!biometryAvailable || !iconProps) return null;
@@ -41,7 +56,11 @@ export const BiometricSwitch = ({ variant }: BiometricSwitchProps) => {
         marginRight={2}
         {...iconProps}
       />
-      <Switch onValueChange={toggleBiometrySwitch} value={isBiometryEnabled} />
+      <Switch
+        onValueChange={toggleBiometrySwitch}
+        value={isBiometryEnabled}
+        trackColor={trackColor}
+      />
     </Container>
   );
 };


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

The switch track on android when the screen was white, was not showing, this PR adds a config to handle that case

### Screenshots

<!-- Screenshots or animated GIFs included here -->

<!-- Use this tag to format the screenshot size

<img width="300" alt="Screenshot" src="URL_GOES_HERE"> -->


<img width="414" alt="image" src="https://user-images.githubusercontent.com/20520102/171206637-756415fa-a198-4f66-bba0-3e550b88606d.png">
