### PR TITLE
Adds unit tests to useAppState

### DIFF
--- a/cardstack/src/hooks/__tests__/useAppState.test.ts
+++ b/cardstack/src/hooks/__tests__/useAppState.test.ts
@@ -29,49 +29,49 @@ const SECOND_OPEN = {
 };
 
 describe('useAppState', () => {
+  const appStateSpy = jest.spyOn(AppState, 'addEventListener');
+
+  const mockAppState = (state: 'active' | 'background') =>
+    appStateSpy.mock.calls[0][1](state);
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should match values for first open state', async () => {
     const { result } = renderHook(() => useAppState());
-    const appStateSpy = jest.spyOn(AppState, 'addEventListener');
 
     await act(async () => {
-      await appStateSpy.mock.calls[0][1]('active');
+      await mockAppState('active');
     });
 
     await waitFor(() => {
       expect(result.current).toEqual(FIRST_OPEN);
     });
-
-    appStateSpy.mockClear();
   });
 
   it('should match values for background if state changes to background', async () => {
     const { result } = renderHook(() => useAppState());
-    const appStateSpy = jest.spyOn(AppState, 'addEventListener');
 
     await act(async () => {
-      await appStateSpy.mock.calls[0][1]('background');
+      await mockAppState('background');
     });
 
     await waitFor(() => {
       expect(result.current).toEqual(BACKGROUND);
     });
-
-    appStateSpy.mockClear();
   });
 
   it('should match values for second open if state changes from background to active', async () => {
     const { result } = renderHook(() => useAppState());
-    const appStateSpy = jest.spyOn(AppState, 'addEventListener');
 
     await act(async () => {
-      await appStateSpy.mock.calls[0][1]('background');
-      await appStateSpy.mock.calls[0][1]('active');
+      await mockAppState('background');
+      await mockAppState('active');
     });
 
     await waitFor(() => {
       expect(result.current).toEqual(SECOND_OPEN);
     });
-
-    appStateSpy.mockClear();
   });
 });

--- a/cardstack/src/hooks/__tests__/useAppState.test.ts
+++ b/cardstack/src/hooks/__tests__/useAppState.test.ts
@@ -1,0 +1,77 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { waitFor, act } from '@testing-library/react-native';
+import { AppState } from 'react-native';
+
+import { useAppState } from '../../../../src/hooks/useAppState';
+
+const FIRST_OPEN = {
+  appState: 'active',
+  justBecameActive: undefined,
+  movedFromBackground: false,
+  isInBackground: false,
+  isActive: true,
+};
+
+const BACKGROUND = {
+  appState: 'background',
+  justBecameActive: false,
+  movedFromBackground: false,
+  isInBackground: true,
+  isActive: false,
+};
+
+const SECOND_OPEN = {
+  appState: 'active',
+  justBecameActive: true,
+  movedFromBackground: true,
+  isInBackground: false,
+  isActive: true,
+};
+
+describe('useAppState', () => {
+  it('should match values for first open state', async () => {
+    const { result } = renderHook(() => useAppState());
+    const appStateSpy = jest.spyOn(AppState, 'addEventListener');
+
+    await act(async () => {
+      await appStateSpy.mock.calls[0][1]('active');
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual(FIRST_OPEN);
+    });
+
+    appStateSpy.mockClear();
+  });
+
+  it('should match values for background if state changes to background', async () => {
+    const { result } = renderHook(() => useAppState());
+    const appStateSpy = jest.spyOn(AppState, 'addEventListener');
+
+    await act(async () => {
+      await appStateSpy.mock.calls[0][1]('background');
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual(BACKGROUND);
+    });
+
+    appStateSpy.mockClear();
+  });
+
+  it('should match values for second open if state changes from background to active', async () => {
+    const { result } = renderHook(() => useAppState());
+    const appStateSpy = jest.spyOn(AppState, 'addEventListener');
+
+    await act(async () => {
+      await appStateSpy.mock.calls[0][1]('background');
+      await appStateSpy.mock.calls[0][1]('active');
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual(SECOND_OPEN);
+    });
+
+    appStateSpy.mockClear();
+  });
+});

--- a/cardstack/src/hooks/__tests__/useAppState.test.ts
+++ b/cardstack/src/hooks/__tests__/useAppState.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { waitFor, act } from '@testing-library/react-native';
 import { AppState } from 'react-native';
 
