### PR TITLE
[CS-3990] Logic model for local authentication

### DIFF
--- a/cardstack/src/components/AppStateUpdate/AppStateUpdate.tsx
+++ b/cardstack/src/components/AppStateUpdate/AppStateUpdate.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+import { useLocalAuth } from '@cardstack/hooks/useLocalAuth';
+
+import useAppState from '@rainbow-me/hooks/useAppState';
+
+export const AppStateUpdate = () => {
+  const { appState } = useAppState();
+  const { revoke } = useLocalAuth();
+
+  useEffect(() => {
+    if (appState === 'background') {
+      revoke();
+    }
+  }, [appState, revoke]);
+
+  return null;
+};

--- a/cardstack/src/components/AppStateUpdate/index.ts
+++ b/cardstack/src/components/AppStateUpdate/index.ts
@@ -1,0 +1,1 @@
+export * from './AppStateUpdate';

--- a/cardstack/src/hooks/useLocalAuth.ts
+++ b/cardstack/src/hooks/useLocalAuth.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import * as BiometricAuth from '@cardstack/models/biometric-auth';
+import {
+  authenticate as storeAuthenticate,
+  revoke as storeRevoke,
+  selectIsLocallyAuthenticated,
+} from '@cardstack/redux/localAuthenticationSlice';
+
+export const useLocalAuth = () => {
+  const dispatch = useDispatch();
+
+  const isAuthenticated = useSelector(selectIsLocallyAuthenticated());
+
+  const authenticate = useCallback(async () => {
+    if (isAuthenticated) return;
+
+    const success = await BiometricAuth.authenticate();
+
+    if (success) {
+      dispatch(storeAuthenticate());
+    }
+  }, [isAuthenticated, dispatch]);
+
+  const revoke = useCallback(() => dispatch(storeRevoke()), [dispatch]);
+
+  return { authenticate, revoke, isAuthenticated };
+};

--- a/cardstack/src/hooks/useLocalAuth.ts
+++ b/cardstack/src/hooks/useLocalAuth.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import * as BiometricAuth from '@cardstack/models/biometric-auth';

--- a/cardstack/src/hooks/useLocalAuth.ts
+++ b/cardstack/src/hooks/useLocalAuth.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import * as BiometricAuth from '@cardstack/models/biometric-auth';

--- a/cardstack/src/models/auth.ts
+++ b/cardstack/src/models/auth.ts
@@ -1,6 +1,6 @@
 import { getPin } from './secure-storage';
 
