### PR TITLE
[CS-3986] Rewards: move all claim functions to custom hook

### DIFF
--- a/cardstack/src/components/TransactionConfirmationSheet/TransactionConfirmationSheet.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/TransactionConfirmationSheet.tsx
@@ -32,6 +32,7 @@ export interface TransactionConfirmationDisplayProps {
   onCancel: () => void;
   onConfirm: () => void;
   onConfirmLoading?: boolean;
+  disabledConfirmButton?: boolean;
 }
 
 export const TransactionConfirmationSheet = (
@@ -125,6 +126,7 @@ const SheetFooter = ({
   onConfirm,
   onCancel,
   onConfirmLoading = false,
+  disabledConfirmButton,
 }: TransactionConfirmationDisplayProps) => {
   const iconProps = useBiometricIconProps();
 
@@ -152,6 +154,7 @@ const SheetFooter = ({
           variant="small"
           onPress={onConfirm}
           iconProps={iconProps}
+          disabled={disabledConfirmButton}
         >
           {strings.buttons.submit}
         </Button>

--- a/cardstack/src/components/TransactionConfirmationSheet/displays/RewardsNetAmountSection.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/displays/RewardsNetAmountSection.tsx
@@ -15,6 +15,7 @@ export const RewardsNetAmountSection = ({
   balance,
   estGasFee,
   token,
+  loadingGasEstimate,
 }: RewardsNetAmountSectionProps) => {
   const estimateNetClaim = useMemo(
     () => (Number(balance?.amount) - Number(estGasFee)).toFixed(2),
@@ -39,5 +40,11 @@ export const RewardsNetAmountSection = ({
     [balance, estGasFee, token, estimateNetClaim]
   );
 
-  return <AmountSection title={headerText} data={data} />;
+  return (
+    <AmountSection
+      title={headerText}
+      data={data}
+      showLoading={loadingGasEstimate}
+    />
+  );
 };

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
@@ -20,11 +20,9 @@ const RewardsCenterScreen = () => {
     isRegistered,
     hasRewardsAvailable,
     mainPoolTokenInfo,
-    onClaimPress,
     historySectionData,
     tokensBalanceData,
     isLoading,
-    isLoadingClaimGas,
   } = useRewardsCenterScreen();
 
   const mainPoolRowProps = useMemo(
@@ -32,12 +30,8 @@ const RewardsCenterScreen = () => {
       primaryText: mainPoolTokenInfo?.balance.display || '',
       subText: mainPoolTokenInfo?.native.balance.display || '',
       coinSymbol: mainPoolTokenInfo?.token.symbol || '',
-      onClaimPress: onClaimPress(
-        mainPoolTokenInfo?.tokenAddress,
-        mainPoolTokenInfo?.rewardProgramId
-      ),
     }),
-    [mainPoolTokenInfo, onClaimPress]
+    [mainPoolTokenInfo]
   );
 
   return (
@@ -63,7 +57,6 @@ const RewardsCenterScreen = () => {
                 claimList={hasRewardsAvailable ? [mainPoolRowProps] : undefined}
                 historyList={historySectionData}
                 balanceList={tokensBalanceData}
-                isLoadingClaimGas={isLoadingClaimGas}
               />
             )}
           </Container>

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsClaimSheet/RewardsClaimSheet.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsClaimSheet/RewardsClaimSheet.tsx
@@ -1,17 +1,14 @@
-import { useRoute } from '@react-navigation/native';
 import React, { memo } from 'react';
 
 import {
   TransactionConfirmationSheet,
   SafeAreaView,
 } from '@cardstack/components';
-import { RouteType } from '@cardstack/navigation/types';
-import { TransactionConfirmationRouteParams } from '@cardstack/types';
+
+import useRewardsClaim from './useRewardsClaim';
 
 const RewardsClaimSheet = () => {
-  const {
-    params: { data, onConfirm, onCancel },
-  } = useRoute<RouteType<TransactionConfirmationRouteParams>>();
+  const { data, onCancel, onConfirm } = useRewardsClaim();
 
   return (
     <SafeAreaView backgroundColor="black" flex={1} width="100%">
@@ -20,6 +17,7 @@ const RewardsClaimSheet = () => {
         onCancel={onCancel}
         onConfirm={onConfirm}
         loading={false}
+        disabledConfirmButton={data.loadingGasEstimate}
       />
     </SafeAreaView>
   );

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsClaimSheet/useRewardsClaim.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsClaimSheet/useRewardsClaim.ts
@@ -1,0 +1,145 @@
+import { StackActions, useNavigation } from '@react-navigation/native';
+import { useCallback, useMemo } from 'react';
+
+import { defaultErrorAlert } from '@cardstack/constants';
+import { useMutationEffects } from '@cardstack/hooks';
+import { useLoadingOverlay } from '@cardstack/navigation';
+import {
+  useClaimRewardsMutation,
+  useGetClaimRewardsGasEstimateQuery,
+} from '@cardstack/services/rewards-center/rewards-center-api';
+import {
+  RewardsClaimData,
+  TransactionConfirmationType,
+} from '@cardstack/types';
+
+import { Alert } from '@rainbow-me/components/alerts';
+import { useWallets } from '@rainbow-me/hooks';
+
+import { strings } from '../strings';
+import useRewardsDataFetch from '../useRewardsDataFetch';
+
+interface onClaimCallbackProps {
+  title: string;
+  message: string;
+  popStackNavigation?: number;
+}
+
+const useRewardsClaim = () => {
+  const { goBack, dispatch } = useNavigation();
+  const { signerParams, accountAddress } = useWallets();
+
+  const {
+    rewardSafes,
+    defaultRewardProgramId,
+    mainPoolTokenInfo,
+  } = useRewardsDataFetch();
+
+  const { dismissLoadingOverlay, showLoadingOverlay } = useLoadingOverlay();
+
+  const [
+    claimRewards,
+    { isSuccess: isClaimSuccess, isError: isClaimError },
+  ] = useClaimRewardsMutation();
+
+  const rewardSafeForProgram = useMemo(
+    () =>
+      rewardSafes?.find(
+        safe => safe.rewardProgramId === defaultRewardProgramId
+      ),
+    [rewardSafes, defaultRewardProgramId]
+  );
+
+  const partialClaimParams = {
+    accountAddress,
+    rewardProgramId: defaultRewardProgramId,
+    tokenAddress: mainPoolTokenInfo?.tokenAddress || '',
+    safeAddress: rewardSafeForProgram?.address || '',
+  };
+
+  const {
+    data: estimatedGasClaim,
+    isLoading: loadingEstimatedGasClaim,
+    isFetching: fetchingEstimatedGasClaim,
+  } = useGetClaimRewardsGasEstimateQuery(partialClaimParams);
+
+  const screenData = useMemo(
+    () => ({
+      loadingGasEstimate: loadingEstimatedGasClaim || fetchingEstimatedGasClaim,
+      type: TransactionConfirmationType.REWARDS_CLAIM,
+      estGasFee: estimatedGasClaim || '0.10',
+      ...mainPoolTokenInfo,
+    }),
+    [
+      estimatedGasClaim,
+      mainPoolTokenInfo,
+      loadingEstimatedGasClaim,
+      fetchingEstimatedGasClaim,
+    ]
+  );
+
+  const onConfirm = useCallback(() => {
+    showLoadingOverlay({ title: strings.claim.loading });
+
+    claimRewards({
+      ...partialClaimParams,
+      signerParams,
+      rewardProgramId: defaultRewardProgramId,
+    });
+  }, [
+    showLoadingOverlay,
+    claimRewards,
+    partialClaimParams,
+    signerParams,
+    defaultRewardProgramId,
+  ]);
+
+  const onClaimCallback = useCallback(
+    ({ title, message, popStackNavigation }: onClaimCallbackProps) => () => {
+      dismissLoadingOverlay();
+
+      Alert({
+        message,
+        title,
+        buttons: [
+          {
+            text: strings.defaultAlertBtn,
+            onPress: popStackNavigation
+              ? () => {
+                  dispatch(StackActions.pop(popStackNavigation));
+                }
+              : undefined,
+          },
+        ],
+      });
+    },
+    [dismissLoadingOverlay, dispatch]
+  );
+
+  useMutationEffects(
+    useMemo(
+      () => ({
+        success: {
+          status: isClaimSuccess,
+          callback: onClaimCallback({
+            ...strings.claim.sucessAlert,
+            popStackNavigation: 1,
+          }),
+        },
+        error: {
+          status: isClaimError,
+          callback: onClaimCallback(defaultErrorAlert),
+        },
+      }),
+      [isClaimError, isClaimSuccess, onClaimCallback]
+    )
+  );
+
+  return {
+    onConfirm,
+    data: screenData as RewardsClaimData, // type casting bc mainPoolTokenInfo type has undefined
+    onCancel: goBack,
+  };
+};
+
+export default useRewardsClaim;

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsClaimSheet/useRewardsClaim.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsClaimSheet/useRewardsClaim.ts
@@ -1,4 +1,4 @@
-import { StackActions, useNavigation } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { useCallback, useMemo } from 'react';
 
 import { defaultErrorAlert } from '@cardstack/constants';
@@ -22,11 +22,11 @@ import useRewardsDataFetch from '../useRewardsDataFetch';
 interface onClaimCallbackProps {
   title: string;
   message: string;
-  popStackNavigation?: number;
+  dismiss?: boolean;
 }
 
 const useRewardsClaim = () => {
-  const { goBack, dispatch } = useNavigation();
+  const { goBack } = useNavigation();
   const { signerParams, accountAddress } = useWallets();
 
   const {
@@ -96,8 +96,8 @@ const useRewardsClaim = () => {
     defaultRewardProgramId,
   ]);
 
-  const onClaimCallback = useCallback(
-    ({ title, message, popStackNavigation }: onClaimCallbackProps) => () => {
+  const onClaimFulfilledAlert = useCallback(
+    ({ title, message, dismiss }: onClaimCallbackProps) => () => {
       dismissLoadingOverlay();
 
       Alert({
@@ -106,16 +106,12 @@ const useRewardsClaim = () => {
         buttons: [
           {
             text: strings.defaultAlertBtn,
-            onPress: popStackNavigation
-              ? () => {
-                  dispatch(StackActions.pop(popStackNavigation));
-                }
-              : undefined,
+            onPress: dismiss ? goBack : undefined,
           },
         ],
       });
     },
-    [dismissLoadingOverlay, dispatch]
+    [dismissLoadingOverlay, goBack]
   );
 
   useMutationEffects(
@@ -123,17 +119,17 @@ const useRewardsClaim = () => {
       () => ({
         success: {
           status: isClaimSuccess,
-          callback: onClaimCallback({
+          callback: onClaimFulfilledAlert({
             ...strings.claim.sucessAlert,
-            popStackNavigation: 1,
+            dismiss: true,
           }),
         },
         error: {
           status: isClaimError,
-          callback: onClaimCallback(defaultErrorAlert),
+          callback: onClaimFulfilledAlert(defaultErrorAlert),
         },
       }),
-      [isClaimError, isClaimSuccess, onClaimCallback]
+      [isClaimError, isClaimSuccess, onClaimFulfilledAlert]
     )
   );
 

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsClaimSheet/useRewardsClaim.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsClaimSheet/useRewardsClaim.ts
@@ -61,7 +61,9 @@ const useRewardsClaim = () => {
     data: estimatedGasClaim,
     isLoading: loadingEstimatedGasClaim,
     isFetching: fetchingEstimatedGasClaim,
-  } = useGetClaimRewardsGasEstimateQuery(partialClaimParams);
+  } = useGetClaimRewardsGasEstimateQuery(partialClaimParams, {
+    refetchOnMountOrArgChange: true,
+  });
 
   const screenData = useMemo(
     () => ({

--- a/cardstack/src/screens/RewardsCenterScreen/__tests__/mocks.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/__tests__/mocks.ts
@@ -1,0 +1,38 @@
+export const mockRewardSafeForProgram = [
+  {
+    address: '0x107c1F2e2cE594cCb60629eaf33cF703419E01fb',
+    createdAt: 1627335495,
+    owners: ['0x8a40AFffb53f4F953a204cAE087219A28771df9d'],
+    rewardProgramId: '0x979C9F171fb6e9BC501Aa7eEd71ca8dC27cF1185', // xdai default ID
+    tokens: [
+      {
+        balance: {
+          amount: '0',
+          display: '0.00 CARD.CPXD',
+          wei: '70089035551997900',
+        },
+        native: {
+          balance: {
+            amount: 0,
+            display: '$0.00 USD',
+          },
+        },
+        token: { decimals: 18, name: 'Cardstack (CPXD)', symbol: 'CARD.CPXD' },
+        tokenAddress: '0xB236ca8DbAB0644ffCD32518eBF4924ba866f7Ee',
+      },
+    ],
+    type: 'reward',
+  },
+];
+
+export const mockMainPoolTokenInfo = {
+  balance: {
+    amount: '52.479664130149567042',
+    display: '52.48 CARD.CPXD',
+    wei: '02d84d387a295fca42',
+  },
+  native: { balance: { amount: 0.10871897, display: '$0.109 USD' } },
+  rewardProgramId: '0x979C9F171fb6e9BC501Aa7eEd71ca8dC27cF1185',
+  token: { symbol: 'CARD.CPXD' },
+  tokenAddress: '0x52031d287Bb58E26A379A7Fec2c84acB54f54fe3',
+};

--- a/cardstack/src/screens/RewardsCenterScreen/__tests__/useRewardsClaim.test.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/__tests__/useRewardsClaim.test.ts
@@ -1,0 +1,168 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { Alert } from 'react-native';
+import { act } from 'react-test-renderer';
+
+import { defaultErrorAlert } from '@cardstack/constants';
+import { useClaimRewardsMutation } from '@cardstack/services/rewards-center/rewards-center-api';
+
+import useRewardsClaim from '../RewardsClaimSheet/useRewardsClaim';
+import { strings } from '../strings';
+import useRewardsDataFetch from '../useRewardsDataFetch';
+
+import { mockMainPoolTokenInfo, mockRewardSafeForProgram } from './mocks';
+
+const mockedShowOverlay = jest.fn();
+const mockedDismissOverlay = jest.fn();
+const accountAddress = '0x0000000000000000000';
+const mockedDispatch = jest.fn();
+const rewardSafes = mockRewardSafeForProgram;
+const mainPoolTokenInfo = mockMainPoolTokenInfo;
+const defaultRewardProgramId = '0x979C9F171fb6e9BC501Aa7eEd71ca8dC27cF1185';
+
+const signerParams = {
+  walletId: '123',
+  accountIndex: 1,
+};
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    dispatch: mockedDispatch,
+  }),
+}));
+
+jest.mock('@cardstack/navigation', () => ({
+  useLoadingOverlay: () => ({
+    showLoadingOverlay: mockedShowOverlay,
+    dismissLoadingOverlay: mockedDismissOverlay,
+  }),
+}));
+
+jest.mock('@rainbow-me/hooks', () => ({
+  useWallets: () => ({
+    signerParams,
+    accountAddress,
+  }),
+}));
+
+jest.mock('@cardstack/services/rewards-center/rewards-center-api', () => ({
+  useClaimRewardsMutation: jest.fn(),
+  useGetClaimRewardsGasEstimateQuery: jest.fn().mockResolvedValue('0.20'),
+}));
+
+jest.mock('../useRewardsDataFetch', () => jest.fn());
+
+describe('useRewardsClaim', () => {
+  const mockedClaimRewards = jest.fn();
+
+  const spyAlert = jest.spyOn(Alert, 'alert');
+
+  const mockUseRewardsDataFetch = (
+    overwriteProps?: Partial<ReturnType<typeof useRewardsDataFetch>>
+  ) =>
+    (useRewardsDataFetch as jest.Mock).mockImplementation(() => ({
+      rewardSafes,
+      defaultRewardProgramId,
+      mainPoolTokenInfo,
+      ...overwriteProps,
+    }));
+
+  const mockClaimRewards = (overwriteStatus?: {
+    isSuccess: boolean;
+    isError: boolean;
+  }) => {
+    (useClaimRewardsMutation as jest.Mock).mockImplementation(() => [
+      mockedClaimRewards.mockResolvedValue(Promise.resolve()),
+      {
+        isSuccess: true,
+        isError: false,
+        ...overwriteStatus,
+      },
+    ]);
+  };
+
+  beforeEach(() => {
+    mockUseRewardsDataFetch();
+    mockClaimRewards();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should show loading and call claimRewards with the correct params', () => {
+    const { result } = renderHook(() => useRewardsClaim());
+
+    act(() => {
+      result.current.onConfirm();
+    });
+
+    expect(mockedShowOverlay).toBeCalledWith({
+      title: strings.claim.loading,
+    });
+
+    expect(mockedClaimRewards).toBeCalledWith({
+      accountAddress,
+      rewardProgramId: defaultRewardProgramId,
+      tokenAddress: mockMainPoolTokenInfo.tokenAddress,
+      safeAddress: mockRewardSafeForProgram[0].address,
+      signerParams,
+    });
+  });
+
+  it('on successful claim, Alert should show Okay button', () => {
+    const { result } = renderHook(() => useRewardsClaim());
+
+    act(() => {
+      result.current.onConfirm();
+    });
+
+    expect(mockedShowOverlay).toBeCalledWith({
+      title: strings.claim.loading,
+    });
+
+    expect(spyAlert).toBeCalledWith(
+      strings.claim.sucessAlert.title,
+      strings.claim.sucessAlert.message,
+      [
+        {
+          text: strings.defaultAlertBtn,
+          onPress: expect.any(Function),
+        },
+      ],
+      undefined
+    );
+
+    expect(mockedDismissOverlay).toBeCalled();
+  });
+
+  it('on unsuccesful claim, Alert should not have an OKay button', () => {
+    mockClaimRewards({
+      isSuccess: false,
+      isError: true,
+    });
+
+    const { result } = renderHook(() => useRewardsClaim());
+
+    act(() => {
+      result.current.onConfirm();
+    });
+
+    expect(mockedShowOverlay).toBeCalledWith({
+      title: strings.claim.loading,
+    });
+
+    expect(spyAlert).toBeCalledWith(
+      defaultErrorAlert.title,
+      defaultErrorAlert.message,
+      [
+        {
+          text: strings.defaultAlertBtn,
+          onPress: undefined,
+        },
+      ],
+      undefined
+    );
+
+    expect(mockedDismissOverlay).toBeCalled();
+  });
+});

--- a/cardstack/src/screens/RewardsCenterScreen/__tests__/useRewardsClaim.test.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/__tests__/useRewardsClaim.test.ts
@@ -14,7 +14,7 @@ import { mockMainPoolTokenInfo, mockRewardSafeForProgram } from './mocks';
 const mockedShowOverlay = jest.fn();
 const mockedDismissOverlay = jest.fn();
 const accountAddress = '0x0000000000000000000';
-const mockedDispatch = jest.fn();
+const mockedGoBack = jest.fn();
 const rewardSafes = mockRewardSafeForProgram;
 const mainPoolTokenInfo = mockMainPoolTokenInfo;
 const defaultRewardProgramId = '0x979C9F171fb6e9BC501Aa7eEd71ca8dC27cF1185';
@@ -26,7 +26,7 @@ const signerParams = {
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
-    dispatch: mockedDispatch,
+    goBack: mockedGoBack,
   }),
 }));
 

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -1,3 +1,4 @@
+import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useMemo } from 'react';
 
 import {
@@ -6,6 +7,7 @@ import {
   useTabHeader,
   InfoBanner,
 } from '@cardstack/components';
+import { Routes } from '@cardstack/navigation';
 
 import { strings } from '../strings';
 
@@ -23,7 +25,6 @@ interface ClaimContentProps {
   claimList?: Array<RewardRowProps>;
   balanceList?: RewardsBalanceListProps;
   historyList?: RewardsHistoryListProps;
-  isLoadingClaimGas?: boolean;
 }
 
 enum Tabs {
@@ -40,9 +41,15 @@ export const ClaimContent = ({
   claimList,
   balanceList,
   historyList,
-  isLoadingClaimGas,
 }: ClaimContentProps) => {
   const { TabHeader, currentTab } = useTabHeader({ tabs });
+
+  const { navigate } = useNavigation();
+
+  const onClaimPress = useCallback(
+    item => () => navigate(Routes.REWARDS_CLAIM_SHEET, item),
+    [navigate]
+  );
 
   const renderClaimList = useCallback(
     () =>
@@ -52,11 +59,10 @@ export const ClaimContent = ({
           primaryText={item.primaryText}
           subText={item.subText}
           paddingBottom={index + 1 < claimList.length ? 5 : 0}
-          onClaimPress={item.onClaimPress}
-          isLoading={isLoadingClaimGas}
+          onClaimPress={onClaimPress(item)}
         />
       )),
-    [claimList, isLoadingClaimGas]
+    [claimList, onClaimPress]
   );
 
   const title = useMemo(

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -46,10 +46,9 @@ export const ClaimContent = ({
 
   const { navigate } = useNavigation();
 
-  const onClaimPress = useCallback(
-    item => () => navigate(Routes.REWARDS_CLAIM_SHEET, item),
-    [navigate]
-  );
+  const onClaimPress = useCallback(() => navigate(Routes.REWARDS_CLAIM_SHEET), [
+    navigate,
+  ]);
 
   const renderClaimList = useCallback(
     () =>
@@ -59,7 +58,7 @@ export const ClaimContent = ({
           primaryText={item.primaryText}
           subText={item.subText}
           paddingBottom={index + 1 < claimList.length ? 5 : 0}
-          onClaimPress={onClaimPress(item)}
+          onClaimPress={onClaimPress}
         />
       )),
     [claimList, onClaimPress]

--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -26,6 +26,10 @@ export const strings = {
   claim: {
     button: 'Claim',
     loading: 'Claiming Reward',
+    sucessAlert: {
+      title: 'Success',
+      message: 'Rewards claimed successfully',
+    },
   },
   balance: {
     title: 'Balance',
@@ -43,4 +47,5 @@ export const strings = {
     claimed: 'Claimed ',
     none: '',
   },
+  defaultAlertBtn: 'Okay',
 };

--- a/cardstack/src/types/transaction-confirmation-types.ts
+++ b/cardstack/src/types/transaction-confirmation-types.ts
@@ -68,6 +68,7 @@ export interface RewardsRegisterData {
 export interface RewardsClaimData extends TokenType {
   estGasFee: string;
   type: TransactionConfirmationType.REWARDS_CLAIM;
+  loadingGasEstimate?: boolean;
 }
 
 export interface PayMerchantDecodedData {


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
This PR moves all claim functions into its own hook with test coverage.

One minor thing I changed visually was to add a loading skeleton to the claim sheet instead of the default `ActivityIndicator` (video below).

Again, thanks @danibonilha for the help with testing.

- [x] Completes #CS-3986

### Screenshots

https://user-images.githubusercontent.com/690904/171737728-8619f94f-b38d-43d3-a97c-1a16fa545b73.mp4


