### PR TITLE
[CS-3838] Replace CyptoCompare with api/exchange-rates endpoint

### DIFF
--- a/cardstack/src/components/Input/InputAmount/useInputAmountHelper.tsx
+++ b/cardstack/src/components/Input/InputAmount/useInputAmountHelper.tsx
@@ -30,7 +30,7 @@ export const useInputAmountHelper = () => {
     [amountInNum, paymentCurrency]
   );
 
-  const { data: rates } = useGetExchangeRatesQuery();
+  const { data: rates } = useGetExchangeRatesQuery({});
 
   const spendAmount = useMemo(() => {
     const isCurrencyUSD = paymentCurrency === NativeCurrency.USD;

--- a/cardstack/src/services/hub/hub-api.ts
+++ b/cardstack/src/services/hub/hub-api.ts
@@ -15,6 +15,7 @@ import {
   GetEoaClaimedQueryResult,
   CheckHubAuthQueryParams,
   RegisterFCMTokenQueryParams,
+  GetExchangeRatesQueryParams,
 } from './hub-types';
 
 const routes = {
@@ -63,8 +64,14 @@ export const hubApi = createApi({
         );
       },
     }),
-    getExchangeRates: builder.query<Record<NativeCurrency, number>, void>({
-      query: () => routes.exchangeRates,
+    getExchangeRates: builder.query<
+      Record<NativeCurrency | string, number>,
+      GetExchangeRatesQueryParams | undefined
+    >({
+      query: params => ({
+        url: routes.exchangeRates,
+        params,
+      }),
       transformResponse: ({ data }) => data.attributes.rates,
     }),
     registerFcmToken: builder.query<string, RegisterFCMTokenQueryParams>({

--- a/cardstack/src/services/hub/hub-service.ts
+++ b/cardstack/src/services/hub/hub-service.ts
@@ -20,7 +20,11 @@ import {
 } from '../hub-service';
 
 import { hubApi } from './hub-api';
-import { BaseQueryExtraOptions, CheckHubAuthQueryParams } from './hub-types';
+import {
+  BaseQueryExtraOptions,
+  CheckHubAuthQueryParams,
+  GetExchangeRatesQueryParams,
+} from './hub-types';
 
 // Helpers
 
@@ -119,9 +123,9 @@ const cacheExpiration = {
   tenMinutes: 60 * 10,
 };
 
-export const getExchangeRatesQuery = () => {
+export const getExchangeRatesQuery = (params?: GetExchangeRatesQueryParams) => {
   const query = store.dispatch(
-    hubApi.endpoints.getExchangeRates.initiate(undefined, {
+    hubApi.endpoints.getExchangeRates.initiate(params, {
       forceRefetch: cacheExpiration.tenMinutes,
     })
   );

--- a/cardstack/src/services/hub/hub-types.ts
+++ b/cardstack/src/services/hub/hub-types.ts
@@ -1,3 +1,4 @@
+import { NativeCurrency } from '@cardstack/cardpay-sdk';
 import { KebabToCamelCaseKeys } from 'globals';
 
 import { CustodialWalletAttrs } from '@cardstack/types';
@@ -34,4 +35,11 @@ export interface CheckHubAuthQueryParams {
 
 export interface RegisterFCMTokenQueryParams {
   fcmToken: string;
+}
+
+export interface GetExchangeRatesQueryParams {
+  from?: NativeCurrency | string;
+  to?: NativeCurrency | string;
+  date?: string | number;
+  e?: 'kucoin' | string;
 }

--- a/cardstack/src/transaction-confirmation-strategies/base-strategy.ts
+++ b/cardstack/src/transaction-confirmation-strategies/base-strategy.ts
@@ -1,4 +1,4 @@
-import { ERC20ABI } from '@cardstack/cardpay-sdk';
+import { ERC20ABI, NativeCurrency } from '@cardstack/cardpay-sdk';
 
 import Web3Instance from '@cardstack/models/web3-instance';
 import { getSafeData } from '@cardstack/services';
@@ -18,7 +18,7 @@ interface BaseStrategyParams {
   verifyingContract?: string;
   primaryType: string | number;
   network: string;
-  nativeCurrency: string;
+  nativeCurrency: string | NativeCurrency;
 }
 
 export abstract class BaseStrategy {


### PR DESCRIPTION
### Description
This PR replaces the CryptoCompare URL with the endpoint created on the Hub API (PR for reference https://github.com/cardstack/cardstack/pull/2992)

- [x] Completes #CS-3838

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots
No visual changes :)
