### PR TITLE
[CS-3992]: Add auth/non-auth routes and app lock based on PIN 

### DIFF
--- a/cardstack/docs/auth-flow.drawio
+++ b/cardstack/docs/auth-flow.drawio
@@ -1,0 +1,355 @@
+<mxfile host="65bd71144e">
+    <diagram id="BcZ6OhFa7y1j6hDmVXnf" name="Page-1">
+        <mxGraphModel dx="938" dy="1802" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" background="none" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="15" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="1" source="12" target="13">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="12" value="Open App" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#99FF99;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="80" width="120" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="16" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeColor=#33FF33;" edge="1" parent="1" source="13" target="14">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="390" y="100" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="17" style="edgeStyle=none;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;fillColor=#f8cecc;strokeColor=#b85450;" edge="1" parent="1" source="13">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="280" y="260" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="13" value="has account?" style="rhombus;whiteSpace=wrap;html=1;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="230" y="65" width="100" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="63" style="edgeStyle=none;html=1;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="1" source="14" target="62">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="14" value="UnlockScreen" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#B266FF;" vertex="1" parent="1">
+                    <mxGeometry x="400" y="75" width="120" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="18" value="Yes" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="345" y="80" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="19" value="No" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="295" y="190" width="30" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="34" style="edgeStyle=none;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="20" target="26">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="20" value="WelcomeScreen" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#FF9933;" vertex="1" parent="1">
+                    <mxGeometry x="220" y="260" width="120" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="55" style="edgeStyle=none;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;fillColor=#d5e8d4;strokeColor=#82b366;" edge="1" parent="1" source="23" target="58">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="550" y="280" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="550" y="250"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="23" value="PinScreen (create)" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#99FFFF;" vertex="1" parent="1">
+                    <mxGeometry x="490" y="375" width="120" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="40" style="edgeStyle=none;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="24">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="280" y="650" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="24" value="RestoreSheet" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="220" y="520" width="120" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="32" style="edgeStyle=none;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;fillColor=#d5e8d4;strokeColor=#82b366;" edge="1" parent="1" source="26" target="23">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="33" style="edgeStyle=none;html=1;" edge="1" parent="1" source="26" target="24">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="26" value="user decision" style="rhombus;whiteSpace=wrap;html=1;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="230" y="360" width="100" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="36" value="Create new acc" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="360" y="380" width="100" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="38" value="Add existing acc" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="170" y="470" width="100" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="43" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;fillColor=#fff2cc;strokeColor=#d6b656;" edge="1" parent="1" source="41" target="23">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="430" y="750" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="500" y="690"/>
+                            <mxPoint x="550" y="690"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="46" style="edgeStyle=none;html=1;entryX=0.7;entryY=1;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;fillColor=#dae8fc;strokeColor=#6c8ebf;entryPerimeter=0;" edge="1" parent="1" source="41" target="23">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="574" y="730"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="41" value="user decision" style="rhombus;whiteSpace=wrap;html=1;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="230" y="650" width="100" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="44" value="&lt;meta charset=&quot;utf-8&quot;&gt;&lt;span style=&quot;color: rgb(240, 240, 240); font-family: helvetica; font-size: 12px; font-style: normal; font-weight: 400; letter-spacing: normal; text-align: center; text-indent: 0px; text-transform: none; word-spacing: 0px; background-color: rgb(42, 42, 42); display: inline; float: none;&quot;&gt;Import seed&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="380" y="660" width="90" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="131" value="" style="edgeStyle=none;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" edge="1" parent="1" source="45" target="130">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="45" value="Cloud backup restore sheet" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="650" y="455" width="130" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="49" value="&lt;div style=&quot;text-align: center&quot;&gt;&lt;span&gt;&lt;font face=&quot;helvetica&quot;&gt;Backup&lt;/font&gt;&lt;/span&gt;&lt;/div&gt;" style="text;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="385" y="710" width="90" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="51" style="edgeStyle=none;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" edge="1" parent="1" source="23" target="45">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="290" y="740" as="sourcePoint"/>
+                        <mxPoint x="584" y="435" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="715" y="400"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="138" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeColor=#d6b656;fillColor=#fff2cc;" edge="1" parent="1" source="52" target="136">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="52" value="Add seed sheet" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="660" y="550" width="130" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="54" style="edgeStyle=none;html=1;fillColor=#fff2cc;strokeColor=#d6b656;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="1" source="23" target="52">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="340" y="700" as="sourcePoint"/>
+                        <mxPoint x="560" y="435" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="610" y="575"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="162" style="edgeStyle=none;html=1;exitX=0.25;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeColor=#CCCC00;fillColor=#ffe6cc;" edge="1" parent="1" source="58" target="160">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="901" y="170"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="58" value="WalletScreen" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#99FF99;" vertex="1" parent="1">
+                    <mxGeometry x="870" y="220" width="122.5" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="144" style="edgeStyle=none;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeColor=#33FF33;exitX=0.5;exitY=0;exitDx=0;exitDy=0;" edge="1" parent="1" source="62" target="143">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="530" y="-120"/>
+                            <mxPoint x="570" y="-120"/>
+                            <mxPoint x="570" y="-87"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="150" style="edgeStyle=none;html=1;entryX=0;entryY=0;entryDx=0;entryDy=0;strokeColor=#b85450;exitX=0.5;exitY=0;exitDx=0;exitDy=0;fillColor=#f8cecc;" edge="1" parent="1" source="146" target="14">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="853" y="-180" as="sourcePoint"/>
+                        <Array as="points">
+                            <mxPoint x="853" y="-180"/>
+                            <mxPoint x="400" y="-180"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="154" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeColor=#b85450;fillColor=#f8cecc;" edge="1" parent="1" source="62" target="153">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="550" y="-87"/>
+                            <mxPoint x="550" y="60"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="62" value="biometric enabled?" style="rhombus;whiteSpace=wrap;html=1;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="420" y="-120" width="80" height="65" as="geometry"/>
+                </mxCell>
+                <mxCell id="132" style="edgeStyle=none;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" edge="1" parent="1" source="130" target="58">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="134" style="edgeStyle=none;html=1;entryX=0.5;entryY=1;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" edge="1" parent="1" source="130" target="45">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="830" y="530"/>
+                            <mxPoint x="715" y="530"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="130" value="valid backup?" style="rhombus;whiteSpace=wrap;html=1;rounded=0;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="885" y="435" width="95" height="95" as="geometry"/>
+                </mxCell>
+                <mxCell id="133" value="Yes" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="930" y="355" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="135" value="No" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="805" y="510" width="30" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="139" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=1.029;entryY=0.391;entryDx=0;entryDy=0;entryPerimeter=0;strokeColor=#d6b656;fillColor=#fff2cc;" edge="1" parent="1" source="136" target="58">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="1063" y="243"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="140" style="edgeStyle=none;html=1;entryX=0.453;entryY=1.031;entryDx=0;entryDy=0;entryPerimeter=0;strokeColor=#d6b656;fillColor=#fff2cc;" edge="1" parent="1" target="52">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="1016" y="620" as="sourcePoint"/>
+                        <Array as="points">
+                            <mxPoint x="1016" y="640"/>
+                            <mxPoint x="930" y="640"/>
+                            <mxPoint x="850" y="640"/>
+                            <mxPoint x="719" y="640"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="136" value="valid seed" style="rhombus;whiteSpace=wrap;html=1;rounded=0;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="970" y="535" width="92.5" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="141" value="Yes" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="1022.5" y="360" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="142" value="No" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="820" y="620" width="30" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="147" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="143" target="146">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="143" value="Local biometric auth" style="shape=parallelogram;perimeter=parallelogramPerimeter;whiteSpace=wrap;html=1;fixedSize=1;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="590" y="-115" width="160" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="145" value="Yes" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="510" y="-137.5" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="148" style="edgeStyle=none;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;strokeColor=#33FF33;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="1" source="146" target="58">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="933" y="-85"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="159" style="edgeStyle=none;html=1;entryX=1;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#b85450;fillColor=#f8cecc;" edge="1" parent="1" source="146" target="14">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="853" y="113"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="146" value="isAuthorized?" style="rhombus;whiteSpace=wrap;html=1;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="805" y="-120" width="95" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="149" value="Yes" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="930" y="60" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="151" value="No" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="370" y="-50" width="30" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="157" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="153" target="146">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="805" y="60"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="153" value="Local Pin Auth" style="shape=parallelogram;perimeter=parallelogramPerimeter;whiteSpace=wrap;html=1;fixedSize=1;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="580" y="30" width="160" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="155" value="No" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="550" width="30" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="158" value="No" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="800" y="90" width="30" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="164" style="edgeStyle=none;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;strokeColor=#CCCC00;" edge="1" parent="1" source="160" target="14">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="460" y="170"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="160" value="App goes to background" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#CCCC00;" vertex="1" parent="1">
+                    <mxGeometry x="610" y="140" width="120" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="166" value="PinScreen (create)" style="swimlane;strokeColor=#99FFFF;" vertex="1" parent="1">
+                    <mxGeometry x="90" y="870" width="870" height="480" as="geometry"/>
+                </mxCell>
+                <mxCell id="179" value="" style="edgeStyle=none;html=1;strokeColor=#FFFFFF;" edge="1" parent="166" source="171" target="178">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="171" value="InputPin" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;" vertex="1" parent="166">
+                    <mxGeometry x="30" y="50" width="110" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="173" value="isValid ?&amp;nbsp;" style="rhombus;whiteSpace=wrap;html=1;strokeColor=#FFFFFF;" vertex="1" parent="166">
+                    <mxGeometry x="220" y="150" width="80" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="193" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeColor=#FFFFFF;" edge="1" parent="166" source="177" target="190">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="177" value="Save Pin" style="shape=parallelogram;perimeter=parallelogramPerimeter;whiteSpace=wrap;html=1;fixedSize=1;strokeColor=#FFFFFF;" vertex="1" parent="166">
+                    <mxGeometry x="370" y="160" width="110" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="180" value="" style="edgeStyle=none;html=1;strokeColor=#FFFFFF;" edge="1" parent="166" source="178" target="173">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="178" value="Confirm Pin" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;" vertex="1" parent="166">
+                    <mxGeometry x="200" y="50" width="120" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="200" style="edgeStyle=none;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeColor=#FFFFFF;" edge="1" parent="166" source="189" target="194">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="575" y="405"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="189" value="Check biometric enrollement" style="shape=parallelogram;perimeter=parallelogramPerimeter;whiteSpace=wrap;html=1;fixedSize=1;strokeColor=#FFFFFF;" vertex="1" parent="166">
+                    <mxGeometry x="510" y="300" width="130" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="191" style="edgeStyle=none;html=1;strokeColor=#FFFFFF;" edge="1" parent="166" source="190" target="189">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="201" style="edgeStyle=none;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;strokeColor=#FFFFFF;" edge="1" parent="166" source="190" target="194">
+                    <mxGeometry relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="730" y="185"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="190" value="Biometric. switcher on?" style="rhombus;whiteSpace=wrap;html=1;strokeColor=#FFFFFF;" vertex="1" parent="166">
+                    <mxGeometry x="530" y="150" width="100" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="194" value="Continue to WalletScreen" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;" vertex="1" parent="166">
+                    <mxGeometry x="670" y="380" width="120" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="198" value="Yes" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="166">
+                    <mxGeometry x="315" y="170" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="202" value="No" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="166">
+                    <mxGeometry x="655" y="170" width="30" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="199" value="Yes&lt;br&gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="166">
+                    <mxGeometry x="580" y="250" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="183" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#FFFFFF;" edge="1" parent="1" source="173">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="460" y="1055" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="196" style="edgeStyle=none;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#FFFFFF;" edge="1" parent="1" source="173">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="280" y="940" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="280" y="1055"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="197" value="No" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+                    <mxGeometry x="255" y="1020" width="30" height="20" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/cardstack/src/components/AppRequirementsCheck/AppRequirementsCheck.tsx
+++ b/cardstack/src/components/AppRequirementsCheck/AppRequirementsCheck.tsx
@@ -29,14 +29,16 @@ export const AppRequirementsCheck = ({ children }: Props) => {
   }, [isReady]);
 
   if (isReady && remoteFlags().maintenanceActive) {
+    hideSplashScreen();
+
     return <MaintenanceMode message={remoteFlags().maintenanceMessage} />;
   }
 
   if (forceUpdate) {
+    hideSplashScreen();
+
     return <MinimumVersion />;
   }
