### PR TITLE
[CS-4146] Prompt for permissions on pay tab logs user out

### DIFF
--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -27,8 +27,8 @@ export const useAppState = () => {
   );
 
   const movedToBackground = useMemo(
-    () => prevAppState === AppStateType.background,
-    [prevAppState]
+    () => appState === AppStateType.background,
+    [appState]
   );
 
   return {


### PR DESCRIPTION
### Description

On Android and in QR code and Pay Merchant screens, de-authorization is being delayed after the app state changes to `background` by 5 seconds. This is a workaround a limitation in Android and rn-navigation 6 that leads to all new activity shown to move the app to background state - thus login out user when not desired.

- [x] Completes #(CS-4146)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

https://user-images.githubusercontent.com/129619/175611056-143ae1eb-71dd-4f34-a727-661bc492aa22.mp4

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->
