### PR TITLE
[CS-4012]: Fix restore backup from init

### DIFF
--- a/src/hooks/useWalletManager.ts
+++ b/src/hooks/useWalletManager.ts
@@ -221,5 +221,6 @@ export default function useWalletManager() {
     createNewWallet,
     importWallet,
     changeSelectedWallet,
+    initWalletResetNavState,
   };
 }

--- a/src/model/backup.ts
+++ b/src/model/backup.ts
@@ -149,6 +149,7 @@ export function findLatestBackUp(wallets: AllRainbowWallets): string | null {
       wallet.backedUp &&
       wallet.backupDate &&
       wallet.backupFile &&
+      typeof wallet.backupFile === 'string' &&
       wallet.backupType === WalletBackupTypes.cloud
     ) {
       // If there is one, let's grab the latest backup
@@ -197,6 +198,7 @@ export async function restoreCloudBackup(
           (wallet.backedUp &&
             wallet.backupDate &&
             wallet.backupFile &&
+            typeof wallet.backupFile === 'string' &&
             wallet.backupType === WalletBackupTypes.cloud) ||
           wallet.type === WalletTypes.readOnly
         ) {


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
There was a lot of back and forth trying to add the createPin flow on the initial backup restore, and we need to rethink how the backup works in oder to add a consistent flow,  so for now, the backup restore will work with the same implementation of an "existing account", which is to prompt the Create flow once the wallet has load and no PIN is found. So this PR basically fixes the restore flow, which was on an infinite loop.

### Screenshots

<!-- Screenshots or animated GIFs included here -->

https://user-images.githubusercontent.com/20520102/172478282-d0b47ea5-f8e6-4aa9-b081-2d77b9eeb04a.mov



