### PR TITLE
[CS-4179]: Dismiss keyboard on old pin

### DIFF
--- a/src/screens/PinAuthenticationScreen.js
+++ b/src/screens/PinAuthenticationScreen.js
@@ -1,6 +1,6 @@
 import { useNavigation, useRoute } from '@react-navigation/native';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Alert } from 'react-native';
+import { Alert, Keyboard } from 'react-native';
 import { Centered, Column, ColumnWithMargins } from '../components/layout';
 import { Numpad, PinValue } from '../components/numpad';
 import { SheetTitle } from '../components/sheet';
@@ -44,6 +44,10 @@ const PinAuthenticationScreen = () => {
   );
 
   const finished = useRef(false);
+
+  useEffect(() => {
+    Keyboard.dismiss();
+  }, []);
 
   useEffect(() => {
     // See if the user previously tried and aborted


### PR DESCRIPTION
### Description

We need to make sure the keyboard is dismissed, on old auth screen, since that screen has it's own keyboard.

<!-- Please, include a summary of the changes. -->

### Checklist

- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">

-->

![dismiss-keybaord](https://user-images.githubusercontent.com/20520102/177207408-6ae0147a-72da-43b0-be69-8d147177a573.gif)