### PR TITLE
[CS-4061] Handles multiple biometrics possible on Android

### DIFF
--- a/cardstack/src/hooks/useBiometry.ts
+++ b/cardstack/src/hooks/useBiometry.ts
@@ -17,7 +17,7 @@ const securityTypeToIcon = {
 };
 
 const securityTypeToLabel = {
-  [SecurityType.BIOMETRIC]: 'biometry',
+  [SecurityType.BIOMETRIC]: 'biometrics',
   [SecurityType.FACE]: 'Face ID',
   [SecurityType.FINGERPRINT]: 'Touch ID',
   [SecurityType.PIN]: 'PIN',

--- a/cardstack/src/hooks/useBiometry.ts
+++ b/cardstack/src/hooks/useBiometry.ts
@@ -9,6 +9,7 @@ import {
 import { useAppState, usePrevious } from '@rainbow-me/hooks';
 
 const securityTypeToIcon = {
+  [SecurityType.BIOMETRIC]: 'lock',
   [SecurityType.FACE]: 'face-id',
   [SecurityType.FINGERPRINT]: 'thumbprint',
   [SecurityType.PIN]: 'lock',
@@ -16,6 +17,7 @@ const securityTypeToIcon = {
 };
 
 const securityTypeToLabel = {
+  [SecurityType.BIOMETRIC]: 'biometry',
   [SecurityType.FACE]: 'Face ID',
   [SecurityType.FINGERPRINT]: 'Touch ID',
   [SecurityType.PIN]: 'PIN',
@@ -53,11 +55,13 @@ export const useBiometry = () => {
     const biometryAvailable =
       !!biometryType &&
       (biometryType === SecurityType.FACE ||
-        biometryType === SecurityType.FINGERPRINT);
+        biometryType === SecurityType.FINGERPRINT ||
+        biometryType === SecurityType.BIOMETRIC);
 
     // Transactions require longpress when biometry is not available or
     // when using Face ID to minimize user errors.
     const longPressToConfirm =
+      biometryType === SecurityType.BIOMETRIC ||
       biometryType === SecurityType.FACE ||
       biometryType === SecurityType.NONE ||
       !biometryAvailable;

--- a/cardstack/src/models/biometric-auth.ts
+++ b/cardstack/src/models/biometric-auth.ts
@@ -1,6 +1,8 @@
 import * as LocalAuthentication from 'expo-local-authentication';
 import { SecurityLevel, AuthenticationType } from 'expo-local-authentication';
 
+import { Device } from '@cardstack/utils';
+
 import logger from 'logger';
 
 export enum SecurityType {
@@ -8,6 +10,7 @@ export enum SecurityType {
   PIN = 2,
   FINGERPRINT = 3,
   FACE = 4,
+  BIOMETRIC = 5,
 }
 
 export const biometricAuthentication = async (
@@ -29,6 +32,16 @@ export const getSecurityType = async (): Promise<SecurityType> => {
   const authType = await LocalAuthentication.supportedAuthenticationTypesAsync();
 
   if (securityLevel === SecurityLevel.BIOMETRIC) {
+    // Special case for Android where both Fingerprint and Face ID are possible,
+    // but we can't know for sure which the user has enabled in their settings.
+    if (
+      Device.isAndroid &&
+      authType.includes(AuthenticationType.FACIAL_RECOGNITION) &&
+      authType.includes(AuthenticationType.FINGERPRINT)
+    ) {
+      return SecurityType.BIOMETRIC;
+    }
+
     // For biometry, first check for Face id or Iris.
     if (
       authType.includes(AuthenticationType.FACIAL_RECOGNITION) ||


### PR DESCRIPTION
### Description

This PR adds a more generic case for biometry text and icon when we can't know for sure which option is available to the user. I roamed a bunch of issues and PRs from Expo and apparently theres no api for knowing the type of biometry enabled, just if the user has one or not.

I also found a bug in expo's lib that was supposed to be fixed but I can still reproduce:
https://github.com/expo/expo/issues/12353

I tried to force cancel the auth request when `app_cancel` occurs but it causes other issues.

And theres a case where you can cancel the face id authentication but no error is returned, nothing we can do about it unfortunately.

- [x] Completes #(CS-4061)

### Checklist

- [x] Tested on a small device
- [ ] Tested on iOS (no faceid enabled device to test on)
- [x] Tested on Android

### Screenshots

https://user-images.githubusercontent.com/129619/176783002-b7dbe7eb-2834-44ab-9984-42cd322925f7.MOV

