### PR TITLE
[CS-4175] Make long press to confirm a transaction default

### DIFF
--- a/cardstack/src/hooks/useBiometry.ts
+++ b/cardstack/src/hooks/useBiometry.ts
@@ -38,6 +38,7 @@ export const useBiometry = () => {
   }, [prevBiometricType]);
 
   useEffect(() => {
+    // We need to check again for biometry type on app becoming active in case a user changes their settings.
     if (!biometryType || justBecameActive) {
       getBiometryType();
     }
@@ -58,19 +59,10 @@ export const useBiometry = () => {
         biometryType === SecurityType.FINGERPRINT ||
         biometryType === SecurityType.BIOMETRIC);
 
-    // Transactions require longpress when biometry is not available or
-    // when using Face ID to minimize user errors.
-    const longPressToConfirm =
-      biometryType === SecurityType.BIOMETRIC ||
-      biometryType === SecurityType.FACE ||
-      biometryType === SecurityType.NONE ||
-      !biometryAvailable;
-
     return {
       biometryLabel,
       biometryAvailable,
       biometryIconProps,
-      longPressToConfirm,
     };
   }, [biometryType]);
 

--- a/src/components/buttons/hold-to-authorize/HoldToAuthorizeButton.js
+++ b/src/components/buttons/hold-to-authorize/HoldToAuthorizeButton.js
@@ -12,7 +12,6 @@ import { useTheme } from '../../../context/ThemeContext';
 import { haptics } from '../../../utils';
 
 import { Button, Container } from '@cardstack/components';
-import { useBiometry } from '@cardstack/hooks/useBiometry';
 
 const { ACTIVE, END } = State;
 
@@ -149,19 +148,10 @@ class HoldToAuthorizeButton extends PureComponent {
   }
 }
 
-const HoldToAuthorizeButtonWithBiometrics = ({ label, testID, ...props }) => {
-  const { longPressToConfirm } = useBiometry();
+const HoldToAuthorizeButtonWithBiometrics = props => {
   const { colors } = useTheme();
 
-  return (
-    <HoldToAuthorizeButton
-      {...props}
-      colors={colors}
-      enableLongPress={longPressToConfirm}
-      label={longPressToConfirm ? label : label.replace('Hold', 'Tap')}
-      testID={testID}
-    />
-  );
+  return <HoldToAuthorizeButton {...props} colors={colors} enableLongPress />;
 };
 
 export default React.memo(HoldToAuthorizeButtonWithBiometrics);


### PR DESCRIPTION
### Description

Since we don't need to ask for authentication at every transaction, it's better to always require a long press to confirm a transaction.

- [x] Completes #(CS-4175)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

https://user-images.githubusercontent.com/129619/176968636-58898e45-7f06-45b6-b49f-245763e38bf6.mp4

