### PR TITLE
[CS-4237] Handle deeplink when user dismiss biometric authentication once

### DIFF
--- a/cardstack/src/navigation/navigator.tsx
+++ b/cardstack/src/navigation/navigator.tsx
@@ -1,7 +1,7 @@
 import { NavigationContainer } from '@react-navigation/native';
 import React, { memo } from 'react';
 
-import { useAuthSelectorAndActions } from '@cardstack/redux/authSlice';
+import { useAuthSelector } from '@cardstack/redux/authSlice';
 
 import { navigationRef } from './Navigation';
 import { onNavigationStateChange } from './onNavigationStateChange';
@@ -9,13 +9,13 @@ import { linking } from './screens';
 import { StackNavigator } from './tabBarNavigator';
 
 const AppContainer = () => {
-  const { isAuthorized } = useAuthSelectorAndActions();
+  const { isAuthorized } = useAuthSelector();
 
-  const hasLinking = isAuthorized ? linking : undefined;
+  const enableLinking = isAuthorized ? linking : undefined;
 
   return (
     <NavigationContainer
-      linking={hasLinking}
+      linking={enableLinking}
       onStateChange={onNavigationStateChange}
       ref={navigationRef}
     >

--- a/cardstack/src/navigation/navigator.tsx
+++ b/cardstack/src/navigation/navigator.tsx
@@ -1,20 +1,28 @@
 import { NavigationContainer } from '@react-navigation/native';
 import React, { memo } from 'react';
 
+import { useAuthSelectorAndActions } from '@cardstack/redux/authSlice';
+
 import { navigationRef } from './Navigation';
 import { onNavigationStateChange } from './onNavigationStateChange';
 import { linking } from './screens';
 import { StackNavigator } from './tabBarNavigator';
 
-const AppContainer = () => (
-  <NavigationContainer
-    linking={linking}
-    onStateChange={onNavigationStateChange}
-    ref={navigationRef}
-  >
-    <StackNavigator />
-  </NavigationContainer>
-);
+const AppContainer = () => {
+  const { isAuthorized } = useAuthSelectorAndActions();
+
+  const hasLinking = isAuthorized ? linking : undefined;
+
+  return (
+    <NavigationContainer
+      linking={hasLinking}
+      onStateChange={onNavigationStateChange}
+      ref={navigationRef}
+    >
+      <StackNavigator />
+    </NavigationContainer>
+  );
+};
 
 AppContainer.displayName = 'AppContainer';
 

--- a/src/useAppInit.ts
+++ b/src/useAppInit.ts
@@ -64,6 +64,8 @@ export const useAppInit = () => {
     handleWcDeepLink();
 
     const subscription = Linking.addEventListener('url', ({ url }) => {
+      // handles the deeplink after user dismissed auth
+      initialDeepLink.current = url;
       handleDeepLink(url);
     });
 

--- a/src/useAppInit.ts
+++ b/src/useAppInit.ts
@@ -46,15 +46,19 @@ export const useAppInit = () => {
 
   const initialDeepLink = useRef<string | null>(null);
 
+  const openDeepLink = useCallback((url: string) => {
+    initialDeepLink.current = url;
+
+    handleDeepLink(url);
+  }, []);
+
   useEffect(() => {
     const handleWcDeepLink = async () => {
       try {
         const initialUrl = await Linking.getInitialURL();
 
         if (initialUrl) {
-          initialDeepLink.current = initialUrl;
-
-          handleDeepLink(initialUrl);
+          openDeepLink(initialUrl);
         }
       } catch (e) {
         Logger.sentry('Error opening deeplink', e);
@@ -64,13 +68,11 @@ export const useAppInit = () => {
     handleWcDeepLink();
 
     const subscription = Linking.addEventListener('url', ({ url }) => {
-      // handles the deeplink after user dismissed auth
-      initialDeepLink.current = url;
-      handleDeepLink(url);
+      openDeepLink(url);
     });
 
     return subscription.remove;
-  }, []);
+  }, [openDeepLink]);
 
   useEffect(() => {
     if (initialDeepLink.current && isAuthorized) {


### PR DESCRIPTION
### Description
This PR handles the scenario of a user that opens the app, authenticates, moves the app to the background in order to read a QR code or to click on a payment link and then dismisses the biometric authorization. Clicking on the payment link or scanning the QR code again would redirect the user directly into the PaymentScreen without asking again for authentication.

- We're only adding the deep link configuration whenever the user is authorized.
- We're calling the `handleDeepLink` function to the `Linking` listener so we can redirect the user properly.

- [x] Completes CS-4237

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
