### PR TITLE
[CS-4094] Hide banner when GET /api/email-card-drop-requests has show-banner: false

### DIFF
--- a/cardstack/src/components/CtaBanner/useWelcomeCtaBanner.ts
+++ b/cardstack/src/components/CtaBanner/useWelcomeCtaBanner.ts
@@ -17,7 +17,7 @@ export const useWelcomeCtaBanner = () => {
   const { accountAddress, network } = useAccountSettings();
 
   const {
-    data: emailDropGetData = { showBanner: true },
+    data: emailDropGetData = { showBanner: false },
   } = useGetEoaClaimedQuery(
     {
       eoa: accountAddress,

--- a/cardstack/src/components/CtaBanner/useWelcomeCtaBanner.ts
+++ b/cardstack/src/components/CtaBanner/useWelcomeCtaBanner.ts
@@ -17,7 +17,7 @@ export const useWelcomeCtaBanner = () => {
   const { accountAddress, network } = useAccountSettings();
 
   const {
-    data: emailDropGetData = { claimed: true, rateLimited: true },
+    data: emailDropGetData = { showBanner: true },
   } = useGetEoaClaimedQuery(
     {
       eoa: accountAddress,
@@ -48,8 +48,7 @@ export const useWelcomeCtaBanner = () => {
       remoteFlags().featurePrepaidCardDrop &&
       showBannerUserDecision &&
       isFirstAddressForCurrentWallet &&
-      !emailDropGetData?.claimed &&
-      !emailDropGetData?.rateLimited,
+      emailDropGetData?.showBanner,
     [
       showBannerUserDecision,
       isFirstAddressForCurrentWallet,

--- a/cardstack/src/services/hub/hub-types.ts
+++ b/cardstack/src/services/hub/hub-types.ts
@@ -21,9 +21,8 @@ export interface GetEoaClaimedQueryParams {
 
 export type EoaClaimedAttrsType = {
   timestamp: string;
-  claimed: boolean;
   'owner-address': string;
-  'rate-limited': boolean;
+  'show-banner': boolean;
 };
 
 export type GetEoaClaimedQueryResult = KebabToCamelCaseKeys<EoaClaimedAttrsType>;


### PR DESCRIPTION
### Description

PR updates welcome banner and getEoaClaimed response type to use new show-banner attribute from `email-card-drop-requests` endpoint call.

- [x] Completes #(CS-4094)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

No UI changes.
