### PR TITLE
[CS-3523] Rewards: move claim functions into own hook

### DIFF
--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -47,4 +47,5 @@ export const strings = {
     claimed: 'Claimed ',
     none: '',
   },
+  defaultAlertBtn: 'Okay',
 };

--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -26,6 +26,10 @@ export const strings = {
   claim: {
     button: 'Claim',
     loading: 'Claiming Reward',
+    sucessAlert: {
+      title: 'Success',
+      message: 'Rewards claimed successfully',
+    },
   },
   balance: {
     title: 'Balance',

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -258,36 +258,11 @@ export const useRewardsCenterScreen = () => {
     });
   }, [navigate, onPrepaidCardSelection]);
 
-  const {
-    onClaimPress,
-    isLoadingClaimGas,
-    isClaimSuccess,
-    isClaimError,
-  } = useRewardsClaim({
+  const { onClaimPress, isLoadingClaimGas } = useRewardsClaim({
     accountAddress,
     mainPoolTokenInfo,
     rewardSafes,
   });
-
-  useMutationEffects(
-    useMemo(
-      () => ({
-        success: {
-          status: isClaimSuccess,
-          callback: onMutationEndAlert({
-            title: strings.claim.sucessAlert.title,
-            message: strings.claim.sucessAlert.message,
-            popStackNavigation: 1,
-          }),
-        },
-        error: {
-          status: isClaimError,
-          callback: onMutationEndAlert(defaultErrorAlert),
-        },
-      }),
-      [isClaimError, isClaimSuccess, onMutationEndAlert]
-    )
-  );
 
   const {
     data: rewardClaims,

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsClaim.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsClaim.ts
@@ -1,0 +1,115 @@
+import { useNavigation } from '@react-navigation/native';
+import { useCallback } from 'react';
+
+import { useBooleanState } from '@cardstack/hooks';
+import { Routes, useLoadingOverlay } from '@cardstack/navigation';
+import { useClaimRewardsMutation } from '@cardstack/services/rewards-center/rewards-center-api';
+import { getClaimRewardsGasEstimate } from '@cardstack/services/rewards-center/rewards-center-service';
+import {
+  RewardsSafeType,
+  TokenByProgramID,
+} from '@cardstack/services/rewards-center/rewards-center-types';
+import { queryPromiseWrapper } from '@cardstack/services/utils';
+import {
+  RewardsClaimData,
+  TransactionConfirmationType,
+} from '@cardstack/types';
+
+import { useWallets } from '@rainbow-me/hooks';
+
+import { strings } from './strings';
+
+interface useRewardClaimsProps {
+  accountAddress: string;
+  mainPoolTokenInfo?: TokenByProgramID;
+  rewardSafes?: RewardsSafeType[];
+}
+
+const useRewardsClaim = ({
+  rewardSafes,
+  accountAddress,
+  mainPoolTokenInfo,
+}: useRewardClaimsProps) => {
+  const { navigate, goBack } = useNavigation();
+
+  const [
+    isLoadingClaimGas,
+    startClaimGasLoading,
+    stopClaimGasLoading,
+  ] = useBooleanState();
+
+  const { showLoadingOverlay } = useLoadingOverlay();
+
+  const { signerParams } = useWallets();
+
+  const [
+    claimRewards,
+    { isSuccess: isClaimSuccess, isError: isClaimError },
+  ] = useClaimRewardsMutation();
+
+  const onClaimPress = useCallback(
+    (tokenAddress, rewardProgramId) => async () => {
+      startClaimGasLoading();
+
+      const rewardSafeForProgram = rewardSafes?.find(
+        safe => safe.rewardProgramId === rewardProgramId
+      );
+
+      const partialClaimParams = {
+        tokenAddress,
+        accountAddress,
+        rewardProgramId,
+        safeAddress: rewardSafeForProgram?.address || '',
+      };
+
+      const {
+        data: estimatedClaimGas,
+      } = await queryPromiseWrapper(
+        getClaimRewardsGasEstimate,
+        partialClaimParams,
+        { errorLogMessage: 'Error fetching reward claim gas fee' }
+      );
+
+      stopClaimGasLoading();
+
+      // Cant assign undefined mainPoolTokenInfo to data.
+      if (mainPoolTokenInfo) {
+        const data: RewardsClaimData = {
+          type: TransactionConfirmationType.REWARDS_CLAIM,
+          estGasFee: estimatedClaimGas || '0.10',
+          ...mainPoolTokenInfo,
+        };
+
+        navigate(Routes.REWARDS_CLAIM_SHEET, {
+          data,
+          onConfirm: () => {
+            showLoadingOverlay({ title: strings.claim.loading });
+
+            claimRewards({
+              ...partialClaimParams,
+              signerParams,
+              rewardProgramId,
+            });
+          },
+          onCancel: goBack,
+        });
+      }
+    },
+    [
+      startClaimGasLoading,
+      rewardSafes,
+      accountAddress,
+      stopClaimGasLoading,
+      mainPoolTokenInfo,
+      navigate,
+      goBack,
+      showLoadingOverlay,
+      claimRewards,
+      signerParams,
+    ]
+  );
+
+  return { onClaimPress, isLoadingClaimGas, isClaimSuccess, isClaimError };
+};
+
+export default useRewardsClaim;

--- a/cardstack/src/services/rewards-center/rewards-center-types.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-types.ts
@@ -17,7 +17,7 @@ export interface RewardsSafeQueryResult {
   rewardSafes: RewardsSafeType[];
 }
 
-interface TokenByProgramID extends TokenType {
+export interface TokenByProgramID extends TokenType {
   rewardProgramId?: string;
 }
 export interface RewardsTokenBalancesResult {


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
This PR is the first part of the `useRewardsCenter` hook refactor into smaller bits, work that's being tracked in [CS-3523](https://linear.app/cardstack/issue/CS-3523/split-userewardscenter-into-smaller-hooks).

Here, we are moving all things claim into its own hook. For now, we're passing params to the hook (accountAddress, mainPoolTokenInfo, rewardSafes) to avoid changing the current hook structure, but this may change in the future.

### Checklist

- [x] All UI changes have been tested on a small device
- [ ] (Trying) Adding Tests

### Screenshots

No visual or behavior changes should be seen from this PR.