-const authenticate = async (pin?: string, isBiometricAuthValid?: string) => {
+const authenticate = async (pin?: string, isBiometricAuthValid?: boolean) => {
   const storedPin = await getPin();
 
   if (!storedPin) {

--- a/cardstack/src/models/biometric-auth.ts
+++ b/cardstack/src/models/biometric-auth.ts
@@ -1,0 +1,19 @@
+import * as LocalAuthentication from 'expo-local-authentication';
+
+import logger from 'logger';
+
+const authenticate = async (
+  options?: LocalAuthentication.LocalAuthenticationOptions
+) => {
+  try {
+    const response = await LocalAuthentication.authenticateAsync(options);
+
+    return response.success;
+  } catch (error) {
+    logger.sentry('Local authentication failed', error);
+
+    return false;
+  }
+};
+
+export { authenticate };

--- a/cardstack/src/redux/localAuthenticationSlice.ts
+++ b/cardstack/src/redux/localAuthenticationSlice.ts
@@ -1,0 +1,34 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import { AppState } from '@rainbow-me/redux/store';
+
+type SliceType = {
+  authenticated: boolean;
+};
+
+const initialState: SliceType = {
+  authenticated: false,
+};
+
+const slice = createSlice({
+  name: 'localAuthentication',
+  initialState,
+  reducers: {
+    authenticate(state) {
+      state.authenticated = true;
+    },
+    revoke(state) {
+      state.authenticated = false;
+    },
+  },
+});
+
+export const {
+  name: localAuthenticationSliceName,
+  actions: { authenticate, revoke },
+} = slice;
+
+export const selectIsLocallyAuthenticated = () => (state: AppState) =>
+  state.localAuthentication.authenticated;
+
+export default slice.reducer;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -14,6 +14,8 @@ PODS:
     - ExpoModulesCore
   - EXFont (10.1.0):
     - ExpoModulesCore
+  - EXLocalAuthentication (12.2.0):
+    - ExpoModulesCore
   - Expo (45.0.4):
     - ExpoModulesCore
   - ExpoKeepAwake (10.1.1):
@@ -633,6 +635,7 @@ DEPENDENCIES:
   - EXErrorRecovery (from `../node_modules/expo-error-recovery/ios`)
   - EXFileSystem (from `../node_modules/expo-file-system/ios`)
   - EXFont (from `../node_modules/expo-font/ios`)
+  - EXLocalAuthentication (from `../node_modules/expo-local-authentication/ios`)
   - Expo (from `../node_modules/expo/ios`)
   - ExpoKeepAwake (from `../node_modules/expo-keep-awake/ios`)
   - ExpoModulesCore (from `../node_modules/expo-modules-core/ios`)
@@ -791,6 +794,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-file-system/ios"
   EXFont:
     :path: "../node_modules/expo-font/ios"
+  EXLocalAuthentication:
+    :path: "../node_modules/expo-local-authentication/ios"
   Expo:
     :path: "../node_modules/expo/ios"
   ExpoKeepAwake:
@@ -966,6 +971,7 @@ SPEC CHECKSUMS:
   EXErrorRecovery: 3ce46e5d42e53c0371ff048a7f0cbc959968ef4a
   EXFileSystem: 2aa2d9289f84bca9532b9ccbd81504fa31eb1ded
   EXFont: 04235cc22e6fef86028feb67db452978dc6f240f
+  EXLocalAuthentication: 7f37b242eae73f9acf111d39bdee3f1379e68902
   Expo: 64d52669fa3b9342919b5b44b2b4f15f19b0cf76
   ExpoKeepAwake: c0c494b442ecd8122974c13b93ccfb57bd408e88
   ExpoModulesCore: e4278a668e8c13c0269ed8b8a4200989deea2973

--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -842,7 +842,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -933,7 +933,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PREPROCESSOR_DEFINITIONS = "LOCAL_RELEASE=1";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1023,7 +1023,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -1066,7 +1066,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;

--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -842,7 +842,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -933,7 +933,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PREPROCESSOR_DEFINITIONS = "LOCAL_RELEASE=1";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1023,7 +1023,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -1066,7 +1066,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "ethers": "^5.6.4",
     "events": "^1.1.1",
     "expo": "^45.0.0",
+    "expo-local-authentication": "~12.2.0",
     "expo-secure-store": "~11.2.0",
     "global": "^4.3.2",
     "grapheme-splitter": "^1.0.4",

--- a/src/App.js
+++ b/src/App.js
@@ -42,6 +42,7 @@ import { loadAddress } from './model/wallet';
 import store, { persistor } from './redux/store';
 import { walletConnectLoadState } from './redux/walletconnect';
 import { AppRequirementsCheck } from '@cardstack/components/AppRequirementsCheck';
+import { AppStateUpdate } from '@cardstack/components/AppStateUpdate';
 import ErrorBoundary from '@cardstack/components/ErrorBoundary/ErrorBoundary';
 import { apolloClient } from '@cardstack/graphql/apollo-client';
 import { registerTokenRefreshListener } from '@cardstack/models/firebase';
@@ -225,6 +226,7 @@ class App extends Component {
                       )}
                     </AppRequirementsCheck>
                     <OfflineToast />
+                    <AppStateUpdate />
                   </FlexItem>
                 </PersistGate>
               </Provider>

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -10,6 +10,7 @@ import wallets from './wallets';
 import appState from '@cardstack/redux/appState';
 import biometryToggle from '@cardstack/redux/biometryToggleSlice';
 import collectibles from '@cardstack/redux/collectibles';
+import localAuthentication from '@cardstack/redux/localAuthenticationSlice';
 import primarySafe from '@cardstack/redux/primarySafeSlice';
 import requests from '@cardstack/redux/requests';
 
@@ -28,4 +29,5 @@ export default {
   wallets,
   primarySafe,
   biometryToggle,
+  localAuthentication,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12031,6 +12031,14 @@ expo-keep-awake@~10.1.1:
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-10.1.1.tgz#03023c130f7e3824b738e3fdd5353b8a2c0c1980"
   integrity sha512-9zC0sdhQljUeMr2yQ7o4kzEZXVAy82fFOAZE1+TwPL7qR0b0sphe7OJ5T1GX1qLcwuVaJ8YewaPoLSHRk79+Rg==
 
+expo-local-authentication@~12.2.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/expo-local-authentication/-/expo-local-authentication-12.2.0.tgz#a1534d2f1a3e63483d20a1cff303b1a312b8e1ef"
+  integrity sha512-JY8aqucTl2SEsC2qnxLD6Dhrxke/Pm10zEMFQVVUO6OsiwqdSO6r/xLE5zzUgLogjOHfKIqGH4rXZLEi8x4Dvw==
+  dependencies:
+    "@expo/config-plugins" "^4.0.14"
+    invariant "^2.2.4"
+
 expo-modules-autolinking@0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-0.8.1.tgz#533c38192847d2272e9af986f8f4c58aae6dfff3"


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description

This PR adds expo's LocalAuthentication lib for our biometry check, also:
- Slice to save authentication value in redux;
- Hook to check for auth, authenticate and revoke more easily;
- AppStateUpdate dummy component to control local auth revoke when the app goes to background state.

Notes on the flow:
- When Unlock screen is opened, if authenticated it navigates straight away to Wallet screen. This looks odd and we should use `isAuthenticated` from `useLocalAuth` to decide the route before showing Unlock screen.
- Auth is stored in memory, so it clears on app refreshes or relaunches.
- Auth is revoked when app enters background mode.
- So in the video below, I first test going into background state to see if auth is revoked and then a second time to see if state is still authenticated.

- [x] Completes #(CS-3990)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

https://user-images.githubusercontent.com/129619/171870581-37ffa1bb-9d91-4fe1-944f-f3b41a283bdb.mp4


