### PR TITLE
[CS-4113] Re-enable KeychainIntegrityCheck + SecureStorage enhancement

### DIFF
--- a/src/handlers/localstorage/globalSettings.js
+++ b/src/handlers/localstorage/globalSettings.js
@@ -18,6 +18,9 @@ export const getKeychainIntegrityState = () =>
 export const saveKeychainIntegrityState = state =>
   saveGlobal(KEYCHAIN_INTEGRITY_STATE, state);
 
+export const deleteKeychainIntegrityState = () =>
+  removeLocal(KEYCHAIN_INTEGRITY_STATE);
+
 export const getAuthTimelock = () => getGlobal(AUTH_TIMELOCK, null);
 
 export const saveAuthTimelock = ts => saveGlobal(AUTH_TIMELOCK, ts);

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -50,7 +50,10 @@ import {
 import { authSlice } from '@cardstack/redux/authSlice';
 import { Device } from '@cardstack/utils/device';
 
-import { deletePinAuthAttemptsData } from '@rainbow-me/handlers/localstorage/globalSettings';
+import {
+  deleteKeychainIntegrityState,
+  deletePinAuthAttemptsData,
+} from '@rainbow-me/handlers/localstorage/globalSettings';
 import store from '@rainbow-me/redux/store';
 import logger from 'logger';
 const encryptor = new AesEncryptor();
@@ -874,6 +877,9 @@ export const resetWallet = async () => {
     if (allWallets) {
       await wipeSecureStorage(allWallets);
       await keychain.wipeKeychain();
+
+      // resets Keychain Integrity Check
+      deleteKeychainIntegrityState();
 
       await deletePinAuthAttemptsData();
 

--- a/src/useAppInit.ts
+++ b/src/useAppInit.ts
@@ -31,8 +31,6 @@ import Logger from 'logger';
 const WALLETCONNECT_SYNC_DELAY = 500;
 const ANDROID_UNAUTHORIZE_DELAY = 5000;
 
-const skipKeychainCheck = true;
-
 export const useAppInit = () => {
   const walletReady = useRainbowSelector(state => state.appState.walletReady);
   const appRequiments = useAppRequirements();
@@ -88,9 +86,7 @@ export const useAppInit = () => {
 
       const unsubscribe = registerTokenRefreshListener();
 
-      if (!skipKeychainCheck) {
-        runKeychainIntegrityChecks();
-      }
+      runKeychainIntegrityChecks();
 
       if (isAuthorized) {
         runWalletBackupStatusChecks();


### PR DESCRIPTION
### Description
This PR adds the `keychainIntegrityCheck` function back to the code. It's a function that we use mostly for debugging purposes, since it goes through all the keychain + secureStorage entries we use and see if they are set correctly.

One thing to notice is that now we are resetting the flag that runs the check whenever we reset the wallet.

I don't know if the team had already mapped out other changes to this file, but I'm happy to address them too.

- [x] Completes #CS-4113

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
