### PR TITLE
[Fix] Handle iconProps on OptionItem component

### DIFF
--- a/cardstack/src/components/OptionItem/OptionItem.tsx
+++ b/cardstack/src/components/OptionItem/OptionItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { Container, CenteredContainer, ContainerProps } from '../Container';
 import { Icon, IconProps } from '../Icon';
@@ -26,41 +26,37 @@ export const OptionItem = ({
   horizontalSpacing = 2,
   disabled,
   ...props
-}: OptionItemProps) => {
-  const [iconVisible] = useState(iconProps.visible ?? true);
-
-  return (
-    <Touchable
-      alignItems="center"
-      disabled={disabled || !onPress}
-      flexDirection="row"
-      onPress={onPress}
-      testID="option-item"
-      {...props}
-    >
-      {iconVisible && (
-        <CenteredContainer
-          borderColor="borderGray"
-          borderRadius={100}
-          borderWidth={borderIcon ? 1 : 0}
-          height={40}
-          marginRight={horizontalSpacing}
-          width={40}
-          testID="option-item-icon-wrapper"
-        >
-          <Icon color="settingsTeal" {...iconProps} />
-        </CenteredContainer>
-      )}
-      <Container flexShrink={1}>
-        <Text weight="bold" {...textProps}>
-          {title}
+}: OptionItemProps) => (
+  <Touchable
+    alignItems="center"
+    disabled={disabled || !onPress}
+    flexDirection="row"
+    onPress={onPress}
+    testID="option-item"
+    {...props}
+  >
+    {iconProps && (
+      <CenteredContainer
+        borderColor="borderGray"
+        borderRadius={100}
+        borderWidth={borderIcon ? 1 : 0}
+        height={40}
+        marginRight={horizontalSpacing}
+        width={40}
+        testID="option-item-icon-wrapper"
+      >
+        <Icon color="settingsTeal" {...iconProps} />
+      </CenteredContainer>
+    )}
+    <Container flexShrink={1}>
+      <Text weight="bold" {...textProps}>
+        {title}
+      </Text>
+      {subText && (
+        <Text variant="subText" marginTop={1}>
+          {subText}
         </Text>
-        {subText && (
-          <Text variant="subText" marginTop={1}>
-            {subText}
-          </Text>
-        )}
-      </Container>
-    </Touchable>
-  );
-};
+      )}
+    </Container>
+  </Touchable>
+);

--- a/src/components/expanded-state/ContactProfileState.js
+++ b/src/components/expanded-state/ContactProfileState.js
@@ -108,9 +108,6 @@ const ContactProfileState = ({ address, color: colorProp, contact }) => {
       <CenteredContainer marginVertical={5}>
         <ButtonPressAnimation onPress={handleAddContact}>
           <OptionItem
-            iconProps={{
-              visible: false,
-            }}
             justifyContent="center"
             testID="wallet-info-submit-button"
             textProps={{ color: 'settingsTeal' }}


### PR DESCRIPTION
### Description
I missed some stuff with the work here https://github.com/cardstack/cardwallet/pull/903.
`OptionItem` component had logic expecting for `iconProps` that we're not gonna use anymore, so I simplified the component a bit and removed the only place where `iconProps.visible` was being set.

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
