### PR TITLE
[CS-4258]: Fix missing contextMenu if all cards are hidden

### DIFF
--- a/src/hooks/useAssetListData.tsx
+++ b/src/hooks/useAssetListData.tsx
@@ -49,7 +49,7 @@ const usePrepaidCardSection = (
       title: 'Prepaid Cards',
       count,
       type: PinnedHiddenSectionOption.PREPAID_CARDS,
-      showContextMenu: !!count,
+      showContextMenu: !!prepaidCards.length,
     },
     data: prepaidCards,
     timestamp,


### PR DESCRIPTION
### Description

This PR shows the menu based on the amount of total cards, instead of the filtered cards


### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

![Simulator Screen Recording - iPhone 11 - 2022-07-15 at 14 53 11](https://user-images.githubusercontent.com/20520102/179282767-29b0ac3e-1ace-4b55-a849-ae545925e364.gif)

