### PR TITLE
[CS-4055]: Fix deepLink with app closed

### DIFF
--- a/src/useAppInit.ts
+++ b/src/useAppInit.ts
@@ -1,7 +1,7 @@
 import notifee, { EventType } from '@notifee/react-native';
 import messaging from '@react-native-firebase/messaging';
 import { useFlipper } from '@react-navigation/devtools';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { Linking } from 'react-native';
 import { useDispatch } from 'react-redux';
 import handleDeepLink from './handlers/deeplinks';
@@ -44,11 +44,16 @@ export const useAppInit = () => {
   useDevSetup();
   useNotificationSetup();
 
+  const initialDeepLink = useRef<string | null>(null);
+
   useEffect(() => {
     const handleWcDeepLink = async () => {
       try {
         const initialUrl = await Linking.getInitialURL();
+
         if (initialUrl) {
+          initialDeepLink.current = initialUrl;
+
           handleDeepLink(initialUrl);
         }
       } catch (e) {
@@ -64,6 +69,14 @@ export const useAppInit = () => {
 
     return subscription.remove;
   }, []);
+
+  useEffect(() => {
+    if (initialDeepLink.current && isAuthorized) {
+      Linking.openURL(initialDeepLink.current);
+
+      initialDeepLink.current = null;
+    }
+  }, [isAuthorized]);
 
   useEffect(() => {
     if (walletReady) {


### PR DESCRIPTION
### Description

This PR handles the pay merchant deeplink when the app is closed, we store the initialDeepLink to trigger after authenticating 

<!-- Please, include a summary of the changes. -->

### Checklist

- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->

![Simulator Screen Recording - iPhone 11 - 2022-06-23 at 18 04 46](https://user-images.githubusercontent.com/20520102/175399612-3f832c08-12fe-4fcd-b7a8-4c77c3a7db33.gif)