-import { useAppState } from '../../../../src/hooks/useAppState';
+import { useAppState } from '../useAppState';
 
 const FIRST_OPEN = {
   appState: 'active',

--- a/cardstack/src/hooks/index.ts
+++ b/cardstack/src/hooks/index.ts
@@ -14,3 +14,4 @@ export * from './currencies/useSpendDisplay';
 export * from './remote-configs/useLoadRemoteConfigs';
 export { default as useInvalidPaste } from './useInvalidPaste';
 export * from './useAppRequirements';
+export * from './useAppState';

--- a/cardstack/src/hooks/useAppState.ts
+++ b/cardstack/src/hooks/useAppState.ts
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { AppState, AppStateStatus } from 'react-native';
-import usePrevious from './usePrevious';
 
 import { AppStateType } from '@cardstack/types';
+
+import usePrevious from '@rainbow-me/hooks/usePrevious';
 
 export const useAppState = () => {
   const [appState, setAppState] = useState(AppState.currentState);

--- a/cardstack/src/hooks/useBiometry.ts
+++ b/cardstack/src/hooks/useBiometry.ts
@@ -59,19 +59,10 @@ export const useBiometry = () => {
         biometryType === SecurityType.FINGERPRINT ||
         biometryType === SecurityType.BIOMETRIC);
 
-    // Transactions require longpress when biometry is not available or
-    // when using Face ID to minimize user errors.
-    const longPressToConfirm =
-      biometryType === SecurityType.BIOMETRIC ||
-      biometryType === SecurityType.FACE ||
-      biometryType === SecurityType.NONE ||
-      !biometryAvailable;
-
     return {
       biometryLabel,
       biometryAvailable,
       biometryIconProps,
-      longPressToConfirm,
     };
   }, [biometryType]);
 

--- a/cardstack/src/hooks/useBiometry.ts
+++ b/cardstack/src/hooks/useBiometry.ts
@@ -38,7 +38,6 @@ export const useBiometry = () => {
   }, [prevBiometricType]);
 
   useEffect(() => {
-    // We need to check again for biometry type on app becoming active in case a user changes their settings.
     if (!biometryType || justBecameActive) {
       getBiometryType();
     }
@@ -59,10 +58,19 @@ export const useBiometry = () => {
         biometryType === SecurityType.FINGERPRINT ||
         biometryType === SecurityType.BIOMETRIC);
 
+    // Transactions require longpress when biometry is not available or
+    // when using Face ID to minimize user errors.
+    const longPressToConfirm =
+      biometryType === SecurityType.BIOMETRIC ||
+      biometryType === SecurityType.FACE ||
+      biometryType === SecurityType.NONE ||
+      !biometryAvailable;
+
     return {
       biometryLabel,
       biometryAvailable,
       biometryIconProps,
+      longPressToConfirm,
     };
   }, [biometryType]);
 