-
-  if (isReady) hideSplashScreen?.();
 
   return children;
 };

--- a/cardstack/src/components/CardwalletLogo/CardwalletLogo.tsx
+++ b/cardstack/src/components/CardwalletLogo/CardwalletLogo.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 
 import { CenteredContainer, Icon, Text } from '@cardstack/components';
 import {
@@ -6,11 +6,14 @@ import {
   ThemeVariant,
 } from '@cardstack/theme/colorStyleVariants';
 
+import { useDimensions } from '@rainbow-me/hooks';
+
 type CardwalletLogoSizes = 'big' | 'medium';
 
 interface Props {
   size?: CardwalletLogoSizes;
   variant?: ThemeVariant;
+  proportionalSize?: boolean;
 }
 
 export const DEFAULT_CARDWALLET_ICON_SIZE = 100;
@@ -42,24 +45,35 @@ const sizes = {
 };
 
 export const CardwalletLogo = memo(
-  ({ size = 'big', variant = 'dark' }: Props) => (
-    <CenteredContainer>
-      <Icon name="cardstack" size={sizes[size].iconSize} />
-      <Text
-        color={colorStyleVariants.textColor[variant]}
-        marginTop={6}
-        variant="welcomeScreen"
-        {...sizes[size].title}
-      >
-        {strings.title}
-      </Text>
-      <Text
-        color={colorStyleVariants.textColor[variant]}
-        weight="bold"
-        {...sizes[size].subtitle}
-      >
-        {strings.subtitle}
-      </Text>
-    </CenteredContainer>
-  )
+  ({ size, variant = 'dark', proportionalSize = false }: Props) => {
+    const { isSmallPhone } = useDimensions();
+
+    const propotionalLogoSize = useMemo(
+      () => (isSmallPhone ? 'medium' : 'big'),
+      [isSmallPhone]
+    );
+
+    const logoSize = proportionalSize || !size ? propotionalLogoSize : size;
+
+    return (
+      <CenteredContainer>
+        <Icon name="cardstack" size={sizes[logoSize].iconSize} />
+        <Text
+          color={colorStyleVariants.textColor[variant]}
+          marginTop={6}
+          variant="welcomeScreen"
+          {...sizes[logoSize].title}
+        >
+          {strings.title}
+        </Text>
+        <Text
+          color={colorStyleVariants.textColor[variant]}
+          weight="bold"
+          {...sizes[logoSize].subtitle}
+        >
+          {strings.subtitle}
+        </Text>
+      </CenteredContainer>
+    );
+  }
 );

--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -8,10 +8,7 @@ export const MainRoutes = {
   SEND_FLOW_EOA: 'SendFlowEOA',
   PAY_MERCHANT: 'PayMerchant',
   ERROR_FALLBACK_SCREEN: 'ErrorFallbackScreen',
-  LOADING_OVERLAY: 'LoadingOverlay',
-  WELCOME_SCREEN: 'WelcomeScreen',
   COLLECTIBLE_SHEET: 'CollectibleSheet',
-  IMPORT_SEED_SHEET: 'ImportSeedSheet',
   PAYMENT_RECEIVED_SHEET: 'PaymentReceivedSheet',
   UNCLAIMED_REVENUE_SHEET: 'UnclaimedRevenueSheet',
   CONFIRM_CLAIM_DESTINY_SHEET: 'ConfirmClaimDestinySheet',
@@ -33,27 +30,42 @@ export const MainRoutes = {
   CONFIRM_REQUEST: 'ConfirmRequest',
   CURRENCY_SELECTION_MODAL: 'CurrencySelectionModal',
   COLOR_PICKER_MODAL: 'ColorPickerModal',
-  PIN_SCREEN: 'PinScreen',
-  UNLOCK_SCREEN: 'UnlockScreen',
   SUPPORT_AND_FEES: 'SupportAndFeesSheet',
   AVAILABLE_BALANCE_SHEET: 'AvailableBalanceSheet',
   TOKEN_WITH_CHART_SHEET: 'TokenWithChartSheet',
 } as const;
 
-const OuterRoutes = {
+const TabRoutes = {
   TAB_NAVIGATOR: 'TabNavigator',
   HOME_SCREEN: 'HomeScreen',
   PROFILE_SCREEN: 'ProfileScreen',
   WALLET_SCREEN: 'WalletScreen',
   QR_SCANNER_SCREEN: 'QRScannerScreen',
-
-  // Non-migrated routes
-  CHANGE_WALLET_SHEET: 'ChangeWalletSheet',
-  MODAL_SCREEN: 'ModalScreen',
-  PIN_AUTHENTICATION_SCREEN: 'PinAuthenticationScreen',
-  RESTORE_SHEET: 'RestoreSheet',
-  SETTINGS_MODAL: 'SettingsModal',
-  SUPPORTED_COUNTRIES_MODAL_SCREEN: 'SupportedCountriesModalScreen',
 } as const;
 
-export const Routes = { ...OuterRoutes, ...MainRoutes } as const;
+const NonMigratedRoutes = {
+  CHANGE_WALLET_SHEET: 'ChangeWalletSheet',
+  PIN_AUTHENTICATION_SCREEN: 'PinAuthenticationScreen',
+  SETTINGS_MODAL: 'SettingsModal',
+} as const;
+
+const SharedRoutes = {
+  PIN_SCREEN: 'PinScreen',
+  LOADING_OVERLAY: 'LoadingOverlay',
+  IMPORT_SEED_SHEET: 'ImportSeedSheet',
+  // non-migrated
+  RESTORE_SHEET: 'RestoreSheet',
+  MODAL_SCREEN: 'ModalScreen',
+} as const;
+
+export const NonAuthRoutes = {
+  UNLOCK_SCREEN: 'UnlockScreen',
+  WELCOME_SCREEN: 'WelcomeScreen',
+} as const;
+
+export const Routes = {
+  ...SharedRoutes,
+  ...NonMigratedRoutes,
+  ...TabRoutes,
+  ...MainRoutes,
+} as const;

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -7,14 +7,11 @@ import {
   CurrencySelectionGlobalModal,
   DepotScreen,
   ErrorFallbackScreen,
-  LoadingOverlayScreen,
-  ImportSeedSheet,
   MerchantScreen,
   PayMerchant,
   PrepaidCardModal,
   SendSheetDepot,
   TransactionConfirmation,
-  WelcomeScreen,
   CollectibleSheet,
   PaymentReceivedSheet,
   PaymentRequestExpandedSheet,
@@ -32,8 +29,6 @@ import {
   TransactionConfirmationSheet,
   ColorPickerModal,
   RequestPrepaidCardScreen,
-  PinScreen,
-  UnlockScreen,
   SupportAndFeesSheet,
   AvailableBalanceSheet,
   TokenWithChartSheet,
@@ -60,7 +55,7 @@ import {
   overlayPreset,
   slideLeftToRightPreset,
 } from './presetOptions';
-import { MainRoutes, Routes } from './routes';
+import { MainRoutes, NonAuthRoutes, Routes } from './routes';
 
 export interface ScreenNavigation {
   component: React.ComponentType<any>;
@@ -69,13 +64,6 @@ export interface ScreenNavigation {
 }
 
 export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
-  LOADING_OVERLAY: {
-    component: LoadingOverlayScreen,
-    options: {
-      ...overlayPreset,
-      gestureEnabled: false,
-    } as StackNavigationOptions,
-  },
   DEPOT_SCREEN: { component: DepotScreen, options: horizontalInterpolator },
   MERCHANT_SCREEN: {
     component: MerchantScreen,
@@ -113,17 +101,9 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
     component: ErrorFallbackScreen,
     options: { ...overlayPreset, gestureEnabled: false },
   },
-  WELCOME_SCREEN: {
-    component: WelcomeScreen,
-  },
   COLLECTIBLE_SHEET: {
     component: CollectibleSheet,
     options: expandedPreset as StackNavigationOptions,
-  },
-  IMPORT_SEED_SHEET: {
-    component: ImportSeedSheet,
-    options: bottomSheetPreset as StackNavigationOptions,
-    listeners: dismissAndroidKeyboardOnClose,
   },
   PAYMENT_RECEIVED_SHEET: {
     component: PaymentReceivedSheet,
@@ -215,14 +195,6 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
     component: ColorPickerModal,
     options: expandedPreset as StackNavigationOptions,
   },
-  PIN_SCREEN: {
-    component: PinScreen,
-    options: horizontalInterpolator,
-  },
-  UNLOCK_SCREEN: {
-    component: UnlockScreen,
-    options: horizontalInterpolator,
-  },
   SUPPORT_AND_FEES: {
     component: SupportAndFeesSheet,
     options: expandedPreset as StackNavigationOptions,
@@ -280,7 +252,7 @@ export const navigationStateInit = {
   index: 0,
   routes: [
     {
-      name: Routes.WELCOME_SCREEN,
+      name: NonAuthRoutes.WELCOME_SCREEN,
     },
   ],
 };

--- a/cardstack/src/redux/authSlice.ts
+++ b/cardstack/src/redux/authSlice.ts
@@ -1,0 +1,67 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { AppState } from '@rainbow-me/redux/store';
+
+type SliceType = {
+  isAuthorized: boolean;
+  hasWallet: boolean;
+};
+
+const initialState: SliceType = {
+  isAuthorized: false,
+  hasWallet: false,
+};
+
+export const authSlice = createSlice({
+  name: 'authSlice',
+  initialState,
+  reducers: {
+    setUserAuthorized(state) {
+      state.isAuthorized = true;
+    },
+    setUserUnauthorized(state) {
+      state.isAuthorized = false;
+    },
+    setHasWallet(state) {
+      state.hasWallet = true;
+    },
+    resetHasWallet(state) {
+      state.hasWallet = false;
+    },
+  },
+});
+
+export const useAuthSelector = () => {
+  const authState = useSelector((state: AppState) => state.authSlice);
+
+  return authState;
+};
+
+export const useAuthActions = () => {
+  const dispatch = useDispatch();
+
+  const setUserAuthorized = useCallback(() => {
+    dispatch(authSlice.actions.setUserAuthorized());
+  }, [dispatch]);
+
+  const setUserUnauthorized = useCallback(() => {
+    dispatch(authSlice.actions.setUserUnauthorized());
+  }, [dispatch]);
+
+  const setHasWallet = useCallback(() => {
+    dispatch(authSlice.actions.setHasWallet());
+  }, [dispatch]);
+
+  const resetHasWallet = useCallback(() => {
+    dispatch(authSlice.actions.resetHasWallet());
+  }, [dispatch]);
+
+  return {
+    setUserAuthorized,
+    setUserUnauthorized,
+    setHasWallet,
+    resetHasWallet,
+  };
+};

--- a/cardstack/src/screens/Dev/DesignSystemScreen.tsx
+++ b/cardstack/src/screens/Dev/DesignSystemScreen.tsx
@@ -9,7 +9,6 @@ import {
   Container,
   Text,
 } from '@cardstack/components';
-import { Routes } from '@cardstack/navigation';
 import { buttonVariants } from '@cardstack/theme';
 
 const themes = ['light', 'dark'];
@@ -21,7 +20,7 @@ const DesignSystemScreen = () => {
   const sections = [
     {
       title: 'Template Screens',
-      data: [Routes.UNLOCK_SCREEN, Routes.PIN_SCREEN],
+      data: [],
     },
     {
       title: 'Biometric Switch',

--- a/cardstack/src/screens/PinScreen/__tests__/usePinScreen.test.ts
+++ b/cardstack/src/screens/PinScreen/__tests__/usePinScreen.test.ts
@@ -16,6 +16,13 @@ jest.mock('@react-navigation/native', () => ({
   StackActions: { push: jest.fn(), popToTop: jest.fn() },
 }));
 
+const mockSetAuthorized = jest.fn();
+
+jest.mock('@cardstack/redux/authSlice', () => ({
+  useAuthActions: () => ({ setUserAuthorized: mockSetAuthorized }),
+  authSlice: { name: 'authSlice', reducer: null },
+}));
+
 const PIN = '111111';
 
 const mockRouteParamsHelper = (overwrite: any = {}) => {
@@ -141,6 +148,8 @@ describe('usePinScreen', () => {
     });
 
     expect(result.current.isValidPin).toStrictEqual(true);
+
+    expect(mockSetAuthorized).toBeCalled();
   });
 
   it('should call onSuccess cb and popToTop when PIN is valid on confirm flow and dismissOnSuccess is true', async () => {

--- a/cardstack/src/screens/PinScreen/usePinScreen.tsx
+++ b/cardstack/src/screens/PinScreen/usePinScreen.tsx
@@ -9,6 +9,7 @@ import { DEFAULT_PIN_LENGTH } from '@cardstack/components/Input/PinInput/PinInpu
 import { savePin } from '@cardstack/models/secure-storage';
 import { Routes } from '@cardstack/navigation/routes';
 import { RouteType } from '@cardstack/navigation/types';
+import { useAuthActions } from '@cardstack/redux/authSlice';
 import { ThemeVariant } from '@cardstack/theme/colorStyleVariants';
 
 import logger from 'logger';
@@ -34,6 +35,8 @@ export const usePinScreen = () => {
 
   const [inputPin, setInputPin] = useState('');
   const [isValidPin, setIsValidPin] = useState<null | boolean>(null);
+
+  const { setUserAuthorized } = useAuthActions();
 
   const {
     flow = PinFlow.create,
@@ -69,6 +72,8 @@ export const usePinScreen = () => {
   const onValidPin = useCallback(async () => {
     try {
       await savePin(inputPin);
+      setUserAuthorized();
+
       await params?.onSuccess?.(inputPin);
     } catch (e) {
       logger.sentry('Error while saving PIN', e);
@@ -77,7 +82,7 @@ export const usePinScreen = () => {
     if (params.dismissOnSuccess) {
       navDispatch(StackActions.popToTop());
     }
-  }, [inputPin, navDispatch, params]);
+  }, [inputPin, navDispatch, params, setUserAuthorized]);
 
   useEffect(() => {
     if (isValidPin) {

--- a/cardstack/src/screens/UnlockScreen/UnlockScreen.tsx
+++ b/cardstack/src/screens/UnlockScreen/UnlockScreen.tsx
@@ -1,8 +1,7 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo } from 'react';
 import { StatusBar, Keyboard, TouchableWithoutFeedback } from 'react-native';
 
 import {
-  Button,
   Container,
   PinInput,
   SafeAreaView,
@@ -13,55 +12,35 @@ import { BiometricSwitch } from '@cardstack/components/BiometricSwitch';
 import { CardwalletLogo } from '@cardstack/components/CardwalletLogo';
 import { colorStyleVariants } from '@cardstack/theme/colorStyleVariants';
 
-import { useDimensions } from '@rainbow-me/hooks';
+import AppVersionStamp from '@rainbow-me/components/AppVersionStamp';
 
 import { strings } from './strings';
 import { useUnlockScreen } from './useUnlockScreen';
 
+const variant = 'dark';
+
 const UnlockScreen = () => {
   const {
-    biometryAvailable,
-    appVersion,
-    variant,
     inputPin,
     setInputPin,
     pinInvalid,
     onResetWalletPress,
   } = useUnlockScreen();
 
-  const { isSmallPhone } = useDimensions();
-
-  const statusBarStyle = useMemo(
-    () => (variant === 'dark' ? 'light-content' : 'dark-content'),
-    [variant]
-  );
-
-  const logoSize = useMemo(() => (isSmallPhone ? 'medium' : 'big'), [
-    isSmallPhone,
-  ]);
-
-  const logoContaineFlex = useMemo(() => (isSmallPhone ? 1.5 : 2), [
-    isSmallPhone,
-  ]);
-
   return (
     <>
-      <StatusBar barStyle={statusBarStyle} />
+      <StatusBar barStyle="light-content" />
       <SafeAreaView
         backgroundColor={colorStyleVariants.backgroundColor[variant]}
         flex={1}
       >
         <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
           <Container flex={1} alignItems="center">
-            <Container
-              flex={logoContaineFlex}
-              alignItems="center"
-              justifyContent="center"
-            >
-              <CardwalletLogo variant={variant} size={logoSize} />
+            <Container flex={1.5} alignItems="center" justifyContent="center">
+              <CardwalletLogo variant={variant} proportionalSize />
             </Container>
             <Container
-              flex={1}
+              flex={0.9}
               justifyContent="space-between"
               width="100%"
               alignItems="center"
@@ -87,32 +66,35 @@ const UnlockScreen = () => {
                   </Container>
                 )}
               </Container>
-              {biometryAvailable && (
-                <Container>
-                  <BiometricSwitch variant={variant} />
-                </Container>
-              )}
+              <Container paddingBottom={1}>
+                <BiometricSwitch variant={variant} />
+              </Container>
             </Container>
             <Container
               flex={1}
+              paddingTop={4}
               width="80%"
-              justifyContent="space-around"
+              justifyContent="flex-end"
               alignItems="center"
             >
-              <Button>{strings.login.button}</Button>
-              <Text textAlign="center" color="grayText" size="xs">
-                {strings.login.eraseMessage}
-              </Text>
-              <Touchable onPress={onResetWalletPress} paddingBottom={4}>
-                <Text color="teal" size="xs">
-                  {strings.login.eraseLink}
+              <Container flex={1} justifyContent="flex-end" alignItems="center">
+                <Text
+                  textAlign="center"
+                  color="grayText"
+                  size="xs"
+                  paddingBottom={5}
+                >
+                  {strings.login.eraseMessage}
                 </Text>
-              </Touchable>
+                <Touchable onPress={onResetWalletPress}>
+                  <Text color="teal" size="xs">
+                    {strings.login.eraseLink}
+                  </Text>
+                </Touchable>
+              </Container>
             </Container>
-            <Container flex={0.3} justifyContent="center">
-              <Text paddingBottom={4} color="grayText" size="xs">
-                Version {appVersion}
-              </Text>
+            <Container flex={0.2} justifyContent="flex-end" paddingBottom={1}>
+              <AppVersionStamp />
             </Container>
           </Container>
         </TouchableWithoutFeedback>

--- a/cardstack/src/screens/UnlockScreen/strings.ts
+++ b/cardstack/src/screens/UnlockScreen/strings.ts
@@ -4,7 +4,6 @@ export const strings = {
     error: 'Incorrect PIN Code',
   },
   login: {
-    button: 'Log In',
     eraseMessage:
       "Can't login? You can ERASE your current wallet and setup a new one",
     eraseLink: 'Reset Wallet',

--- a/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
+++ b/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
@@ -1,4 +1,4 @@
-import { useNavigation, useRoute } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { useCallback, useState, useEffect } from 'react';
 import { Alert } from 'react-native';
 import RNRestart from 'react-native-restart';
@@ -8,27 +8,16 @@ import { DEFAULT_PIN_LENGTH } from '@cardstack/components/Input/PinInput/PinInpu
 import { useBooleanState } from '@cardstack/hooks';
 import { getPin, deletePin } from '@cardstack/models/secure-storage';
 import { Routes } from '@cardstack/navigation/routes';
-import { RouteType } from '@cardstack/navigation/types';
-import { ThemeVariant } from '@cardstack/theme/colorStyleVariants';
 
-import { useAppVersion } from '@rainbow-me/hooks';
 import { wipeKeychain } from '@rainbow-me/model/keychain';
 
 import { strings } from './strings';
 
-interface NavParams {
-  variant: ThemeVariant;
-}
-
 export const useUnlockScreen = () => {
   const { navigate } = useNavigation();
-  const { params } = useRoute<RouteType<NavParams>>();
   const { biometryAvailable } = useBiometricSwitch();
-  const appVersion = useAppVersion();
   const [inputPin, setInputPin] = useState('');
   const [pinInvalid, setPinInvalid, setPinValid] = useBooleanState();
-
-  const { variant = 'dark' } = params;
 
   const validatePin = useCallback(
     async (input: string) => {
@@ -72,8 +61,6 @@ export const useUnlockScreen = () => {
 
   return {
     biometryAvailable,
-    appVersion,
-    variant,
     inputPin,
     setInputPin,
     pinInvalid,

--- a/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
+++ b/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
@@ -1,37 +1,47 @@
-import { useNavigation } from '@react-navigation/native';
-import { useCallback, useState, useEffect } from 'react';
+import { useCallback, useState, useEffect, useRef } from 'react';
 import { Alert } from 'react-native';
 import RNRestart from 'react-native-restart';
 
 import { useBiometricSwitch } from '@cardstack/components/BiometricSwitch';
 import { DEFAULT_PIN_LENGTH } from '@cardstack/components/Input/PinInput/PinInput';
 import { useBooleanState } from '@cardstack/hooks';
-import { getPin, deletePin } from '@cardstack/models/secure-storage';
-import { Routes } from '@cardstack/navigation/routes';
+import { getPin } from '@cardstack/models/secure-storage';
+import { useAuthActions } from '@cardstack/redux/authSlice';
+import { useWorker } from '@cardstack/utils';
 
 import { wipeKeychain } from '@rainbow-me/model/keychain';
 
 import { strings } from './strings';
 
 export const useUnlockScreen = () => {
-  const { navigate } = useNavigation();
+  const storedPin = useRef<string | null>(null);
+
   const { biometryAvailable } = useBiometricSwitch();
   const [inputPin, setInputPin] = useState('');
   const [pinInvalid, setPinInvalid, setPinValid] = useBooleanState();
 
+  const { setUserAuthorized } = useAuthActions();
+
+  // Fetch on init so login it's faster
+  const { callback: getStoredPin } = useWorker(async () => {
+    storedPin.current = await getPin();
+  }, []);
+
+  useEffect(() => {
+    getStoredPin();
+  }, [getStoredPin]);
+
   const validatePin = useCallback(
     async (input: string) => {
-      const savedPin = await getPin();
-
-      if (savedPin === input) {
+      if (storedPin.current === input) {
         setPinValid();
-        navigate(Routes.WALLET_SCREEN);
+        setUserAuthorized();
       } else {
         setPinInvalid();
         setInputPin('');
       }
     },
-    [navigate, setPinInvalid, setPinValid]
+    [setPinInvalid, setPinValid, setUserAuthorized]
   );
 
   const onResetWalletPress = useCallback(() => {
@@ -40,7 +50,6 @@ export const useUnlockScreen = () => {
         text: strings.reset.delete,
         onPress: async () => {
           await wipeKeychain();
-          await deletePin();
           RNRestart.Restart();
         },
       },

--- a/cardstack/src/screens/WelcomeScreen/WelcomeScreen.tsx
+++ b/cardstack/src/screens/WelcomeScreen/WelcomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo } from 'react';
 
 import {
   Button,
@@ -11,7 +11,6 @@ import {
 import { CardwalletLogo } from '@cardstack/components/CardwalletLogo';
 
 import AppVersionStamp from '@rainbow-me/components/AppVersionStamp';
-import { useDimensions } from '@rainbow-me/hooks';
 
 import { useWelcomeScreen } from './hooks';
 import { strings } from './strings';
@@ -21,11 +20,6 @@ const MID_IMAGE_WRAPPER = 85;
 
 const WelcomeScreen = () => {
   const { onCreateWallet, onAddExistingWallet } = useWelcomeScreen();
-  const { isSmallPhone } = useDimensions();
-
-  const logoSize = useMemo(() => (isSmallPhone ? 'medium' : 'big'), [
-    isSmallPhone,
-  ]);
 
   return (
     <SafeAreaView
@@ -35,7 +29,7 @@ const WelcomeScreen = () => {
       paddingBottom={4}
     >
       <CenteredContainer flex={1} justifyContent="flex-end">
-        <CardwalletLogo size={logoSize} />
+        <CardwalletLogo proportionalSize />
       </CenteredContainer>
       <CenteredContainer flex={0.5}>
         <Container height={MID_IMAGE_WRAPPER}>

--- a/cardstack/src/screens/WelcomeScreen/hooks.tsx
+++ b/cardstack/src/screens/WelcomeScreen/hooks.tsx
@@ -45,7 +45,6 @@ export const useWelcomeScreen = () => {
     };
 
     checkCloudBackupOnInit();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const onCreateWallet = useCallback(() => {

--- a/cardstack/src/screens/WelcomeScreen/hooks.tsx
+++ b/cardstack/src/screens/WelcomeScreen/hooks.tsx
@@ -10,7 +10,7 @@ import {
   isCloudBackupAvailable,
   syncCloud,
 } from '@rainbow-me/handlers/cloudBackup';
-import { useHideSplashScreen, useWalletManager } from '@rainbow-me/hooks';
+import { useWalletManager } from '@rainbow-me/hooks';
 import { ICloudBackupData } from '@rainbow-me/model/backup';
 import logger from 'logger';
 
@@ -18,8 +18,6 @@ export const useWelcomeScreen = () => {
   const { navigate } = useNavigation<StackNavigationProp<ParamListBase>>();
 
   const [userData, setUserData] = useState<ICloudBackupData | null>(null);
-
-  const hideSplashScreen = useHideSplashScreen();
 
   const { createNewWallet } = useWalletManager();
 
@@ -43,8 +41,6 @@ export const useWelcomeScreen = () => {
         }
       } catch (e) {
         logger.log('error getting userData', e);
-      } finally {
-        hideSplashScreen();
       }
     };
 

--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,6 @@ import {
   showNetworkResponses,
 } from './config/debug';
 import { MainThemeProvider } from './context/ThemeContext';
-import { InitialRouteContext } from './context/initialRoute';
 import monitorNetwork from './debugging/network';
 import handleDeepLink from './handlers/deeplinks';
 import {
@@ -50,6 +49,7 @@ import {
   displayLocalNotification,
   notificationHandler,
 } from '@cardstack/notification-handler';
+import { authSlice } from '@cardstack/redux/authSlice';
 import { requestsForTopic } from '@cardstack/redux/requests';
 import theme from '@cardstack/theme';
 import { Device } from '@cardstack/utils';
@@ -195,6 +195,12 @@ class App extends Component {
   };
 
   handleAppStateChange = async nextAppState => {
+    const disabledStates = ['background', 'inactive'];
+
+    if (disabledStates.includes(this.state.appState)) {
+      store.dispatch(authSlice.actions.setUserUnauthorized());
+    }
+
     // Restore WC connectors when going from BG => FG
     if (this.state.appState === 'background' && nextAppState === 'active') {
       store.dispatch(walletConnectLoadState());
@@ -215,14 +221,8 @@ class App extends Component {
                 <PersistGate loading={null} persistor={persistor}>
                   <FlexItem>
                     <AppRequirementsCheck>
-                      {this.state.initialRoute && (
-                        <InitialRouteContext.Provider
-                          value={this.state.initialRoute}
-                        >
-                          <AppContainer />
-                          <PortalConsumer />
-                        </InitialRouteContext.Provider>
-                      )}
+                      <AppContainer />
+                      <PortalConsumer />
                     </AppRequirementsCheck>
                     <OfflineToast />
                   </FlexItem>

--- a/src/components/AppVersionStamp.tsx
+++ b/src/components/AppVersionStamp.tsx
@@ -42,7 +42,7 @@ const AppVersionStamp = () => {
   return (
     <>
       <TouchableWithoutFeedback onPress={handleVersionPress}>
-        <Text color="grayText" size="small" weight="bold">
+        <Text color="grayText" size="xs">
           Version {appVersion}
         </Text>
       </TouchableWithoutFeedback>

--- a/src/handlers/walletReadyEvents.js
+++ b/src/handlers/walletReadyEvents.js
@@ -8,7 +8,7 @@ import store from '@rainbow-me/redux/store';
 import { checkKeychainIntegrity } from '@rainbow-me/redux/wallets';
 import logger from 'logger';
 
-const BACKUP_SHEET_DELAY_MS = 3000;
+const BACKUP_SHEET_DELAY_MS = 4000;
 
 export const runKeychainIntegrityChecks = () => {
   setTimeout(async () => {
@@ -41,6 +41,10 @@ export const runWalletBackupStatusChecks = () => {
   );
 
   logger.log('wallet not backed up that is selected?', hasSelectedWallet);
+
+  if (Navigation.getActiveRouteName() !== Routes.WALLET_SCREEN) {
+    return;
+  }
 
   // if one of them is selected, show the default BackupSheet
   if (selected && hasSelectedWallet) {

--- a/src/model/keychain.ts
+++ b/src/model/keychain.ts
@@ -16,6 +16,7 @@ import {
   setInternetCredentials,
   UserCredentials,
 } from 'react-native-keychain';
+import { deletePin } from '@cardstack/models/secure-storage';
 import { Device } from '@cardstack/utils/device';
 import logger from 'logger';
 
@@ -146,10 +147,12 @@ export async function hasKey(key: string): Promise<boolean | Result> {
 export async function wipeKeychain(): Promise<void> {
   try {
     const results = await loadAllKeys();
+
     if (results) {
       await Promise.all(
         results?.map(result => resetInternetCredentials(result.username))
       );
+      await deletePin();
       logger.log('keychain wiped!');
     }
   } catch (e) {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -3,6 +3,7 @@ import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { setupListeners } from '@reduxjs/toolkit/dist/query';
 import { persistReducer, persistStore } from 'redux-persist';
 import reducers from './reducers';
+import { authSlice } from '@cardstack/redux/authSlice';
 import { biometryToggleSliceName } from '@cardstack/redux/biometryToggleSlice';
 import { primarySafeSliceName } from '@cardstack/redux/primarySafeSlice';
 import { hubApi } from '@cardstack/services/hub/hub-api';
@@ -23,6 +24,7 @@ const rootReducer = combineReducers({
   [safesApi.reducerPath]: safesApi.reducer,
   [hubApi.reducerPath]: hubApi.reducer,
   [serviceStatusApi.reducerPath]: serviceStatusApi.reducer,
+  [authSlice.name]: authSlice.reducer,
 });
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);

--- a/src/screens/ModalScreen.js
+++ b/src/screens/ModalScreen.js
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import TouchableBackdrop from '../components/TouchableBackdrop';
 import {
   ContactProfileState,
-  SupportedCountriesExpandedState,
   WalletProfileState,
 } from '../components/expanded-state';
 import { Centered } from '../components/layout';
@@ -14,7 +13,6 @@ import { padding, position } from '@rainbow-me/styles';
 
 const ModalTypes = {
   contact_profile: ContactProfileState,
-  supported_countries: SupportedCountriesExpandedState,
   wallet_profile: WalletProfileState,
   copy_address: CopyAddressSheet,
 };


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
This PR adds the ability to lock the app when it goes to background.

- Adds redux slice to handle auth 
- Updates the UnlockScreen,  removing the login btn 
- Makes cardLogo handle proportional size, to cleanup welcome/unlock screen
- Adds the logic that authorizes the user to use the app with the PIN 
- Splits the navigation based on auth flags, there's a quirk here using shared routes, ideally it would not be required to call nav reset, but since the routes are shared, once we have the address, the navigator doesn't navigate automatically, this can be simplified, using the `Group` component and `navigationKey` of react-navigation, but unfortunately it's only available on version 6. (which might be trick to update right now based on the breaking changes).
- Handles create/delete flows


### Screenshots

[GIF on Linear](https://linear.app/cardstack/issue/CS-3992#comment-9a57ad08)