### PR TITLE
[CS-3523] Rewards: create custom hook for safes and pool

### DIFF
--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
@@ -55,11 +55,16 @@ const useRewardsDataFetch = () => {
     [rewardPoolTokenBalances, defaultRewardProgramId]
   );
 
-  return {
-    isLoading:
+  const isLoading = useMemo(
+    () =>
       isLoadingSafes ||
       isLoadingTokens ||
       (isUninitialized && !isLayer1(network)),
+    [isLoadingSafes, isLoadingTokens, isUninitialized, network]
+  );
+
+  return {
+    isLoading,
     rewardSafes,
     rewardPoolTokenBalances,
     mainPoolTokenInfo,

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+
+import {
+  useGetRewardPoolTokenBalancesQuery,
+  useGetRewardsSafeQuery,
+} from '@cardstack/services/rewards-center/rewards-center-api';
+import { isLayer1 } from '@cardstack/utils';
+
+import { networkTypes } from '@rainbow-me/helpers/networkTypes';
+import { useAccountSettings } from '@rainbow-me/hooks';
+
+const rewardDefaultProgramId = {
+  [networkTypes.sokol]: '0x5E4E148baae93424B969a0Ea67FF54c315248BbA',
+  // TestID
+  [networkTypes.xdai]: '0x979C9F171fb6e9BC501Aa7eEd71ca8dC27cF1185',
+};
+
+const useRewardsDataFetch = () => {
+  const { accountAddress, nativeCurrency, network } = useAccountSettings();
+
+  const defaultRewardProgramId = rewardDefaultProgramId[network];
+
+  const query = useMemo(
+    () => ({
+      params: {
+        accountAddress,
+        nativeCurrency,
+      },
+      options: {
+        skip: !accountAddress || isLayer1(network),
+        refetchOnMountOrArgChange: true,
+      },
+    }),
+    [accountAddress, nativeCurrency, network]
+  );
+
+  const {
+    isLoading: isLoadingSafes,
+    isUninitialized,
+    data: { rewardSafes } = {},
+  } = useGetRewardsSafeQuery(query.params, query.options);
+
+  const {
+    isLoading: isLoadingTokens,
+    data: { rewardPoolTokenBalances } = {},
+  } = useGetRewardPoolTokenBalancesQuery(query.params, query.options);
+
+  // Checks if available tokens matches default program and has amount
+  const mainPoolTokenInfo = useMemo(
+    () =>
+      rewardPoolTokenBalances?.find(
+        ({ rewardProgramId, balance: { amount } }) =>
+          Number(amount) > 0 && rewardProgramId === defaultRewardProgramId
+      ),
+    [rewardPoolTokenBalances, defaultRewardProgramId]
+  );
+
+  return {
+    isLoading:
+      isLoadingSafes ||
+      isLoadingTokens ||
+      (isUninitialized && !isLayer1(network)),
+    rewardSafes,
+    rewardPoolTokenBalances,
+    mainPoolTokenInfo,
+    defaultRewardProgramId,
+  };
+};
+
+export default useRewardsDataFetch;

--- a/cardstack/src/services/rewards-center/rewards-center-api.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-api.ts
@@ -7,6 +7,7 @@ import {
   claimRewards,
   fetchRewardPoolTokenBalances,
   fetchRewardsSafe,
+  getClaimRewardsGasEstimate,
   getRegisterGasEstimate,
   getWithdrawGasEstimate,
   registerToRewardProgram,
@@ -14,6 +15,7 @@ import {
 } from './rewards-center-service';
 import {
   RegisterGasEstimateQueryParams,
+  RewardsClaimGasEstimateParams,
   RewardsClaimMutationParams,
   RewardsRegisterMutationParams,
   RewardsRegisterMutationResult,
@@ -114,6 +116,21 @@ const rewardsApi = safesApi.injectEndpoints({
       },
       invalidatesTags: [CacheTags.REWARDS_SAFE, CacheTags.REWARDS_POOL],
     }),
+    getClaimRewardsGasEstimate: builder.query<
+      string,
+      RewardsClaimGasEstimateParams
+    >({
+      async queryFn(params) {
+        return queryPromiseWrapper<string, RewardsClaimGasEstimateParams>(
+          getClaimRewardsGasEstimate,
+          params,
+          {
+            errorLogMessage: 'Error fetching reward claim gas fee',
+            timeout: 60000, // 1 min
+          }
+        );
+      },
+    }),
     withdrawRewardBalance: builder.mutation<
       SuccessfulTransactionReceipt,
       RewardWithdrawParams
@@ -140,4 +157,5 @@ export const {
   useLazyGetRegisterRewardeeGasEstimateQuery,
   useWithdrawRewardBalanceMutation,
   useGetRewardWithdrawGasEstimateQuery,
+  useGetClaimRewardsGasEstimateQuery,
 } = rewardsApi;

--- a/cardstack/src/services/rewards-center/rewards-center-api.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-api.ts
@@ -126,7 +126,6 @@ const rewardsApi = safesApi.injectEndpoints({
           params,
           {
             errorLogMessage: 'Error fetching reward claim gas fee',
-            timeout: 60000, // 1 min
           }
         );
       },


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
This ticket is part of the effort to solve [CS-3523](https://linear.app/cardstack/issue/CS-3523/split-userewardscenter-into-smaller-hooks).

On #869, my approach was wrong. I tried to abstract all the claim functions, but bumped into an issue with the data fetching part (`rewardPoolTokenBalances` e `rewardSafes`) so I decided to abstract that first to be easier to have access to this info.
