### PR TITLE
[CS-4140] PrepaidCard screen workaround for Android

### DIFF
--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -38,6 +38,7 @@ import {
   RewardWithdrawConfirmationScreen,
   RewardWithdrawToScreen,
 } from '@cardstack/screens/RewardsCenterScreen/flows';
+import { Device } from '@cardstack/utils';
 
 import BackupSheet from '@rainbow-me/screens/BackupSheet';
 import SendSheetEOA from '@rainbow-me/screens/SendSheetEOA';
@@ -71,7 +72,7 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
   },
   PREPAID_CARD_MODAL: {
     component: PrepaidCardModal,
-    options: sheetPreset(),
+    options: { ...sheetPreset(), gestureEnabled: Device.isIOS },
   },
   BUY_PREPAID_CARD: {
     component: BuyPrepaidCard,

--- a/cardstack/src/screens/PrepaidCardModal.tsx
+++ b/cardstack/src/screens/PrepaidCardModal.tsx
@@ -1,18 +1,21 @@
-import { useRoute } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import React, { memo } from 'react';
 import { SectionList } from 'react-native';
 
 import {
   Container,
+  Icon,
   ListEmptyComponent,
   PrepaidCard,
   PrepaidCardProps,
   SafeAreaView,
   SheetHandle,
   Text,
+  Touchable,
   TransactionItem,
 } from '@cardstack/components';
 import { usePrepaidCardTransactions } from '@cardstack/hooks';
+import { Device } from '@cardstack/utils';
 import { sectionStyle } from '@cardstack/utils/layouts';
 
 import { TransactionListLoading } from '../components/TransactionList/TransactionListLoading';
@@ -26,9 +29,18 @@ const PrepaidCardModal = () => {
     prepaidCardProps.address
   );
 
+  const { goBack } = useNavigation();
+
   return (
     <SafeAreaView flex={1} width="100%" alignItems="center" paddingTop={1}>
-      <SheetHandle color="buttonDarkBackground" opacity={1} />
+      {/* TODO NAVIGATION: remove this workaround after handling gestures manually */}
+      {Device.isAndroid ? (
+        <Touchable onPress={goBack} alignSelf="flex-start">
+          <Icon name="chevron-left" color="teal" size={30} />
+        </Touchable>
+      ) : (
+        <SheetHandle color="buttonDarkBackground" opacity={1} />
+      )}
       <PrepaidCard
         {...prepaidCardProps}
         disabled


### PR DESCRIPTION
### Description
This PR adds a workaround for the PrepaidCard screen while we don't figure out what's happening after the `react-navigation` upgrade. On Android, we're removing the gesture on the View to allow the user to scroll inside the history section and adding a back button on the top for the modal to be closed.

On iOS the behavior is the same as before.
 
- [x] Completes #CS-4140

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

#### Android
https://user-images.githubusercontent.com/690904/175328970-c1f56515-b753-4545-9469-7172ddf25602.mov 

#### iOS
https://user-images.githubusercontent.com/690904/175330886-c89c4d7d-16b3-42c2-8c1f-a4c998b289a7.mp4


