### PR TITLE
[CS-3934]: Add exponential backoff  on too many attempts

### DIFF
--- a/cardstack/src/utils/formatting-utils.ts
+++ b/cardstack/src/utils/formatting-utils.ts
@@ -80,3 +80,6 @@ export const transformObjKeysToCamelCase = <ObjType>(obj: ObjType) =>
   Object.fromEntries(
     Object.entries(obj).map(([key, value]) => [_.camelCase(key), value])
   ) as KebabToCamelCaseKeys<ObjType>;
+
+export const addLeftZero = (value: string | number | undefined) =>
+  value ? ('0' + value).slice(-2) : '00';

--- a/src/handlers/localstorage/globalSettings.js
+++ b/src/handlers/localstorage/globalSettings.js
@@ -1,5 +1,5 @@
 import networkTypes from '../../helpers/networkTypes';
-import { getGlobal, saveGlobal } from './common';
+import { getGlobal, removeLocal, saveGlobal } from './common';
 
 const IMAGE_METADATA = 'imageMetadata';
 const KEYBOARD_HEIGHT = 'keyboardHeight';
@@ -9,6 +9,8 @@ const NETWORK = 'network';
 const KEYCHAIN_INTEGRITY_STATE = 'keychainIntegrityState';
 const AUTH_TIMELOCK = 'authTimelock';
 const PIN_AUTH_ATTEMPTS_LEFT = 'pinAuthAttemptsLeft';
+const PIN_AUTH_ATTEMPTS = 'pinAuthAttempts';
+const PIN_AUTH_NEXT_DATE_ATTEMPT = 'pinAuthNextDateAttempts';
 
 export const getKeychainIntegrityState = () =>
   getGlobal(KEYCHAIN_INTEGRITY_STATE, null);
@@ -46,3 +48,19 @@ export const getImageMetadata = () => getGlobal(IMAGE_METADATA, {});
 
 export const saveImageMetadata = imageMetadata =>
   saveGlobal(IMAGE_METADATA, imageMetadata);
+
+export const getPinAuthAttempts = () => getGlobal(PIN_AUTH_ATTEMPTS, 0);
+
+export const savePinAuthAttempts = (amount = 0) =>
+  saveGlobal(PIN_AUTH_ATTEMPTS, amount);
+
+export const getPinAuthNextDateAttempt = () =>
+  getGlobal(PIN_AUTH_NEXT_DATE_ATTEMPT, null);
+
+export const savePinAuthNextDateAttempt = timestamp =>
+  saveGlobal(PIN_AUTH_NEXT_DATE_ATTEMPT, timestamp);
+
+export const deletePinAuthAttemptsData = async () => {
+  await removeLocal(PIN_AUTH_NEXT_DATE_ATTEMPT);
+  await removeLocal(PIN_AUTH_ATTEMPTS);
+};

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -50,6 +50,7 @@ import {
 import { authSlice } from '@cardstack/redux/authSlice';
 import { Device } from '@cardstack/utils/device';
 
+import { deletePinAuthAttemptsData } from '@rainbow-me/handlers/localstorage/globalSettings';
 import store from '@rainbow-me/redux/store';
 import logger from 'logger';
 const encryptor = new AesEncryptor();
@@ -873,6 +874,8 @@ export const resetWallet = async () => {
     if (allWallets) {
       await wipeSecureStorage(allWallets);
       await keychain.wipeKeychain();
+
+      await deletePinAuthAttemptsData();
 
       logger.log('Wallet reset done!');
 


### PR DESCRIPTION
### Description

This PR adds the max attempts amount and an exponential backoff to secure the pin authentication, for now we are showing an alert with the remaining waiting time, but it would be best to have some type of timer, which can be done on a diff PR, also the tests, I'll be adding tomorrow on a diff PR, so we can get this shipped.

### Checklist

-[x] Tested on iOS
-[x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->

![Simulator Screen Recording - iPhone 11 - 2022-06-28 at 17 29 43](https://user-images.githubusercontent.com/20520102/176279243-b84e9ca7-5065-4356-b9b4-23a925733c26.gif)

First try: 
<img width="300" alt="image" src="https://user-images.githubusercontent.com/20520102/176280097-7e955e7c-62e6-4df4-b779-2ea7cefc0660.png">

Second try: 
<img width="300" alt="image" src="https://user-images.githubusercontent.com/20520102/176281279-a9112b18-50a7-49ea-b4a8-19e5dca83266.png">
