### PR TITLE
[CS-4222]: Alert user on damaged wallet while adding new acc

### DIFF
--- a/cardstack/src/components/CtaBanner/useWelcomeCtaBanner.ts
+++ b/cardstack/src/components/CtaBanner/useWelcomeCtaBanner.ts
@@ -36,7 +36,7 @@ export const useWelcomeCtaBanner = () => {
   }, [navigate]);
 
   // We only consider an address for the drop if its the first address of an EOA.
-  // Derivated addresses are not elegible.
+  // Derived addresses are not elegible.
   const isFirstAddressForCurrentWallet = useMemo(
     () => selectedAccount?.index === 0 || false,
     [selectedAccount]

--- a/cardstack/src/screens/WelcomeScreen/__tests__/hooks.test.ts
+++ b/cardstack/src/screens/WelcomeScreen/__tests__/hooks.test.ts
@@ -105,8 +105,6 @@ describe('useWelcomeScreen', () => {
       result.current.onCreateWallet();
     });
 
-    expect(mockedCreateWallet).toBeCalledWith({
-      isFromWelcomeFlow: true,
-    });
+    expect(mockedCreateWallet).toBeCalledTimes(1);
   });
 });

--- a/cardstack/src/screens/WelcomeScreen/hooks.tsx
+++ b/cardstack/src/screens/WelcomeScreen/hooks.tsx
@@ -48,9 +48,7 @@ export const useWelcomeScreen = () => {
   }, []);
 
   const onCreateWallet = useCallback(() => {
-    createNewWallet({
-      isFromWelcomeFlow: true,
-    });
+    createNewWallet();
   }, [createNewWallet]);
 
   const onAddExistingWallet = useCallback(() => {

--- a/src/components/change-wallet/WalletList.js
+++ b/src/components/change-wallet/WalletList.js
@@ -187,7 +187,7 @@ export default function WalletList({
       switch (item.rowType) {
         case RowTypes.ADDRESS:
           return (
-            <Container height={item.height}>
+            <Container>
               <AddressRow
                 data={item}
                 editMode={editMode}
@@ -222,7 +222,7 @@ export default function WalletList({
             scrollEnabled={scrollEnabled}
           />
           {showDividers && <WalletListDivider />}
-          <Container marginBottom={5} marginLeft={5}>
+          <Container justifyContent="flex-end" marginBottom={1} marginLeft={5}>
             <OptionItem
               borderIcon
               disabled={editMode}

--- a/src/components/change-wallet/WalletList.js
+++ b/src/components/change-wallet/WalletList.js
@@ -233,7 +233,7 @@ export default function WalletList({
                 color: editMode ? 'grayText' : 'black',
                 fontSize: 14,
               }}
-              title="Create derivated account"
+              title="Create derived account"
             />
             {__DEV__ && (
               <OptionItem

--- a/src/hooks/useWalletManager.ts
+++ b/src/hooks/useWalletManager.ts
@@ -41,11 +41,6 @@ import walletLoadingStates from '@rainbow-me/helpers/walletLoadingStates';
 
 import logger from 'logger';
 
-interface CreateWalletParams
-  extends Pick<CreateImportParams, 'color' | 'name'> {
-  isFromWelcomeFlow?: boolean;
-}
-
 interface WalletsState {
   selectedWallet: RainbowWallet;
   wallets: RainbowWallet[];
@@ -223,19 +218,15 @@ export default function useWalletManager() {
   );
 
   const createNewWallet = useCallback(
-    async ({ color, name, isFromWelcomeFlow }: CreateWalletParams = {}) =>
+    async () =>
       createWalletPin({
         onSuccess: async (pin: string) => {
           try {
-            if (isFromWelcomeFlow) {
-              showLoadingOverlay({
-                title: walletLoadingStates.CREATING_WALLET,
-              });
-            }
+            showLoadingOverlay({
+              title: walletLoadingStates.CREATING_WALLET,
+            });
 
             const wallet = await createOrImportWallet({
-              color,
-              name,
               pin,
             });
 


### PR DESCRIPTION
### Description

Since we support one wallet only, if a wallet is damaged we don't want to try to create a new one anymore, we alert the user about it, so they can reset it and create a new one or re-import it. There's also a minor UI change on the WalletList, which could be better, but it will do for now.

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->

https://user-images.githubusercontent.com/20520102/177828695-c75b35c8-f07d-492e-ad9a-53b82e0f6407.mov


