### PR TITLE
[CS-4233] Set wallet as backed up when importing a wallet from a cloud backup

### DIFF
--- a/cardstack/src/models/__tests__/backup.test.ts
+++ b/cardstack/src/models/__tests__/backup.test.ts
@@ -68,6 +68,7 @@ const password = '12345678';
 
 describe('backup', () => {
   const mockedSeed = 'foo bar foo';
+  const mockedBackupFile = 'latestBackupFile.json';
 
   const encryptAndSaveDataToCloud = jest
     .spyOn(cloudBackup, 'encryptAndSaveDataToCloud')
@@ -169,7 +170,10 @@ describe('backup', () => {
 
       const seed = await restoreCloudBackup(password, userData);
 
-      expect(seed).toBe(mockedSeed);
+      expect(seed).toEqual({
+        filename: mockedBackupFile,
+        restoredSeed: mockedSeed,
+      });
     });
 
     it('should return restored seed for old backup format', async () => {
@@ -188,7 +192,10 @@ describe('backup', () => {
 
       const seed = await restoreCloudBackup(password, userData);
 
-      expect(seed).toBe(mockedSeed);
+      expect(seed).toEqual({
+        filename: mockedBackupFile,
+        restoredSeed: mockedSeed,
+      });
     });
 
     describe('findAndParseOldSeed', () => {

--- a/cardstack/src/models/backup.ts
+++ b/cardstack/src/models/backup.ts
@@ -109,10 +109,10 @@ export async function restoreCloudBackup(
         latestBackedUpWallet?.id
       );
 
-      return oldSeedPhrase;
+      return { restoredSeed: oldSeedPhrase, filename };
     }
 
-    return seedPhrase;
+    return { restoredSeed: seedPhrase, filename };
   } catch (e) {
     logger.sentry('Error while restoring back up');
     captureException(e);

--- a/src/components/backup/RestoreCloudStep.js
+++ b/src/components/backup/RestoreCloudStep.js
@@ -61,14 +61,15 @@ export default function RestoreCloudStep({ userData, backupSelected }) {
 
       showLoadingOverlay({ title: WalletLoadingStates.RESTORING_WALLET });
 
-      const restoredSeed = await restoreCloudBackup(
+      // restoreCloudBackup needs to return both seed and filename
+      const { restoredSeed, filename } = await restoreCloudBackup(
         password,
         userData,
         selectedBackupName
       );
 
       if (isValidSeed(restoredSeed)) {
-        await importWallet({ seed: restoredSeed });
+        await importWallet({ seed: restoredSeed, backupFilename: filename });
         return;
       }
 


### PR DESCRIPTION
### Description
When importing a wallet from a cloud backup, we're not setting the wallet as backed up in our state management. This PR aims to fix that by calling the same function we use on the backup flow inside the app.

- [x] Completes #CS-4233

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
