### PR TITLE
[CS-3838] Fix api/exchange-rates errors

### DIFF
--- a/cardstack/src/components/Input/InputAmount/useInputAmountHelper.tsx
+++ b/cardstack/src/components/Input/InputAmount/useInputAmountHelper.tsx
@@ -30,7 +30,7 @@ export const useInputAmountHelper = () => {
     [amountInNum, paymentCurrency]
   );
 
-  const { data: rates } = useGetExchangeRatesQuery({});
+  const { data: rates } = useGetExchangeRatesQuery();
 
   const spendAmount = useMemo(() => {
     const isCurrencyUSD = paymentCurrency === NativeCurrency.USD;

--- a/cardstack/src/services/historical-pricing-service.ts
+++ b/cardstack/src/services/historical-pricing-service.ts
@@ -22,38 +22,33 @@ export const fetchHistoricalPrice = async (
     // For cpxd tokens we chop off .CPXD in order to get mainnet's historical price
     const tokenSymbol = removeCPXDTokenSuffix(symbol);
 
-    // cryptocompare does not support CARD price history correctly,
-    // so uses kucoin exchange to get CARD price in USDT(kucoin supports only USDT) and convert it to native currency
-    if (tokenSymbol === cryptoCurrencies.CARD.currency) {
-      const { data: kucoinRate } = await getExchangeRatesQuery({
-        from: tokenSymbol,
-        to: 'USDT',
-        date: formattedDate,
-        e: 'kucoin',
-      });
-
-      const usdtPrice = kucoinRate?.USDT;
-
-      const { data: USDTRate } = await getExchangeRatesQuery({
-        from: 'USDT',
-        to: tokenSymbol,
-        date: formattedDate,
-      });
-
-      const nativeCurrencyPriceForUSDT = USDTRate?.[tokenSymbol];
-
-      if (usdtPrice && nativeCurrencyPriceForUSDT) {
-        return usdtPrice * nativeCurrencyPriceForUSDT;
-      } else {
-        return 0;
-      }
-    }
-
     const defaultParams = {
       from: tokenSymbol,
       to: nativeCurrency,
       date: formattedDate,
     };
+
+    // cryptocompare does not support CARD price history correctly,
+    // so uses kucoin exchange to get CARD price in USDT(kucoin supports only USDT) and convert it to native currency
+    if (tokenSymbol === cryptoCurrencies.CARD.currency) {
+      const { data: kucoinRate } = await getExchangeRatesQuery({
+        ...defaultParams,
+        to: 'USDT',
+        e: 'kucoin',
+      });
+
+      const usdtPrice = kucoinRate?.USDT || 0;
+
+      const { data: USDTRate } = await getExchangeRatesQuery({
+        ...defaultParams,
+        from: 'USDT',
+        to: tokenSymbol,
+      });
+
+      const nativeCurrencyPriceForUSDT = USDTRate?.[tokenSymbol] || 0;
+
+      return usdtPrice * nativeCurrencyPriceForUSDT;
+    }
 
     const { data: rates } = await getExchangeRatesQuery(defaultParams);
 

--- a/cardstack/src/services/historical-pricing-service.ts
+++ b/cardstack/src/services/historical-pricing-service.ts
@@ -16,8 +16,10 @@ export const fetchHistoricalPrice = async (
       return 0;
     }
 
+    // timestamp can be any when coming from GraphQL.
+    // forcing it to number solves this issue.
     // date needs to be formatted as yyyy-MM-dd
-    const formattedDate = format(timestamp, 'yyyy-MM-dd');
+    const formattedDate = format(Number(timestamp), 'yyyy-MM-dd');
 
     // For cpxd tokens we chop off .CPXD in order to get mainnet's historical price
     const tokenSymbol = removeCPXDTokenSuffix(symbol);

--- a/cardstack/src/services/hub/hub-api.ts
+++ b/cardstack/src/services/hub/hub-api.ts
@@ -66,9 +66,9 @@ export const hubApi = createApi({
     }),
     getExchangeRates: builder.query<
       Record<NativeCurrency | string, number>,
-      GetExchangeRatesQueryParams | undefined
+      GetExchangeRatesQueryParams | void
     >({
-      query: params => ({
+      query: (params?: GetExchangeRatesQueryParams) => ({
         url: routes.exchangeRates,
         params,
       }),

--- a/cardstack/src/services/hub/hub-types.ts
+++ b/cardstack/src/services/hub/hub-types.ts
@@ -38,8 +38,8 @@ export interface RegisterFCMTokenQueryParams {
 }
 
 export interface GetExchangeRatesQueryParams {
-  from?: NativeCurrency | string;
-  to?: NativeCurrency | string;
-  date?: string | number;
+  from: NativeCurrency | string;
+  to: NativeCurrency | string;
+  date: string | number;
   e?: 'kucoin' | string;
 }


### PR DESCRIPTION
### Description
This PR solves an error that's being logged with the `fetchHistoricalPrice` function. Seems like some transactions that come from GraphQL have `timestamp` as a string instead of a number and that was breaking the `date-fns` format.

Also addressed some late comments from Dani on the other PR to improve code readability.

- [x] Completes #[CS-3838]

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
