### PR TITLE
[CS-4023] Enhance resetWallet with secure storage + keychain cleanup

### DIFF
--- a/cardstack/src/models/secure-storage.ts
+++ b/cardstack/src/models/secure-storage.ts
@@ -78,14 +78,16 @@ const setEncryptedItem = async (item: string, key: Keys, pin: string) => {
 const buildKeyWithId = (key: Keys, id: string) => `${key}_${id}`;
 
 // PIN
-const savePin = (pin: string) => SecureStore.setItemAsync(keys.AUTH_PIN, pin);
+const savePin = async (pin: string) =>
+  await SecureStore.setItemAsync(keys.AUTH_PIN, pin);
 
-const getPin = () => getSecureValue(keys.AUTH_PIN);
+const getPin = async () => await getSecureValue(keys.AUTH_PIN);
 
-const deletePin = () =>
-  SecureStore.deleteItemAsync(keys.AUTH_PIN).then(() =>
-    logger.log('Deleted PIN')
-  );
+const deletePin = async () => {
+  await SecureStore.deleteItemAsync(keys.AUTH_PIN);
+
+  logger.log('Deleted PIN');
+};
 
 const encryptor = new AesEncryptor();
 
@@ -107,9 +109,9 @@ const getSeedPhrase = async (walletId: string) => {
 const deleteSeedPhrase = async (walletId: string) => {
   const seedKey = buildKeyWithId(keys.SEED, walletId);
 
-  await SecureStore.deleteItemAsync(seedKey).then(() =>
-    logger.log('Deleted seed phrase')
-  );
+  await SecureStore.deleteItemAsync(seedKey);
+
+  logger.log('Deleted seed phrase');
 };
 
 // PRIVATE_KEY
@@ -136,9 +138,9 @@ const getPrivateKey = async (walletAddress: string) => {
 const deletePrivateKey = async (walletAddress: string) => {
   const pKey = buildKeyWithId(keys.PKEY, walletAddress);
 
-  await SecureStore.deleteItemAsync(pKey).then(() =>
-    logger.log('Deleted private key')
-  );
+  await SecureStore.deleteItemAsync(pKey);
+
+  logger.log('Deleted private key');
 };
 
 const wipeSecureStorage = async (wallets: AllRainbowWallets) => {

--- a/cardstack/src/models/secure-storage.ts
+++ b/cardstack/src/models/secure-storage.ts
@@ -2,6 +2,7 @@ import * as SecureStore from 'expo-secure-store';
 import { SECURE_STORE_KEY } from 'react-native-dotenv';
 
 import AesEncryptor from '@rainbow-me/handlers/aesEncryption';
+import { AllRainbowWallets } from '@rainbow-me/model/wallet';
 import logger from 'logger';
 
 const keys = {
@@ -131,6 +132,19 @@ const deletePrivateKey = async (walletAddress: string) => {
   const pKey = buildKeyWithId(keys.PKEY, walletAddress);
 
   await SecureStore.deleteItemAsync(pKey);
+const wipeSecureStorage = async (wallets: AllRainbowWallets) => {
+  for (const walletId of Object.keys(wallets)) {
+    const walletAddresses = wallets[walletId].addresses;
+
+    // loop through addresses to pass all .address to deletePrivateKey
+    for (const account of walletAddresses) {
+      await deleteSeedPhrase(walletId);
+      await deletePrivateKey(account.address);
+      await deletePin();
+    }
+  }
+
+  return;
 };
 
 export {

--- a/cardstack/src/models/secure-storage.ts
+++ b/cardstack/src/models/secure-storage.ts
@@ -82,7 +82,10 @@ const savePin = (pin: string) => SecureStore.setItemAsync(keys.AUTH_PIN, pin);
 
 const getPin = () => getSecureValue(keys.AUTH_PIN);
 
-const deletePin = () => SecureStore.deleteItemAsync(keys.AUTH_PIN);
+const deletePin = () =>
+  SecureStore.deleteItemAsync(keys.AUTH_PIN).then(() =>
+    logger.log('Deleted PIN')
+  );
 
 const encryptor = new AesEncryptor();
 
@@ -104,7 +107,9 @@ const getSeedPhrase = async (walletId: string) => {
 const deleteSeedPhrase = async (walletId: string) => {
   const seedKey = buildKeyWithId(keys.SEED, walletId);
 
-  await SecureStore.deleteItemAsync(seedKey);
+  await SecureStore.deleteItemAsync(seedKey).then(() =>
+    logger.log('Deleted seed phrase')
+  );
 };
 
 // PRIVATE_KEY
@@ -131,7 +136,11 @@ const getPrivateKey = async (walletAddress: string) => {
 const deletePrivateKey = async (walletAddress: string) => {
   const pKey = buildKeyWithId(keys.PKEY, walletAddress);
 
-  await SecureStore.deleteItemAsync(pKey);
+  await SecureStore.deleteItemAsync(pKey).then(() =>
+    logger.log('Deleted private key')
+  );
+};
+
 const wipeSecureStorage = async (wallets: AllRainbowWallets) => {
   for (const walletId of Object.keys(wallets)) {
     const walletAddresses = wallets[walletId].addresses;
@@ -157,4 +166,5 @@ export {
   savePrivateKey,
   getPrivateKey,
   deletePrivateKey,
+  wipeSecureStorage,
 };

--- a/cardstack/src/models/secure-storage.ts
+++ b/cardstack/src/models/secure-storage.ts
@@ -144,18 +144,22 @@ const deletePrivateKey = async (walletAddress: string) => {
 };
 
 const wipeSecureStorage = async (wallets: AllRainbowWallets) => {
-  for (const walletId of Object.keys(wallets)) {
-    const walletAddresses = wallets[walletId].addresses;
+  // these deletions need to be sequential, otherwise they break
+  try {
+    for (const walletId of Object.keys(wallets)) {
+      const walletAddresses = wallets[walletId].addresses;
 
-    // loop through addresses to pass all .address to deletePrivateKey
-    for (const account of walletAddresses) {
       await deleteSeedPhrase(walletId);
-      await deletePrivateKey(account.address);
       await deletePin();
-    }
-  }
 
-  return;
+      // loop through addresses to pass all .address to deletePrivateKey
+      for (const account of walletAddresses) {
+        await deletePrivateKey(account.address);
+      }
+    }
+  } catch (error) {
+    logger.sentry('Error wiping secure storage', error);
+  }
 };
 
 export {

--- a/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
+++ b/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useState, useEffect, useMemo, useRef } from 'react';
 import { Alert } from 'react-native';
-import RNRestart from 'react-native-restart';
 
 import { useBiometricSwitch } from '@cardstack/components/BiometricSwitch';
 import { DEFAULT_PIN_LENGTH } from '@cardstack/components/Input/PinInput/PinInput';
@@ -72,10 +71,7 @@ export const useUnlockScreen = () => {
     Alert.alert(strings.reset.title, strings.reset.message, [
       {
         text: strings.reset.delete,
-        onPress: async () => {
-          await resetWallet();
-          RNRestart.Restart();
-        },
+        onPress: resetWallet,
       },
       {
         text: strings.reset.cancel,

--- a/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
+++ b/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
@@ -10,7 +10,7 @@ import { getPin } from '@cardstack/models/secure-storage';
 import { useAuthActions } from '@cardstack/redux/authSlice';
 import { useWorker } from '@cardstack/utils';
 
-import { wipeKeychain } from '@rainbow-me/model/keychain';
+import { resetWallet } from '@rainbow-me/model/wallet';
 
 import { strings } from './strings';
 
@@ -73,7 +73,7 @@ export const useUnlockScreen = () => {
       {
         text: strings.reset.delete,
         onPress: async () => {
-          await wipeKeychain();
+          await resetWallet();
           RNRestart.Restart();
         },
       },

--- a/src/components/settings-menu/DeveloperSettings.js
+++ b/src/components/settings-menu/DeveloperSettings.js
@@ -8,7 +8,7 @@ import { ListFooter, ListItem } from '../list';
 import { Routes } from '@cardstack/navigation';
 import { deleteAllBackups } from '@rainbow-me/handlers/cloudBackup';
 import { useWallets } from '@rainbow-me/hooks';
-import { wipeKeychain } from '@rainbow-me/model/keychain';
+import { resetWallet } from '@rainbow-me/model/wallet';
 import { clearImageMetadataCache } from '@rainbow-me/redux/imageMetadata';
 import store from '@rainbow-me/redux/store';
 import { walletsUpdate } from '@rainbow-me/redux/wallets';
@@ -50,7 +50,7 @@ const DeveloperSettings = () => {
       />
       <ListItem
         label="💣 Reset Keychain"
-        onPress={wipeKeychain}
+        onPress={resetWallet}
         testID="reset-keychain-section"
       />
       <ListItem label="🔄 Restart app" onPress={() => RNRestart.Restart()} />

--- a/src/components/settings-menu/DeveloperSettings.js
+++ b/src/components/settings-menu/DeveloperSettings.js
@@ -49,7 +49,7 @@ const DeveloperSettings = () => {
         onPress={clearImageMetadataCache}
       />
       <ListItem
-        label="💣 Reset Keychain"
+        label="💣 Reset Wallet"
         onPress={resetWallet}
         testID="reset-keychain-section"
       />

--- a/src/model/keychain.ts
+++ b/src/model/keychain.ts
@@ -16,7 +16,6 @@ import {
   setInternetCredentials,
   UserCredentials,
 } from 'react-native-keychain';
-import { deletePin } from '@cardstack/models/secure-storage';
 import { Device } from '@cardstack/utils/device';
 import logger from 'logger';
 
@@ -152,7 +151,6 @@ export async function wipeKeychain(): Promise<void> {
       await Promise.all(
         results?.map(result => resetInternetCredentials(result.username))
       );
-      await deletePin();
       logger.log('keychain wiped!');
     }
   } catch (e) {

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -44,9 +44,12 @@ import {
   getSeedPhrase,
   savePrivateKey,
   saveSeedPhrase,
+  wipeSecureStorage,
 } from '@cardstack/models/secure-storage';
+import { authSlice } from '@cardstack/redux/authSlice';
 import { Device } from '@cardstack/utils/device';
 
+import store from '@rainbow-me/redux/store';
 import logger from 'logger';
 const encryptor = new AesEncryptor();
 
@@ -843,5 +846,21 @@ export const migrateSecretsWithNewPin = async (
   } catch (e) {
     logger.sentry('Error migrating secrets', e);
     captureException(e);
+  }
+};
+
+export const resetWallet = async () => {
+  const allWallets = await getAllWallets();
+
+  console.log('allWallets', allWallets);
+
+  // clearing secure storage and keychain
+  if (allWallets) {
+    await wipeSecureStorage(allWallets);
+    await keychain.wipeKeychain();
+
+    logger.log('Wallet reset done!');
+
+    store.dispatch(authSlice.actions.resetHasWallet());
   }
 };

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -850,15 +850,19 @@ export const migrateSecretsWithNewPin = async (
 };
 
 export const resetWallet = async () => {
-  const allWallets = await getAllWallets();
+  try {
+    const allWallets = await getAllWallets();
 
-  // clearing secure storage and keychain
-  if (allWallets) {
-    await wipeSecureStorage(allWallets);
-    await keychain.wipeKeychain();
+    // clearing secure storage and keychain
+    if (allWallets) {
+      await wipeSecureStorage(allWallets);
+      await keychain.wipeKeychain();
 
-    logger.log('Wallet reset done!');
+      logger.log('Wallet reset done!');
 
-    store.dispatch(authSlice.actions.resetHasWallet());
+      store.dispatch(authSlice.actions.resetHasWallet());
+    }
+  } catch (error) {
+    logger.sentry('Error resetting the wallet', error);
   }
 };

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -852,8 +852,6 @@ export const migrateSecretsWithNewPin = async (
 export const resetWallet = async () => {
   const allWallets = await getAllWallets();
 
-  console.log('allWallets', allWallets);
-
   // clearing secure storage and keychain
   if (allWallets) {
     await wipeSecureStorage(allWallets);

--- a/src/screens/ChangeWalletSheet.js
+++ b/src/screens/ChangeWalletSheet.js
@@ -31,7 +31,6 @@ import { getRandomColor } from '../styles/colors';
 import { Container, Sheet, Text, Touchable } from '@cardstack/components';
 import { removeFCMToken } from '@cardstack/models/firebase';
 import { Routes, useLoadingOverlay } from '@cardstack/navigation';
-import { useAuthActions } from '@cardstack/redux/authSlice';
 import { getAddressPreview } from '@cardstack/utils';
 import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
 import {
@@ -40,7 +39,7 @@ import {
   useWallets,
 } from '@rainbow-me/hooks';
 
-import { wipeKeychain } from '@rainbow-me/model/keychain';
+import { resetWallet } from '@rainbow-me/model/wallet';
 import { deviceUtils, showActionSheetWithOptions } from '@rainbow-me/utils';
 import logger from 'logger';
 
@@ -75,8 +74,6 @@ export default function ChangeWalletSheet() {
   const [currentSelectedWallet, setCurrentSelectedWallet] = useState(
     selectedWallet
   );
-
-  const { resetHasWallet } = useAuthActions();
 
   const apolloClient = useApolloClient();
 
@@ -265,11 +262,9 @@ export default function ChangeWalletSheet() {
                   const isLastAvailableWallet = !otherAccounts.length;
 
                   if (isLastAvailableWallet) {
-                    await wipeKeychain();
+                    await resetWallet();
 
                     dismissLoadingOverlay();
-
-                    resetHasWallet();
 
                     return;
                   } else {
@@ -302,7 +297,6 @@ export default function ChangeWalletSheet() {
       dismissLoadingOverlay,
       onChangeAccount,
       renameWallet,
-      resetHasWallet,
       showLoadingOverlay,
       wallets,
     ]


### PR DESCRIPTION
### Description
This PR adds two new methods to handle the complete reset of the current wallet on the app. 

- `wipeSecureStorage` handles everything that's in the secure storage. 
- calling `resetHasWallet` handles the user redirection to the auth screen.
- added some logs after the deletion of pin, seed phrase and private key to help debug. Can be removed before merging to develop.

- [x] Completes CS-4023

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
