### PR TITLE
[CS-4165]:Add tests to unlock w/ exponential backoff

### DIFF
--- a/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
+++ b/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
@@ -20,7 +20,7 @@ import { resetWallet } from '@rainbow-me/model/wallet';
 
 import { strings } from './strings';
 
-const MAX_WRONG_ATTEMPTS = 4;
+export const MAX_WRONG_ATTEMPTS = 5;
 
 export const useUnlockScreen = () => {
   const storedPin = useRef<string | null>(null);
@@ -53,7 +53,7 @@ export const useUnlockScreen = () => {
   }, []);
 
   const validatePin = useCallback(
-    async (input: string) => {
+    (input: string) => {
       if (storedPin.current === input) {
         attemptsCount.current = 0;
         setPinValid();
@@ -107,7 +107,7 @@ export const useUnlockScreen = () => {
 
     if (
       !nextAttemptDate.current &&
-      attemptsCount.current > MAX_WRONG_ATTEMPTS
+      attemptsCount.current >= MAX_WRONG_ATTEMPTS
     ) {
       nextAttemptDate.current = now + 10 ** attemptsCount.current;
 
@@ -169,5 +169,8 @@ export const useUnlockScreen = () => {
     onResetWalletPress,
     retryBiometricLabel,
     authenticateBiometrically,
+    // Exported for tests purposes
+    nextAttemptDate,
+    attemptsCount,
   };
 };


### PR DESCRIPTION
### Description

This PR adds tests for the exponential backoff feature on the unlockScreen, it covers the cases like, persisting the values, blocking, unblocking and exponentially increasing the time on wrong attempts. I did notice some `act` warnings, tried a bunch of stuff, by it didn't work, if anyone has any ideas, lmk and we can get rid of the warning. 