### PR TITLE
[Bug]: Fix crash wallet address when wallet is not fully loaded

### DIFF
--- a/cardstack/src/screens/WalletAddressScreen/WalletAddressScreen.tsx
+++ b/cardstack/src/screens/WalletAddressScreen/WalletAddressScreen.tsx
@@ -18,7 +18,9 @@ const WalletAddressScreen = () => {
   return (
     <>
       <Container flex={1} alignItems="center" paddingTop={10}>
-        <StyledQRCode value={accountAddress} addLogo={false} />
+        {!!accountAddress && (
+          <StyledQRCode value={accountAddress} addLogo={false} />
+        )}
         <Container
           flex={0.3}
           alignItems="center"


### PR DESCRIPTION
### Description

While trying to access wallet address on fresh init, if the account was not loaded, the qrCode was erroring, triggering a crash, this PR prevents this behavior.