--- a/cardstack/src/hooks/useBiometry.ts
+++ b/cardstack/src/hooks/useBiometry.ts
@@ -38,6 +38,7 @@ export const useBiometry = () => {
   }, [prevBiometricType]);
 
   useEffect(() => {
+    // We need to check again for biometry type on app becoming active in case a user changes their settings.
     if (!biometryType || justBecameActive) {
       getBiometryType();
     }

--- a/cardstack/src/hooks/useBiometry.ts
+++ b/cardstack/src/hooks/useBiometry.ts
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useState, useMemo } from 'react';
 
 import { IconProps, IconName } from '@cardstack/components';
+import { useAppState } from '@cardstack/hooks/useAppState';
 import {
   getSecurityType,
   SecurityType,
 } from '@cardstack/models/biometric-auth';
 
-import { useAppState, usePrevious } from '@rainbow-me/hooks';
+import { usePrevious } from '@rainbow-me/hooks';
 
 const securityTypeToIcon = {
   [SecurityType.BIOMETRIC]: 'lock',

--- a/cardstack/src/screens/UnlockScreen/__tests__/useUnlockScreen.test.ts
+++ b/cardstack/src/screens/UnlockScreen/__tests__/useUnlockScreen.test.ts
@@ -3,6 +3,7 @@ import { waitFor, act } from '@testing-library/react-native';
 import { Alert } from 'react-native';
 
 import { useBiometricSwitch } from '@cardstack/components/BiometricSwitch';
+import { useAppState } from '@cardstack/hooks/useAppState';
 import { useBiometry } from '@cardstack/hooks/useBiometry';
 import { biometricAuthentication } from '@cardstack/models/biometric-auth';
 import { getPin } from '@cardstack/models/secure-storage';
@@ -13,7 +14,6 @@ import {
   savePinAuthAttempts,
   savePinAuthNextDateAttempt,
 } from '@rainbow-me/handlers/localstorage/globalSettings';
-import { useAppState } from '@rainbow-me/hooks';
 
 import { strings } from '../strings';
 import { MAX_WRONG_ATTEMPTS, useUnlockScreen } from '../useUnlockScreen';
@@ -45,7 +45,7 @@ jest.mock('@cardstack/components/BiometricSwitch', () => ({
   useBiometricSwitch: jest.fn(),
 }));
 
-jest.mock('@rainbow-me/hooks', () => ({
+jest.mock('@cardstack/hooks/useAppState', () => ({
   useAppState: jest.fn(),
 }));
 

--- a/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
+++ b/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
@@ -4,7 +4,7 @@ import { Alert } from 'react-native';
 
 import { useBiometricSwitch } from '@cardstack/components/BiometricSwitch';
 import { DEFAULT_PIN_LENGTH } from '@cardstack/components/Input/PinInput/PinInput';
-import { useBooleanState } from '@cardstack/hooks';
+import { useBooleanState, useAppState } from '@cardstack/hooks';
 import { biometricAuthentication } from '@cardstack/models/biometric-auth';
 import { getPin } from '@cardstack/models/secure-storage';
 import { useAuthActions } from '@cardstack/redux/authSlice';
@@ -16,7 +16,6 @@ import {
   savePinAuthAttempts,
   savePinAuthNextDateAttempt,
 } from '@rainbow-me/handlers/localstorage/globalSettings';
-import { useAppState } from '@rainbow-me/hooks';
 import { resetWallet } from '@rainbow-me/model/wallet';
 
 import { strings } from './strings';

--- a/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
+++ b/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
@@ -75,6 +75,8 @@ export const useUnlockScreen = () => {
   const authenticateBiometrically = useCallback(async () => {
     resetRetryBiometricAuth();
 
+    console.log('::: authenticateBiometrically');
+
     if (await biometricAuthentication()) {
       setPinValid();
       setUserAuthorized();
@@ -158,6 +160,8 @@ export const useUnlockScreen = () => {
   }, [checkUserTemporaryBlock, inputPin, validatePin]);
 
   useEffect(() => {
+    console.log('::: isBiometryEnabled', { isBiometryEnabled, isActive });
+
     if (isBiometryEnabled && isActive) {
       authenticateBiometrically();
     }

--- a/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
+++ b/cardstack/src/screens/UnlockScreen/useUnlockScreen.tsx
@@ -75,8 +75,6 @@ export const useUnlockScreen = () => {
   const authenticateBiometrically = useCallback(async () => {
     resetRetryBiometricAuth();
 
-    console.log('::: authenticateBiometrically');
-
     if (await biometricAuthentication()) {
       setPinValid();
       setUserAuthorized();
@@ -160,8 +158,6 @@ export const useUnlockScreen = () => {
   }, [checkUserTemporaryBlock, inputPin, validatePin]);
 
   useEffect(() => {
-    console.log('::: isBiometryEnabled', { isBiometryEnabled, isActive });
-
     if (isBiometryEnabled && isActive) {
       authenticateBiometrically();
     }

--- a/cardstack/src/screens/sheets/WalletConnectRedirectSheet.tsx
+++ b/cardstack/src/screens/sheets/WalletConnectRedirectSheet.tsx
@@ -2,9 +2,8 @@ import { useRoute, useNavigation } from '@react-navigation/native';
 import React, { useEffect } from 'react';
 
 import { CenteredContainer, Sheet, Text } from '@cardstack/components';
+import { useAppState } from '@cardstack/hooks/useAppState';
 import { RouteType } from '@cardstack/navigation/types';
-
-import { useAppState } from '@rainbow-me/hooks';
 
 export enum WCRedirectTypes {
   connect = 'connect',

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -55,4 +55,3 @@ export { default as useWalletsWithBalancesAndNames } from './useWalletsWithBalan
 export { default as useAccountEmptyState } from './useAccountEmptyState';
 export * from './useAssetListData';
 export * from './usePinnedAndHiddenItemOptions';
-export * from './useAppState';

--- a/src/hooks/useClipboard.js
+++ b/src/hooks/useClipboard.js
@@ -1,6 +1,6 @@
 import Clipboard from '@react-native-community/clipboard';
 import { useCallback, useEffect, useState } from 'react';
-import { useAppState } from './useAppState';
+import { useAppState } from '@cardstack/hooks';
 import { deviceUtils } from '@rainbow-me/utils';
 
 const listeners = new Set();

--- a/src/useAppInit.ts
+++ b/src/useAppInit.ts
@@ -9,12 +9,11 @@ import {
   runKeychainIntegrityChecks,
   runWalletBackupStatusChecks,
 } from './handlers/walletReadyEvents';
-import { useAppState } from './hooks';
 
 import { useRainbowSelector } from './redux/hooks';
 import store from './redux/store';
 import { walletConnectLoadState } from './redux/walletconnect';
-import { useAppRequirements } from '@cardstack/hooks';
+import { useAppRequirements, useAppState } from '@cardstack/hooks';
 import { registerTokenRefreshListener } from '@cardstack/models/firebase';
 import { Navigation, Routes } from '@cardstack/navigation';
 import { navigationRef } from '@cardstack/navigation/Navigation';


### PR DESCRIPTION
### Description

Adds unit tests to assert different values expected from `useAppState` hook for different app states.

It uses a `spyOn` mock call to the hook's app state listener, so for each test we need to remove and reattach the spyOn or  the hook is not correctly unmounted between tests.

