### PR TITLE
[CS-4123] Remove Firebase Analytics ID collection from Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,8 @@
       android:networkSecurityConfig="@xml/network_security_config"
     >
 
+      <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" tools:replace="android:value" />
+      
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"


### PR DESCRIPTION
### Description
This PR adds a configuration to `AndroidManifest.xml` that disables Firebase from collecting the Advertising ID. We already had configured that on iOS, but we missed on Android.

This will solve the policy error that Play Store is signaling to us.

- [x] Completes #CS-4123
