### PR TITLE
[CS-4177] Changes ask for biometrics on app state change.

### DIFF
--- a/cardstack/src/hooks/useBiometry.ts
+++ b/cardstack/src/hooks/useBiometry.ts
@@ -38,6 +38,7 @@ export const useBiometry = () => {
   }, [prevBiometricType]);
 
   useEffect(() => {
+    // We need to check again for biometry type on app becoming active in case a user changes their settings.
     if (!biometryType || justBecameActive) {
       getBiometryType();
     }
@@ -58,19 +59,10 @@ export const useBiometry = () => {
         biometryType === SecurityType.FINGERPRINT ||
         biometryType === SecurityType.BIOMETRIC);
 
-    // Transactions require longpress when biometry is not available or
-    // when using Face ID to minimize user errors.
-    const longPressToConfirm =
-      biometryType === SecurityType.BIOMETRIC ||
-      biometryType === SecurityType.FACE ||
-      biometryType === SecurityType.NONE ||
-      !biometryAvailable;
-
     return {
       biometryLabel,
       biometryAvailable,
       biometryIconProps,
-      longPressToConfirm,
     };
   }, [biometryType]);
 

--- a/cardstack/src/hooks/useBiometry.ts
+++ b/cardstack/src/hooks/useBiometry.ts
@@ -38,7 +38,6 @@ export const useBiometry = () => {
   }, [prevBiometricType]);
 
   useEffect(() => {
-    // We need to check again for biometry type on app becoming active in case a user changes their settings.
     if (!biometryType || justBecameActive) {
       getBiometryType();
     }
@@ -59,10 +58,19 @@ export const useBiometry = () => {
         biometryType === SecurityType.FINGERPRINT ||
         biometryType === SecurityType.BIOMETRIC);
 
+    // Transactions require longpress when biometry is not available or
+    // when using Face ID to minimize user errors.
+    const longPressToConfirm =
+      biometryType === SecurityType.BIOMETRIC ||
+      biometryType === SecurityType.FACE ||
+      biometryType === SecurityType.NONE ||
+      !biometryAvailable;
+
     return {
       biometryLabel,
       biometryAvailable,
       biometryIconProps,
+      longPressToConfirm,
     };
   }, [biometryType]);
 

