### PR TITLE
[CS-4141] Re-enable autoFocus on Android

### DIFF
--- a/cardstack/src/components/Input/Input.tsx
+++ b/cardstack/src/components/Input/Input.tsx
@@ -19,8 +19,6 @@ import TextInputMask, {
   TextInputMaskProps,
 } from 'react-native-text-input-mask';
 
-import { Device } from '@cardstack/utils';
-
 import { Theme } from '../../theme';
 import { Container } from '../Container';
 import { Icon, IconProps } from '../Icon';
@@ -75,7 +73,6 @@ export const Input = React.forwardRef((props: InputProps, ref) => (
       ref={ref}
       color="black"
       {...props}
-      autoFocus={Device.enableAutoFocus}
     />
     {props.iconProps && (
       <Icon

--- a/cardstack/src/components/Input/InputAmount/InputAmount.tsx
+++ b/cardstack/src/components/Input/InputAmount/InputAmount.tsx
@@ -12,7 +12,6 @@ import { Keyboard } from 'react-native';
 import { useSpendToNativeDisplay } from '@cardstack/hooks';
 import { Routes } from '@cardstack/navigation';
 import { palette } from '@cardstack/theme/colors';
-import { Device } from '@cardstack/utils';
 
 import { removeLeadingZeros } from '@rainbow-me/utils';
 
@@ -134,7 +133,7 @@ export const InputAmount = memo(
                 alignSelf="stretch"
                 autoCapitalize="none"
                 autoCorrect={false}
-                autoFocus={Device.enableAutoFocus}
+                autoFocus
                 color={isInvalid ? 'red' : 'black'}
                 fontSize={30}
                 fontWeight="bold"

--- a/cardstack/src/utils/device.ts
+++ b/cardstack/src/utils/device.ts
@@ -17,7 +17,6 @@ const Device = {
   supportsHapticFeedback: isIOS,
   scrollSheetOffset: isIOS ? -(screenHeight * 0.2) : 1,
   tabBarHeightSize: screenHeight * 0.1,
-  enableAutoFocus: isIOS,
 };
 
 export { Device };

--- a/src/components/inputs/Input.js
+++ b/src/components/inputs/Input.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { TextInput as TextInputPrimitive } from 'react-native';
 import styled from 'styled-components';
 import { useTheme } from '../../context/ThemeContext';
-import { Device } from '@cardstack/utils';
 import { buildTextStyles } from '@rainbow-me/styles';
 
 const TextInput = styled(TextInputPrimitive)`
@@ -40,7 +39,6 @@ const Input = (
       allowFontScaling={allowFontScaling}
       autoCapitalize={autoCapitalize}
       autoCorrect={autoCorrect}
-      autoFocus={Device.enableAutoFocus}
       keyboardAppearance={isDarkMode ? 'dark' : keyboardAppearance}
       keyboardType={keyboardType}
       placeholderTextColor={placeholderTextColor || defaultPlaceholderTextColor}


### PR DESCRIPTION
### Description
This PR brings back the `autoFocus` prop to the inputs on Android devices. Evidences below point to critical flows.

- [x] Completes #CS-4141

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

https://user-images.githubusercontent.com/690904/176018786-e3753c77-d93a-4184-8022-e9a1fc4b4d20.mov

https://user-images.githubusercontent.com/690904/176018787-d0d2d1c8-e2d7-404e-ba52-db4822169f52.mov

https://user-images.githubusercontent.com/690904/176018765-6ef7b8dc-e9b5-4522-8f86-2f47dd9a8d5a.mov


