### PR TITLE
[CS-3370] Show rewards available count on MainHeader rewards icon

### DIFF
--- a/cardstack/src/components/MainHeader/MainHeader.tsx
+++ b/cardstack/src/components/MainHeader/MainHeader.tsx
@@ -8,11 +8,13 @@ import {
   MainHeaderWrapper,
 } from '@cardstack/components';
 import { Routes } from '@cardstack/navigation';
+import useRewardsDataFetch from '@cardstack/screens/RewardsCenterScreen/useRewardsDataFetch';
 
 import { networkInfo } from '@rainbow-me/helpers/networkInfo';
 import { useAccountSettings } from '@rainbow-me/hooks';
 
 import { ContainerProps } from '../Container';
+import { Touchable } from '../Touchable';
 
 interface Props extends ContainerProps {
   title?: string;
@@ -32,6 +34,7 @@ const MainHeader = ({
 }: Props) => {
   const { navigate } = useNavigation();
   const { network } = useAccountSettings();
+  const { rewardPoolTokenBalances } = useRewardsDataFetch();
 
   const onMenuPress = useCallback(() => navigate(Routes.SETTINGS_MODAL), [
     navigate,
@@ -40,6 +43,8 @@ const MainHeader = ({
   const onRewardPress = useCallback(() => {
     navigate(Routes.REWARDS_CENTER_SCREEN);
   }, [navigate]);
+
+  const hasRewardsClaim = rewardPoolTokenBalances?.length;
 
   return (
     <MainHeaderWrapper {...containerProps}>
@@ -71,13 +76,19 @@ const MainHeader = ({
         children
       )}
       {!rightIcon ? (
-        <Icon
-          color="teal"
-          iconSize="medium"
-          size={26}
-          name="rewards"
+        <Touchable
+          flexDirection="row"
+          alignItems="center"
+          alignContent="center"
           onPress={onRewardPress}
-        />
+        >
+          <Icon color="teal" iconSize="medium" size={26} name="rewards" />
+          {!!hasRewardsClaim && (
+            <Text color="teal" fontSize={16} weight="bold" marginLeft={2}>
+              {hasRewardsClaim}
+            </Text>
+          )}
+        </Touchable>
       ) : (
         rightIcon
       )}

--- a/cardstack/src/components/MainHeader/MainHeader.tsx
+++ b/cardstack/src/components/MainHeader/MainHeader.tsx
@@ -44,7 +44,7 @@ const MainHeader = ({
     navigate(Routes.REWARDS_CENTER_SCREEN);
   }, [navigate]);
 
-  const hasRewardsClaim = rewardPoolTokenBalances?.length;
+  const availableRewards = rewardPoolTokenBalances?.length;
 
   return (
     <MainHeaderWrapper {...containerProps}>
@@ -78,15 +78,16 @@ const MainHeader = ({
       {!rightIcon ? (
         <Touchable
           flexDirection="row"
-          alignItems="center"
-          alignContent="center"
+          alignItems="flex-end"
           onPress={onRewardPress}
         >
           <Icon color="teal" iconSize="medium" size={26} name="rewards" />
-          {!!hasRewardsClaim && (
-            <Text color="teal" fontSize={16} weight="bold" marginLeft={2}>
-              {hasRewardsClaim}
-            </Text>
+          {!!availableRewards && (
+            <Container>
+              <Text color="teal" fontSize={18} weight="bold" marginLeft={2}>
+                {availableRewards}
+              </Text>
+            </Container>
           )}
         </Touchable>
       ) : (


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
This PR adds the rewards available count to the Rewards icon that lives inside the MainHeader component.  To get the count number, I'm using the information that comes from the `rewardPoolTokenBalances` query for future-proofing. Let me know if you think that we should be using `mainPoolTokenInfo` instead.

- [x] Completes [#CS-3370](https://linear.app/cardstack/issue/CS-3370/show-reward-claims-available-count-on-reward-icon)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/172952924-eef6ddd5-76bc-4b9e-924f-6895b128522f.png">