--- a/cardstack/src/hooks/useBiometry.ts
+++ b/cardstack/src/hooks/useBiometry.ts
@@ -38,6 +38,7 @@ export const useBiometry = () => {
   }, [prevBiometricType]);
 
   useEffect(() => {
+    // We need to check again for biometry type on app becoming active in case a user changes their settings.
     if (!biometryType || justBecameActive) {
       getBiometryType();
     }

--- a/cardstack/src/models/biometric-auth.ts
+++ b/cardstack/src/models/biometric-auth.ts
@@ -17,7 +17,9 @@ export const biometricAuthentication = async (
   options?: LocalAuthentication.LocalAuthenticationOptions
 ): Promise<boolean> => {
   try {
+    console.log('::: biometricAuthentication');
     const response = await LocalAuthentication.authenticateAsync(options);
+    console.log('::: biometricAuthentication response', response);
 
     return response.success;
   } catch (error) {

--- a/cardstack/src/models/biometric-auth.ts
+++ b/cardstack/src/models/biometric-auth.ts
@@ -17,9 +17,7 @@ export const biometricAuthentication = async (
   options?: LocalAuthentication.LocalAuthenticationOptions
 ): Promise<boolean> => {
   try {
-    console.log('::: biometricAuthentication');
     const response = await LocalAuthentication.authenticateAsync(options);
-    console.log('::: biometricAuthentication response', response);
 
     return response.success;
   } catch (error) {

--- a/cardstack/src/screens/UnlockScreen/__tests__/useUnlockScreen.test.ts
+++ b/cardstack/src/screens/UnlockScreen/__tests__/useUnlockScreen.test.ts
@@ -39,6 +39,10 @@ jest.mock('@cardstack/hooks/useBiometry', () => ({
   useBiometry: jest.fn(),
 }));
 
+jest.mock('@rainbow-me/hooks', () => ({
+  useAppState: () => ({ isActive: true }),
+}));
+
 const mockStorage = {
   attempts: 0,
   nextDate: null,

--- a/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
+++ b/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
@@ -75,6 +75,8 @@ export const useUnlockScreen = () => {
   const authenticateBiometrically = useCallback(async () => {
     resetRetryBiometricAuth();
 
+    console.log('::: authenticateBiometrically');
+
     if (await biometricAuthentication()) {
       setPinValid();
       setUserAuthorized();
@@ -158,6 +160,8 @@ export const useUnlockScreen = () => {
   }, [checkUserTemporaryBlock, inputPin, validatePin]);
 
   useEffect(() => {
+    console.log('::: isBiometryEnabled', { isBiometryEnabled, isActive });
+
     if (isBiometryEnabled && isActive) {
       authenticateBiometrically();
     }

--- a/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
+++ b/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
@@ -16,6 +16,7 @@ import {
   savePinAuthAttempts,
   savePinAuthNextDateAttempt,
 } from '@rainbow-me/handlers/localstorage/globalSettings';
+import { useAppState } from '@rainbow-me/hooks';
 import { resetWallet } from '@rainbow-me/model/wallet';
 
 import { strings } from './strings';
@@ -36,6 +37,8 @@ export const useUnlockScreen = () => {
 
   const { setUserAuthorized } = useAuthActions();
   const { isBiometryEnabled, biometryLabel } = useBiometricSwitch();
+
+  const { isActive } = useAppState();
 
   const attemptsCount = useRef(0);
   const nextAttemptDate = useRef<number | null>(null);
@@ -155,10 +158,10 @@ export const useUnlockScreen = () => {
   }, [checkUserTemporaryBlock, inputPin, validatePin]);
 
   useEffect(() => {
-    if (isBiometryEnabled) {
+    if (isBiometryEnabled && isActive) {
       authenticateBiometrically();
     }
-  }, [authenticateBiometrically, isBiometryEnabled]);
+  }, [authenticateBiometrically, isBiometryEnabled, isActive]);
 
   return {
     inputPin,

--- a/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
+++ b/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
@@ -75,8 +75,6 @@ export const useUnlockScreen = () => {
   const authenticateBiometrically = useCallback(async () => {
     resetRetryBiometricAuth();
 
-    console.log('::: authenticateBiometrically');
-
     if (await biometricAuthentication()) {
       setPinValid();
       setUserAuthorized();
@@ -160,8 +158,6 @@ export const useUnlockScreen = () => {
   }, [checkUserTemporaryBlock, inputPin, validatePin]);
 
   useEffect(() => {
-    console.log('::: isBiometryEnabled', { isBiometryEnabled, isActive });
-
     if (isBiometryEnabled && isActive) {
       authenticateBiometrically();
     }

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -26,14 +26,22 @@ export const useAppState = () => {
     [appState, prevAppState]
   );
 
-  const movedToBackground = useMemo(
-    () => appState === AppStateType.background,
-    [appState]
+  const movedFromBackground = useMemo(
+    () => prevAppState === AppStateType.background,
+    [prevAppState]
   );
+
+  const isInBackground = useMemo(() => appState === AppStateType.background, [
+    appState,
+  ]);
+
+  const isActive = useMemo(() => appState === AppStateType.active, [appState]);
 
   return {
     appState,
     justBecameActive,
-    movedToBackground,
+    movedFromBackground,
+    isInBackground,
+    isActive,
   };
 };

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -26,6 +26,7 @@ export const useAppState = () => {
     [appState, prevAppState]
   );
 
+  // Will update to true once the app is resumed from a backgroud state.
   const movedFromBackground = useMemo(
     () => prevAppState === AppStateType.background,
     [prevAppState]

--- a/src/useAppInit.ts
+++ b/src/useAppInit.ts
@@ -35,7 +35,7 @@ export const useAppInit = () => {
   const walletReady = useRainbowSelector(state => state.appState.walletReady);
   const appRequiments = useAppRequirements();
 
-  const { justBecameActive, movedToBackground } = useAppState();
+  const { justBecameActive, isInBackground } = useAppState();
   const {
     setUserUnauthorized,
     isAuthorized,
@@ -99,7 +99,7 @@ export const useAppInit = () => {
   useEffect(() => {
     const currentDate = Date.now();
 
-    if (movedToBackground) {
+    if (isInBackground) {
       const tempAuthorizedRoutes: string[] = [
         Routes.QR_SCANNER_SCREEN,
         Routes.PAY_MERCHANT,
@@ -126,7 +126,7 @@ export const useAppInit = () => {
         setUserUnauthorized();
       }
     }
-  }, [setUserUnauthorized, movedToBackground]);
+  }, [setUserUnauthorized, isInBackground]);
 
   useEffect(() => {
     if (!isAuthorized && hasWallet) {


### PR DESCRIPTION
### Description

Fix a bug in Biometric request not showing up on app being minimized then reopened. It was querying for biometrics on app going to background and that got the check stuck.

- Changes ask for biometrics only for app state active;
- Renames `useAppState`'s `movedToBackground` to `isInBackground` and adds a new `movedFromBackground` value that checks for prevAppState - it is not being used, but I think it's good to have it there so we are more clear of the intention for prevAppState.

- [x] Completes task (CS-4177)

### Checklist

- [x] Tested on a small device
- [ ] Tested on iOS - sorry, no iOS with biometry available :(
- [x] Tested on Android

### Screenshots

No visual changes.