### PR TITLE
[CS-4059] Prevent asset list to show assets with zero balance amount

### DIFF
--- a/src/components/send/SendAssetList.js
+++ b/src/components/send/SendAssetList.js
@@ -59,9 +59,14 @@ export default class SendAssetList extends React.Component {
     const { assets } = buildCoinsList(allAssets, nativeCurrency, true);
     let shitcoins = [];
 
-    const visibleAssetsLength = assets.length;
+    // assets with no balance shouldn't be visible
+    const assetsWithBalance = assets.filter(
+      asset => parseFloat(asset.balance.amount) > 0
+    );
 
-    this.data = assets;
+    const visibleAssetsLength = assetsWithBalance.length;
+
+    this.data = assetsWithBalance;
 
     if (savings && savings.length > 0 && network === networkTypes.mainnet) {
       this.data = this.data.concat([{ data: savings, name: 'Savings' }]);


### PR DESCRIPTION
### Description
This PR solves an issue with the asset list on the `SendSheet` component. For unknown reasons, we were listing assets with zero balance, thus allowing the user to choose this option. When doing that, the app would break because the `getGasPriceEstimate` function would break.

This PR removes the asset from the list.

- [x] Completes #CS-4059

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

|  Before | After |
|--|--|
| <img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/174372779-cffbb274-2cf5-445c-a62b-55998b37eb8e.png"> |  <img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/174364063-478372ec-7df4-4ed8-8b20-c829269acbb8.png"> |


