### PR TITLE
[CS-4139] Remove handleFocus from SendSheet Header to avoid focus error

### DIFF
--- a/cardstack/src/screens/SendSheetDepot/__tests__/useSendSheetDepotScreen.test.ts
+++ b/cardstack/src/screens/SendSheetDepot/__tests__/useSendSheetDepotScreen.test.ts
@@ -41,10 +41,6 @@ jest.mock('@rainbow-me/hooks', () => ({
     nativeCurrency: 'USD',
     network: 'sokol',
   })),
-  useMagicAutofocus: () => ({
-    handleFocus: jest.fn(),
-    triggerFocus: jest.fn(),
-  }),
   useWallets: () => ({ selectedWallet: 'fooSelectedWallet' }),
 }));
 

--- a/cardstack/src/screens/SendSheetDepot/useSendSheetDepotScreen.ts
+++ b/cardstack/src/screens/SendSheetDepot/useSendSheetDepotScreen.ts
@@ -30,7 +30,6 @@ import { useSendAddressValidation } from '@rainbow-me/components/send/SendSheet'
 import {
   useAccountAssets,
   useAccountSettings,
-  useMagicAutofocus,
   useWallets,
 } from '@rainbow-me/hooks';
 import logger from 'logger';
@@ -91,7 +90,6 @@ export const useSendSheetDepotScreen = () => {
   // Inputs
   const recipientFieldRef = useRef();
   const [recipient, setRecipient] = useState('');
-  const { handleFocus, triggerFocus } = useMagicAutofocus(recipientFieldRef);
 
   const [amountDetails, setAmountDetails] = useState(amountDetailsInitialState);
 
@@ -422,9 +420,7 @@ export const useSendSheetDepotScreen = () => {
       selected,
       amountDetails,
       isAuthorizing,
-      handleFocus,
       setRecipient,
-      triggerFocus,
       onSendPress,
       onChangeAssetAmount,
       onChangeNativeAmount,
@@ -439,7 +435,6 @@ export const useSendSheetDepotScreen = () => {
       amountDetails,
       depotAssets,
       gasEstimatedFee,
-      handleFocus,
       isAuthorizing,
       isValidAddress,
       nativeCurrency,
@@ -451,7 +446,6 @@ export const useSendSheetDepotScreen = () => {
       onSendPress,
       recipient,
       selected,
-      triggerFocus,
     ]
   );
 };

--- a/cardstack/src/screens/sheets/ImportSeed/ImportSeedSheet.tsx
+++ b/cardstack/src/screens/sheets/ImportSeed/ImportSeedSheet.tsx
@@ -15,7 +15,7 @@ import {
   ToastPositionContainer,
   InvalidPasteToast,
 } from '@rainbow-me/components/toasts';
-import { useKeyboardHeight, useMagicAutofocus } from '@rainbow-me/hooks';
+import { useKeyboardHeight } from '@rainbow-me/hooks';
 
 import { useImportSeedSheet } from './useImportSeedSheet';
 
@@ -32,7 +32,6 @@ const ImportSeedSheet = () => {
     isInvalidPaste,
   } = useImportSeedSheet();
 
-  const { handleFocus } = useMagicAutofocus(inputRef);
   const keyboardHeight = useKeyboardHeight();
 
   return (
@@ -54,7 +53,6 @@ const ImportSeedSheet = () => {
               multiline
               numberOfLines={3}
               onChangeText={handleSetSeedPhrase}
-              onFocus={handleFocus}
               onSubmitEditing={handlePressImportButton}
               placeholder="Enter seed phrase or secret recovery phrase"
               placeholderTextColor={colors.grayText}

--- a/src/components/expanded-state/profile/ProfileNameInput.js
+++ b/src/components/expanded-state/profile/ProfileNameInput.js
@@ -2,13 +2,11 @@ import React, { Fragment, useCallback, useEffect, useRef } from 'react';
 
 import { PlaceholderText } from '../../text';
 import { Input } from '@cardstack/components';
-import { useMagicAutofocus } from '@rainbow-me/hooks';
 
 function ProfileNameInput(
   { onChange, placeholder, testID, value, ...props },
   ref
 ) {
-  const { handleFocus } = useMagicAutofocus(ref);
   const placeholderRef = useRef(null);
 
   const handleChange = useCallback(
@@ -39,7 +37,6 @@ function ProfileNameInput(
         autoFocus
         fontSize={20}
         onChange={handleChange}
-        onFocus={handleFocus}
         ref={ref}
         returnKeyType="done"
         spellCheck={false}

--- a/src/components/fields/AddressField.js
+++ b/src/components/fields/AddressField.js
@@ -57,6 +57,8 @@ const AddressField = (
     []
   );
 
+  const onPress = useCallback(() => ref?.current?.focus(), [ref]);
+
   return (
     <Row flex={1}>
       <Input
@@ -83,7 +85,7 @@ const AddressField = (
       />
       {!inputValue && (
         <Container position="absolute" zIndex={1} {...androidProps}>
-          <Touchable onPress={ref?.current?.focus}>
+          <Touchable onPress={onPress}>
             <Text color="grayText" fontSize={15} weight="bold">
               Enter Address (0x...) or ENS
             </Text>

--- a/src/components/send/SendHeader.js
+++ b/src/components/send/SendHeader.js
@@ -30,9 +30,7 @@ export default function SendHeader({
   contacts,
   isValidAddress,
   onChangeAddressInput,
-  onFocus,
   onPressPaste,
-  onRefocusInput,
   recipient,
   recipientFieldRef,
   removeContact,
@@ -59,10 +57,9 @@ export default function SendHeader({
       address: recipient,
       color,
       contact: isEmpty(contact.address) ? false : contact,
-      onRefocusInput,
       type: 'contact_profile',
     });
-  }, [colors, contact, navigate, onRefocusInput, recipient]);
+  }, [colors, contact, navigate, recipient]);
 
   const handleOpenContactActionSheet = useCallback(async () => {
     return showActionSheetWithOptions(
@@ -95,17 +92,9 @@ export default function SendHeader({
         } else if (buttonIndex === 2) {
           setClipboard(recipient);
         }
-
-        onRefocusInput();
       }
     );
-  }, [
-    handleNavigateToContact,
-    onRefocusInput,
-    recipient,
-    removeContact,
-    setClipboard,
-  ]);
+  }, [handleNavigateToContact, recipient, removeContact, setClipboard]);
 
   const isPreExistingContact = (contact?.nickname?.length || 0) > 0;
 
@@ -120,7 +109,6 @@ export default function SendHeader({
           autoFocus={!showAssetList}
           name={contact.nickname}
           onChange={onChangeAddressInput}
-          onFocus={onFocus}
           ref={recipientFieldRef}
           testID="send-asset-form-field"
         />

--- a/src/components/send/SendSheet.js
+++ b/src/components/send/SendSheet.js
@@ -40,9 +40,7 @@ export const useSendAddressValidation = recipient => {
 
 export default function SendSheet({
   isValidAddress,
-  handleFocus,
   setRecipient,
-  triggerFocus,
   recipient,
   recipientFieldRef,
   allAssets,
@@ -94,10 +92,8 @@ export default function SendSheet({
         contacts={contacts}
         isValidAddress={isValidAddress}
         onChangeAddressInput={onChangeInput}
-        onFocus={handleFocus}
         onInvalidPaste={onInvalidPaste}
         onPressPaste={setRecipient}
-        onRefocusInput={triggerFocus}
         recipient={recipient}
         recipientFieldRef={recipientFieldRef}
         removeContact={onRemoveContact}
@@ -142,7 +138,6 @@ export default function SendSheet({
           nativeCurrency={nativeCurrency}
           onChangeAssetAmount={onChangeAssetAmount}
           onChangeNativeAmount={onChangeNativeAmount}
-          onFocus={handleFocus}
           onResetAssetSelection={onResetAssetSelection}
           selected={selected}
           sendMaxBalance={onMaxBalancePress}

--- a/src/screens/SendSheetEOA.js
+++ b/src/screens/SendSheetEOA.js
@@ -25,7 +25,6 @@ import {
   useAccountAssets,
   useAccountSettings,
   useGas,
-  useMagicAutofocus,
   useMaxInputBalance,
   usePrevious,
   useRefreshAccountData,
@@ -88,14 +87,6 @@ const useSendSheetScreen = () => {
   const { showAssetList, showAssetForm } = useShowAssetFlags(
     isValidAddress,
     selected
-  );
-
-  const { handleFocus, triggerFocus } = useMagicAutofocus(
-    recipientFieldRef,
-    useCallback(
-      lastFocusedRef => (showAssetList ? null : lastFocusedRef.current),
-      [showAssetList]
-    )
   );
 
   useEffect(() => {
@@ -436,9 +427,7 @@ const useSendSheetScreen = () => {
 
   return {
     isValidAddress,
-    handleFocus,
     setRecipient,
-    triggerFocus,
     recipient,
     recipientFieldRef,
     allAssets,


### PR DESCRIPTION
### Description
This PR is part of the workarounds we're doing after `react-navigation` upgrades.
For some unknown reason, the `autoFocus` prop isn't working on Android. Using the `magicAutoFocus()` makes things even buggier, so we're deleting this function. On Android, the user will have to tap on the Input to focus. On iOS, things are OK since `autoFocus` is working as expected.

- [x] Completes #CS-4139

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

