### PR TITLE
[CS-4058] Pin: create basic screen to list all the seed phrases for backup

### DIFF
--- a/cardstack/src/hooks/useCopyToast.tsx
+++ b/cardstack/src/hooks/useCopyToast.tsx
@@ -6,7 +6,7 @@ import { useBottomToast } from './useBottomToast';
 
 interface useCopyToastParams {
   customCopyLabel?: string;
-  dataToCopy: string;
+  dataToCopy?: string;
 }
 
 export const useCopyToast = ({
@@ -17,12 +17,15 @@ export const useCopyToast = ({
 
   const { ToastComponent, showToast } = useBottomToast();
 
-  const copyToClipboard = useCallback(() => {
-    setClipboard(dataToCopy);
-    showToast({
-      label: `Copied "${customCopyLabel || clipboard}" to clipboard`,
-    });
-  }, [clipboard, customCopyLabel, dataToCopy, showToast, setClipboard]);
+  const copyToClipboard = useCallback(
+    (copy?: string) => {
+      setClipboard(dataToCopy || copy);
+      showToast({
+        label: `Copied "${customCopyLabel || copy || clipboard}" to clipboard`,
+      });
+    },
+    [clipboard, customCopyLabel, dataToCopy, showToast, setClipboard]
+  );
 
   return {
     CopyToastComponent: ToastComponent,

--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -33,6 +33,7 @@ export const MainRoutes = {
   SUPPORT_AND_FEES: 'SupportAndFeesSheet',
   AVAILABLE_BALANCE_SHEET: 'AvailableBalanceSheet',
   TOKEN_WITH_CHART_SHEET: 'TokenWithChartSheet',
+  SEED_PHRASE_BACKUP: 'SeedPhraseBackup',
 } as const;
 
 const TabRoutes = {

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -32,6 +32,7 @@ import {
   SupportAndFeesSheet,
   AvailableBalanceSheet,
   TokenWithChartSheet,
+  SeedPhraseBackup,
 } from '@cardstack/screens';
 import {
   RewardWithdrawConfirmationScreen,
@@ -206,6 +207,10 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
   TOKEN_WITH_CHART_SHEET: {
     component: TokenWithChartSheet,
     options: expandedPreset as StackNavigationOptions,
+  },
+  SEED_PHRASE_BACKUP: {
+    component: SeedPhraseBackup,
+    options: horizontalInterpolator,
   },
 };
 

--- a/cardstack/src/screens/CopyAddressSheet.tsx
+++ b/cardstack/src/screens/CopyAddressSheet.tsx
@@ -75,7 +75,7 @@ const CopyAddressSheet = () => {
         ) : null}
         <CenteredContainer padding={4}>
           <Pressable
-            onLongPress={copyToClipboard}
+            onLongPress={copyToClipboard as any}
             delayLongPress={delayLongPressMs}
           >
             <Text

--- a/cardstack/src/screens/SeedPhraseBackup/SeedPhraseBackup.tsx
+++ b/cardstack/src/screens/SeedPhraseBackup/SeedPhraseBackup.tsx
@@ -14,10 +14,8 @@ import {
   SafeAreaView,
   Text,
 } from '@cardstack/components';
-import { useBottomToast } from '@cardstack/hooks';
+import { useCopyToast } from '@cardstack/hooks';
 import { RouteType } from '@cardstack/navigation/types';
-
-import { useClipboard } from '@rainbow-me/hooks';
 
 import { strings } from './strings';
 
@@ -27,23 +25,12 @@ interface SeedPhraseBackupParams {
 
 const SeedPhraseBackup = () => {
   const { params } = useRoute<RouteType<SeedPhraseBackupParams>>();
-  const { setClipboard } = useClipboard();
-  const { ToastComponent, showToast } = useBottomToast();
 
-  const copySeedPhrase = useCallback(
-    (item: string) => () => {
-      setClipboard(item);
-
-      showToast({
-        label: `Copied to clipboard`,
-      });
-    },
-    [setClipboard, showToast]
-  );
+  const { CopyToastComponent, copyToClipboard } = useCopyToast({});
 
   const renderSeedPhrases = useCallback(
     ({ item }) => (
-      <TouchableOpacity onPress={copySeedPhrase(item)}>
+      <TouchableOpacity onPress={() => copyToClipboard(item)}>
         <CenteredContainer
           borderWidth={1}
           borderColor="teal"
@@ -57,14 +44,12 @@ const SeedPhraseBackup = () => {
         </CenteredContainer>
       </TouchableOpacity>
     ),
-    [copySeedPhrase]
+    [copyToClipboard]
   );
 
   const onPress = useCallback(() => {
-    showToast({
-      label: `Go Back`,
-    });
-  }, [showToast]);
+    // TODO: go to create pin flow
+  }, []);
 
   return (
     <SafeAreaView
@@ -90,7 +75,7 @@ const SeedPhraseBackup = () => {
       </Container>
       <Button onPress={onPress}>{strings.button}</Button>
 
-      <ToastComponent />
+      <CopyToastComponent />
     </SafeAreaView>
   );
 };

--- a/cardstack/src/screens/SeedPhraseBackup/SeedPhraseBackup.tsx
+++ b/cardstack/src/screens/SeedPhraseBackup/SeedPhraseBackup.tsx
@@ -1,0 +1,104 @@
+import { useRoute } from '@react-navigation/native';
+import React, { useCallback } from 'react';
+import {
+  FlatList,
+  StatusBar,
+  StyleSheet,
+  TouchableOpacity,
+} from 'react-native';
+
+import {
+  Button,
+  CenteredContainer,
+  Container,
+  SafeAreaView,
+  Text,
+} from '@cardstack/components';
+import { useBottomToast } from '@cardstack/hooks';
+import { RouteType } from '@cardstack/navigation/types';
+
+import { useClipboard } from '@rainbow-me/hooks';
+
+import { strings } from './strings';
+
+interface SeedPhraseBackupParams {
+  seedPhrases: string[];
+}
+
+const SeedPhraseBackup = () => {
+  const { params } = useRoute<RouteType<SeedPhraseBackupParams>>();
+  const { setClipboard } = useClipboard();
+  const { ToastComponent, showToast } = useBottomToast();
+
+  const copySeedPhrase = useCallback(
+    (item: string) => () => {
+      setClipboard(item);
+
+      showToast({
+        label: `Copied to clipboard`,
+      });
+    },
+    [setClipboard, showToast]
+  );
+
+  const renderSeedPhrases = useCallback(
+    ({ item }) => (
+      <TouchableOpacity onPress={copySeedPhrase(item)}>
+        <CenteredContainer
+          borderWidth={1}
+          borderColor="teal"
+          borderRadius={10}
+          marginBottom={6}
+          paddingHorizontal={4}
+          paddingTop={4}
+          paddingBottom={5}
+        >
+          <Text color="white">{item}</Text>
+        </CenteredContainer>
+      </TouchableOpacity>
+    ),
+    [copySeedPhrase]
+  );
+
+  const onPress = useCallback(() => {
+    showToast({
+      label: `Go Back`,
+    });
+  }, [showToast]);
+
+  return (
+    <SafeAreaView
+      backgroundColor="backgroundDarkPurple"
+      flex={1}
+      alignItems="center"
+      paddingBottom={18}
+    >
+      <StatusBar barStyle="light-content" />
+      <Container paddingVertical={4} paddingHorizontal={4}>
+        <Text fontSize={24} marginTop={8} color="white">
+          {strings.title}
+        </Text>
+        <Text fontSize={16} marginTop={4} marginBottom={4} color="white">
+          {strings.subtitle}
+        </Text>
+        <FlatList
+          data={params?.seedPhrases || []}
+          renderItem={renderSeedPhrases}
+          contentContainerStyle={styles.contentContainer}
+          showsVerticalScrollIndicator={false}
+        />
+      </Container>
+      <Button onPress={onPress}>{strings.button}</Button>
+
+      <ToastComponent />
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    paddingTop: 24,
+  },
+});
+
+export default SeedPhraseBackup;

--- a/cardstack/src/screens/SeedPhraseBackup/strings.ts
+++ b/cardstack/src/screens/SeedPhraseBackup/strings.ts
@@ -1,0 +1,6 @@
+export const strings = {
+  button: 'OK, I copied all my seed phrases',
+  title: 'Backup your seed phrases',
+  subtitle:
+    'Tap the seed phrases below to copy them. Save them in a secure place.',
+};

--- a/cardstack/src/screens/SeedPhraseBackup/strings.ts
+++ b/cardstack/src/screens/SeedPhraseBackup/strings.ts
@@ -1,5 +1,5 @@
 export const strings = {
-  button: 'OK, I copied all my seed phrases',
+  button: `OK, I've saved my seed phrases`,
   title: 'Backup your seed phrases',
   subtitle:
     'Tap the seed phrases below to copy them. Save them in a secure place.',

--- a/cardstack/src/screens/index.ts
+++ b/cardstack/src/screens/index.ts
@@ -37,3 +37,4 @@ export { default as UnlockScreen } from './UnlockScreen/UnlockScreen';
 export { default as SupportAndFeesSheet } from './sheets/SupportAndFeesSheet/SupportAndFeesSheet';
 export { default as AvailableBalanceSheet } from './sheets/AvailableBalanceSheet/AvailableBalanceSheet';
 export { default as TokenWithChartSheet } from './sheets/TokenWithChartSheet/TokenWithChartSheet';
+export { default as SeedPhraseBackup } from './SeedPhraseBackup/SeedPhraseBackup';

--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -95,6 +95,10 @@ export default function SettingsSection({
     });
   }, [navigate]);
 
+  const onPressSeedPhraseBackup = useCallback(() => {
+    navigate(Routes.SEED_PHRASE_BACKUP);
+  }, [navigate]);
+
   return (
     <ScrollView backgroundColor="white">
       <ColumnWithDividers dividerRenderer={ListItemDivider} marginTop={7}>
@@ -157,14 +161,23 @@ export default function SettingsSection({
           <ListItemArrowGroup />
         </ListItem>
         {__DEV__ && (
-          <ListItem
-            icon={<Icon color="settingsTeal" name="lock" />}
-            label="Change Pin"
-            onPress={onPressChangePin}
-            testID="changePin-section"
-          >
-            <ListItemArrowGroup />
-          </ListItem>
+          <>
+            <ListItem
+              icon={<Icon color="settingsTeal" name="lock" />}
+              label="Change Pin"
+              onPress={onPressChangePin}
+              testID="changePin-section"
+            >
+              <ListItemArrowGroup />
+            </ListItem>
+            <ListItem
+              icon={<Icon color="settingsTeal" name="warning" />}
+              label="Seed Phrase Backup"
+              onPress={onPressSeedPhraseBackup}
+            >
+              <ListItemArrowGroup />
+            </ListItem>
+          </>
         )}
       </ColumnWithDividers>
       <ListFooter />


### PR DESCRIPTION
<!-- This is a pull request. Please make sure any applicable bullet points have been covered. -->

### Description
Pretty average screen for when the user has multiple wallets. In order for them to not loose access to their wallets, they need to manually save each wallet's seed phrase.

@danibonilha I used the approach of having the seed phrases being passed as navigation params. Let me know if you prefer another approach.

- [x] Completes [#CS-4058](https://linear.app/cardstack/issue/CS-4058/[flow]-add-screen-to-show-seed-phrases-and-allow-copy)

### Checklist

- [x] All UI changes have been tested on a small device

### Screenshots


