### PR TITLE
[CS-3939] Remove line-break from Mailchimp's privacy practices link

### DIFF
--- a/cardstack/src/screens/RequestPrepaidCardScreen/strings.ts
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/strings.ts
@@ -11,7 +11,7 @@ export const strings = {
     messageNote:
       'We use Mailchimp as our marketing platform. By clicking below to subscribe, you acknowledge that your information will be transferred to Mailchimp for processing.',
     link: {
-      text: "Learn more about Mailchimp's privacy practices here.",
+      text: 'Learn more.',
       url: 'https://mailchimp.com/legal/terms/',
     },
   },


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
This PR is an attempt to solve the line-breaking issue we have on Mailchimp's privacy practices link. It is currently causing the tap area to act weird. Removing the long text may help this.

- [x] Completes [#CS-3939](https://linear.app/cardstack/issue/CS-3939/[android]-[card-drop]-link-to-mailchimps-privacy-practices-is-not)

### Checklist

- [x] All UI changes have been tested on a small device

