### PR TITLE
[CS-3978]: Fix android failing build and loadingOverlay layout

### DIFF
--- a/cardstack/src/components/LoadingOverlay/LoadingOverlay.tsx
+++ b/cardstack/src/components/LoadingOverlay/LoadingOverlay.tsx
@@ -45,9 +45,11 @@ const LoadingOverlay = ({
       <Text color="black" marginTop={5} fontSize={18} weight="bold">
         {title}
       </Text>
-      <Text color="blueText" marginTop={1} size="body" textAlign="center">
-        {subTitle}
-      </Text>
+      {!!subTitle && (
+        <Text color="blueText" marginTop={1} size="body" textAlign="center">
+          {subTitle}
+        </Text>
+      )}
     </CenteredContainer>
   </CenteredContainer>
 );

--- a/patches/react-native-keychain+6.2.0.patch
+++ b/patches/react-native-keychain+6.2.0.patch
@@ -94,6 +94,24 @@ index 98e45fe..01e9b76 100644
 +
 +
  @end
+diff --git a/node_modules/react-native-keychain/android/src/main/AndroidManifest.xml b/node_modules/react-native-keychain/android/src/main/AndroidManifest.xml
+index 54446d4..b468ea2 100644
+--- a/node_modules/react-native-keychain/android/src/main/AndroidManifest.xml
++++ b/node_modules/react-native-keychain/android/src/main/AndroidManifest.xml
+@@ -6,13 +6,4 @@
+   <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+   <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+ 
+-  <application>
+-    <!--suppress AndroidDomInspection -->
+-    <activity
+-      android:name="androidx.biometric.DeviceCredentialHandlerActivity"
+-      android:exported="true"
+-      android:theme="@style/DeviceCredentialHandlerTheme"
+-      />
+-  </application>
+-
+ </manifest>
 diff --git a/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.java b/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.java
 index d4ded69..8503993 100644
 --- a/node_modules/react-native-keychain/android/src/main/java/com/oblador/keychain/KeychainModule.java


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

Expo-secure store uses the same lib as keychain for biometric auth, but theirs are most up-to-date, so we had a conflict going on since only the mos recent one is installed and the newer version doesn't need to  use `DeviceCredentialHandlerTheme`, so the keychain patch was updated to reflect that. I also slipped the loadingOverlay fix 😬 in this one it was having too much spacing when it didn't had the subtitle. 
Latest Android build was triggered from this Branch in order to make sure it's working.
