### PR TITLE
[CS-3988] Rewards: move balance and history to own hook file

### DIFF
--- a/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
@@ -19,8 +19,6 @@ const RewardsCenterScreen = () => {
     isRegistered,
     hasRewardsAvailable,
     mainPoolTokenInfo,
-    historySectionData,
-    tokensBalanceData,
     isLoading,
   } = useRewardsCenterScreen();
 
@@ -51,8 +49,6 @@ const RewardsCenterScreen = () => {
             {isRegistered && (
               <ClaimContent
                 claimList={hasRewardsAvailable ? [mainPoolRowProps] : undefined}
-                historyList={historySectionData}
-                balanceList={tokensBalanceData}
               />
             )}
           </Container>

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -16,15 +16,11 @@ import {
   RewardRow,
   RewardRowProps,
   RewardsBalanceList,
-  RewardsBalanceListProps,
   RewardsHistoryList,
-  RewardsHistoryListProps,
 } from '.';
 
 interface ClaimContentProps {
   claimList?: Array<RewardRowProps>;
-  balanceList?: RewardsBalanceListProps;
-  historyList?: RewardsHistoryListProps;
 }
 
 enum Tabs {
@@ -37,11 +33,7 @@ const tabs = [
   { title: strings.history.title, key: Tabs.HISTORY },
 ];
 
-export const ClaimContent = ({
-  claimList,
-  balanceList,
-  historyList,
-}: ClaimContentProps) => {
+export const ClaimContent = ({ claimList }: ClaimContentProps) => {
   const { TabHeader, currentTab } = useTabHeader({ tabs });
 
   const { navigate } = useNavigation();
@@ -84,9 +76,9 @@ export const ClaimContent = ({
       <TabHeader />
       <Container padding={5}>
         {currentTab.key === Tabs.BALANCE ? (
-          <RewardsBalanceList {...balanceList} />
+          <RewardsBalanceList />
         ) : (
-          <RewardsHistoryList {...historyList} />
+          <RewardsHistoryList />
         )}
       </Container>
     </ScrollView>

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsBalanceList.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsBalanceList.tsx
@@ -46,7 +46,7 @@ export const RewardsBalanceList = () => {
 
   return (
     <FlatList
-      data={tokensBalanceData || []}
+      data={tokensBalanceData}
       renderItem={renderItem}
       ItemSeparatorComponent={spacing}
       ListEmptyComponent={<ListEmptyComponent text={strings.balance.empty} />}

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsBalanceList.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsBalanceList.tsx
@@ -7,16 +7,15 @@ import { Routes } from '@cardstack/navigation';
 import { TokenType } from '@cardstack/types';
 
 import { strings } from '../strings';
+import useRewardsBalanceHistory from '../useRewardsBalanceHistory';
 
 import { RewardRow } from '.';
 
 export type TokenWithSafeAddress = TokenType & { safeAddress: string };
-export interface RewardsBalanceListProps {
-  data?: TokenWithSafeAddress[];
-}
 
-export const RewardsBalanceList = ({ data = [] }: RewardsBalanceListProps) => {
+export const RewardsBalanceList = () => {
   const { navigate } = useNavigation();
+  const { tokensBalanceData } = useRewardsBalanceHistory();
 
   const onPress = useCallback(
     tokenInfo => () => {
@@ -47,7 +46,7 @@ export const RewardsBalanceList = ({ data = [] }: RewardsBalanceListProps) => {
 
   return (
     <FlatList
-      data={data}
+      data={tokensBalanceData || []}
       renderItem={renderItem}
       ItemSeparatorComponent={spacing}
       ListEmptyComponent={<ListEmptyComponent text={strings.balance.empty} />}

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
@@ -46,7 +46,7 @@ export const RewardsHistoryList = () => {
   return (
     <SectionList
       renderSectionHeader={renderSectionHeader}
-      sections={historySectionData || []}
+      sections={historySectionData}
       renderItem={renderItem}
       ItemSeparatorComponent={spacing}
       SectionSeparatorComponent={spacing}

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardsHistoryList.tsx
@@ -7,22 +7,15 @@ import { RewardeeClaim, TokenTransfer } from '@cardstack/graphql';
 import { fromWeiToFixedEth } from '@cardstack/utils';
 
 import { strings } from '../strings';
+import useRewardsBalanceHistory from '../useRewardsBalanceHistory';
 
 import { RewardRow } from '.';
 
 export type ClaimOrTokenWithdraw = OptionalUnion<RewardeeClaim, TokenTransfer>;
-export interface RewardsHistorySectionType {
-  title: string;
-  data: ClaimOrTokenWithdraw[];
-}
 
-export interface RewardsHistoryListProps {
-  sections?: Array<RewardsHistorySectionType>;
-}
+export const RewardsHistoryList = () => {
+  const { historySectionData } = useRewardsBalanceHistory();
 
-export const RewardsHistoryList = ({
-  sections = [],
-}: RewardsHistoryListProps) => {
   const renderSectionHeader = useCallback(
     ({ section }) => (
       <Container backgroundColor="white">
@@ -53,7 +46,7 @@ export const RewardsHistoryList = ({
   return (
     <SectionList
       renderSectionHeader={renderSectionHeader}
-      sections={sections}
+      sections={historySectionData || []}
       renderItem={renderItem}
       ItemSeparatorComponent={spacing}
       SectionSeparatorComponent={spacing}

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsBalanceHistory.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsBalanceHistory.ts
@@ -68,21 +68,21 @@ const useRewardsBalanceHistory = () => {
           title,
           data: data.sort(sortByTime) as ClaimOrTokenWithdraw[],
         }))
-        .sort((a, b) => sortByTime(a.data[0], b.data[0])),
+        .sort((a, b) => sortByTime(a.data[0], b.data[0])) || [],
     [rewardClaims, rewardSafeWithdraws]
   );
 
   // Get tokens from all rewardSafes
   const tokensBalanceData = useMemo(
     () =>
-      rewardSafes?.reduce((tokens: TokenType[], safe: RewardsSafeType) => {
+      (rewardSafes?.reduce((tokens: TokenType[], safe: RewardsSafeType) => {
         const tokensWithAddress = safe.tokens?.map(token => ({
           ...token,
           safeAddress: safe.address,
         }));
 
         return [...tokens, ...tokensWithAddress];
-      }, []) as TokenWithSafeAddress[],
+      }, []) as TokenWithSafeAddress[]) || [],
     [rewardSafes]
   );
 

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsBalanceHistory.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsBalanceHistory.ts
@@ -86,7 +86,7 @@ const useRewardsBalanceHistory = () => {
     [rewardSafes]
   );
 
-  // Refetchs when rewardSafes or rewardPoolTokenBalances updates
+  // Refetches when rewardSafes or rewardPoolTokenBalances updates
   useEffect(() => {
     refetchClaimHistory();
     refetchWithdrawHistory();

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsBalanceHistory.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsBalanceHistory.ts
@@ -1,0 +1,99 @@
+import { getAddressByNetwork } from '@cardstack/cardpay-sdk';
+import { groupBy } from 'lodash';
+import { useMemo, useEffect } from 'react';
+
+import {
+  useGetRewardClaimsQuery,
+  useGetTransactionsFromSafesQuery,
+} from '@cardstack/graphql';
+import { RewardsSafeType } from '@cardstack/services/rewards-center/rewards-center-types';
+import { TokenType } from '@cardstack/types';
+import {
+  isLayer1,
+  groupTransactionsByDate,
+  sortByTime,
+} from '@cardstack/utils';
+
+import { useAccountSettings } from '@rainbow-me/hooks';
+
+import { ClaimOrTokenWithdraw, TokenWithSafeAddress } from './components';
+import useRewardsDataFetch from './useRewardsDataFetch';
+
+const useRewardsBalanceHistory = () => {
+  const { accountAddress, network } = useAccountSettings();
+  const { rewardSafes, rewardPoolTokenBalances } = useRewardsDataFetch();
+
+  const rewardSafesAddresses = useMemo(
+    () => rewardSafes?.map(({ address }) => address),
+    [rewardSafes]
+  );
+
+  const {
+    data: rewardClaims,
+    refetch: refetchClaimHistory,
+  } = useGetRewardClaimsQuery({
+    skip: !accountAddress,
+    variables: {
+      rewardeeAddress: accountAddress,
+    },
+    context: { network },
+  });
+
+  const {
+    data: rewardSafeWithdraws,
+    refetch: refetchWithdrawHistory,
+  } = useGetTransactionsFromSafesQuery({
+    skip: !rewardSafesAddresses || isLayer1(network),
+    variables: {
+      safeAddresses: rewardSafesAddresses,
+      relayAddress: !isLayer1(network)
+        ? getAddressByNetwork('relay', network)
+        : '',
+    },
+    context: { network },
+  });
+
+  const historySectionData = useMemo(
+    () =>
+      Object.entries(
+        groupBy(
+          [
+            ...(rewardClaims?.rewardeeClaims || []),
+            ...(rewardSafeWithdraws?.tokenTransfers || []),
+          ],
+          groupTransactionsByDate
+        )
+      )
+        .map(([title, data]) => ({
+          title,
+          data: data.sort(sortByTime) as ClaimOrTokenWithdraw[],
+        }))
+        .sort((a, b) => sortByTime(a.data[0], b.data[0])),
+    [rewardClaims, rewardSafeWithdraws]
+  );
+
+  // Get tokens from all rewardSafes
+  const tokensBalanceData = useMemo(
+    () =>
+      rewardSafes?.reduce((tokens: TokenType[], safe: RewardsSafeType) => {
+        const tokensWithAddress = safe.tokens?.map(token => ({
+          ...token,
+          safeAddress: safe.address,
+        }));
+
+        return [...tokens, ...tokensWithAddress];
+      }, []) as TokenWithSafeAddress[],
+    [rewardSafes]
+  );
+
+  // Refetchs when rewardSafes or rewardPoolTokenBalances updates
+  useEffect(() => {
+    refetchClaimHistory();
+    refetchWithdrawHistory();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rewardSafes, rewardPoolTokenBalances]);
+
+  return { historySectionData, tokensBalanceData };
+};
+
+export default useRewardsBalanceHistory;

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -1,27 +1,8 @@
-import { getAddressByNetwork } from '@cardstack/cardpay-sdk';
-import { groupBy } from 'lodash';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 
-import {
-  useGetRewardClaimsQuery,
-  useGetTransactionsFromSafesQuery,
-} from '@cardstack/graphql';
-import { RewardsSafeType } from '@cardstack/services/rewards-center/rewards-center-types';
-import { TokenType } from '@cardstack/types';
-import {
-  groupTransactionsByDate,
-  isLayer1,
-  sortByTime,
-} from '@cardstack/utils';
-
-import { useAccountSettings } from '@rainbow-me/hooks';
-
-import { ClaimOrTokenWithdraw, TokenWithSafeAddress } from './components';
 import useRewardsDataFetch from './useRewardsDataFetch';
 
 export const useRewardsCenterScreen = () => {
-  const { accountAddress, network } = useAccountSettings();
-
   const {
     rewardSafes,
     rewardPoolTokenBalances,
@@ -48,81 +29,6 @@ export const useRewardsCenterScreen = () => {
     [rewardSafes, defaultRewardProgramId]
   );
 
-  const {
-    data: rewardClaims,
-    refetch: refetchClaimHistory,
-  } = useGetRewardClaimsQuery({
-    skip: !accountAddress,
-    variables: {
-      rewardeeAddress: accountAddress,
-    },
-    context: { network },
-  });
-
-  const rewardSafesAddresses = useMemo(
-    () => rewardSafes?.map(({ address }) => address),
-    [rewardSafes]
-  );
-
-  const {
-    data: rewardSafeWithdraws,
-    refetch: refetchWithdrawHistory,
-  } = useGetTransactionsFromSafesQuery({
-    skip: !rewardSafesAddresses || isLayer1(network),
-    variables: {
-      safeAddresses: rewardSafesAddresses,
-      relayAddress: !isLayer1(network)
-        ? getAddressByNetwork('relay', network)
-        : '',
-    },
-    context: { network },
-  });
-
-  const historySectionData = useMemo(
-    () => ({
-      sections: Object.entries(
-        groupBy(
-          [
-            ...(rewardClaims?.rewardeeClaims || []),
-            ...(rewardSafeWithdraws?.tokenTransfers || []),
-          ],
-          groupTransactionsByDate
-        )
-      )
-        .map(([title, data]) => ({
-          title,
-          data: data.sort(sortByTime) as ClaimOrTokenWithdraw[],
-        }))
-        .sort((a, b) => sortByTime(a.data[0], b.data[0])),
-    }),
-    [rewardClaims, rewardSafeWithdraws]
-  );
-
-  // Refetchs when rewardSafes or rewardPoolTokenBalances updates
-  useEffect(() => {
-    refetchClaimHistory();
-    refetchWithdrawHistory();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rewardSafes, rewardPoolTokenBalances]);
-
-  const tokensBalanceData = useMemo(
-    () => ({
-      // Get tokens from all rewardSafes
-      data: rewardSafes?.reduce(
-        (tokens: TokenType[], safe: RewardsSafeType) => {
-          const tokensWithAddress = safe.tokens?.map(token => ({
-            ...token,
-            safeAddress: safe.address,
-          }));
-
-          return [...tokens, ...tokensWithAddress] as TokenWithSafeAddress[];
-        },
-        []
-      ),
-    }),
-    [rewardSafes]
-  );
-
   return {
     rewardSafes,
     registeredPools,
@@ -131,7 +37,5 @@ export const useRewardsCenterScreen = () => {
     hasRewardsAvailable: !!mainPoolTokenInfo,
     mainPoolTokenInfo,
     isLoading,
-    historySectionData,
-    tokensBalanceData,
   };
 };


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

This is the final PR of the useRewardsCenter hook refactor. It moves all the history and balance queries and data manipulation into its own hook. Not sure yet how to test it... maybe adding tests to the data manipulation (`historySectionData`& `tokensBalanceData`)? 

<!-- Include a summary of the changes. -->

- [x] Completes [#CS-3988](https://linear.app/cardstack/issue/CS-3988/move-balance-and-history-functions-to-its-own-hooks-and-add-tests)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

No visual changes :)
