### PR TITLE
[Chore] Adds Husky pre-push scripts

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn test
+yarn ci

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn test
 yarn ci
+yarn test

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "Cardwallet",
   "private": true,
   "scripts": {
-    "setup": "yarn install && yarn postinstall",
+    "setup": "yarn install && yarn postinstall && husky install",
     "check-env": "./scripts/check-env.sh",
     "build:ios": "node node_modules/react-native/local-cli/cli.js bundle --entry-file='index.js' --bundle-output='./ios/main.jsbundle' --dev=false --platform='ios'",
     "android": "react-native run-android",
@@ -38,8 +38,7 @@
     "reset:cache": "yarn start --reset-cache",
     "rebuild": "yarn setup && yarn install-bundle && yarn install-pods && yarn build:ios && yarn start",
     "rebuild:m1": "yarn setup && yarn install-bundle && yarn install-pods:m1 && yarn build:ios && yarn start:clean",
-    "codegen": "graphql-codegen",
-    "prepare": "husky install"
+    "codegen": "graphql-codegen"
   },
   "husky": {
     "hooks": {
@@ -113,7 +112,6 @@
     "grapheme-splitter": "^1.0.4",
     "graphql-tag": "^2.10.3",
     "https-browserify": "0.0.1",
-    "husky": "^2.4.0",
     "i18n-js": "^3.8.0",
     "i18next": "^17.0.3",
     "imgix-core-js": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "reset:cache": "yarn start --reset-cache",
     "rebuild": "yarn setup && yarn install-bundle && yarn install-pods && yarn build:ios && yarn start",
     "rebuild:m1": "yarn setup && yarn install-bundle && yarn install-pods:m1 && yarn build:ios && yarn start:clean",
-    "codegen": "graphql-codegen"
+    "codegen": "graphql-codegen",
+    "prepare": "husky install"
   },
   "husky": {
     "hooks": {
@@ -283,7 +284,8 @@
     "stylelint-processor-styled-components": "^1.10.0",
     "stylelint-react-native": "^2.4.0",
     "ts-jest": "^26.5.5",
-    "typescript": "4.5.5"
+    "typescript": "4.5.5",
+    "husky": "^8.0.0"
   },
   "resolutions": {
     "**/tunnel-agent": "0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13728,21 +13728,10 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-husky@^2.4.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-2.7.0.tgz#c0a9a6a3b51146224e11bba0b46bba546e461d05"
-  integrity sha512-LIi8zzT6PyFpcYKdvWRCn/8X+6SuG2TgYYMrM6ckEYhlp44UcEduVymZGIZNLiwOUjrEud+78w/AsAiqJA/kRg==
-  dependencies:
-    cosmiconfig "^5.2.0"
-    execa "^1.0.0"
-    find-up "^3.0.0"
-    get-stdin "^7.0.0"
-    is-ci "^2.0.0"
-    pkg-dir "^4.1.0"
-    please-upgrade-node "^3.1.1"
-    read-pkg "^5.1.1"
-    run-node "^1.0.0"
-    slash "^3.0.0"
+husky@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
+  integrity sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==
 
 i18n-js@^3.8.0:
   version "3.8.0"
@@ -18841,7 +18830,7 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-pkg-dir@^4.1.0, pkg-dir@^4.2.0:
+pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
@@ -18862,7 +18851,7 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
-please-upgrade-node@^3.1.1, please-upgrade-node@^3.2.0:
+please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
@@ -20227,7 +20216,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-read-pkg@^5.1.1, read-pkg@^5.2.0:
+read-pkg@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
   integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
@@ -20954,11 +20943,6 @@ run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
-
-run-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
-  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
 
 run-parallel@^1.1.2, run-parallel@^1.1.9:
   version "1.1.9"


### PR DESCRIPTION
### Description

Adds Husky pre-push `git-hook` script. It will not allow lint or test issues to be pushed to origin.

The pre-push script first runs `yarn ci` because it's the most common to have issues, then `yarn test`.

Husky hooks are "configured" during `yarn setup` step, so make sure to run that.