### PR TITLE
[CS-4077]: Improve ProfileNameScreen w/ animation and hook

### DIFF
--- a/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
+++ b/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
@@ -34,7 +34,7 @@ enum Animation {
 
 const layouts = {
   defaultPadding: 5,
-  keyboardVerticalOffset: Device.isIOS ? 15 : 110,
+  keyboardVerticalOffset: Device.isIOS ? 15 : 95,
 };
 
 const styles = StyleSheet.create({

--- a/cardstack/src/screens/Profile/ProfileNameScreen/components/ProfilePhonePreview.tsx
+++ b/cardstack/src/screens/Profile/ProfileNameScreen/components/ProfilePhonePreview.tsx
@@ -1,35 +1,21 @@
 import * as React from 'react';
 import { ImageSourcePropType } from 'react-native';
-import Svg, {
-  Defs,
-  ClipPath,
-  Rect,
-  Image,
-  G,
-  Path,
-  Text,
-  TSpan,
-} from 'react-native-svg';
+import Svg, { Rect, Image, G, Path, Text, TSpan } from 'react-native-svg';
 
 import QRCodePreview from './QRCodePreview';
 
 interface Props {
   profileUrl: string;
-  profileName?: string;
+  profileName: string;
   profileColor?: string;
 }
 
 const ProfilePhonePreview = ({
-  profileName = 'Profile Name',
+  profileName,
   profileUrl = 'mandello123.card.xyz',
   profileColor = '#0089f9',
 }: Props) => (
   <Svg width="100%" height="100%" viewBox="0 0 431 520">
-    <Defs>
-      <ClipPath id="a">
-        <Rect width="100%" height="56%" x={35} />
-      </ClipPath>
-    </Defs>
     <G data-name="Group 14578" transform="translate(-35 0)">
       <Rect
         data-name="Background"

--- a/cardstack/src/screens/Profile/ProfileNameScreen/useProfileNameScreen.ts
+++ b/cardstack/src/screens/Profile/ProfileNameScreen/useProfileNameScreen.ts
@@ -1,0 +1,37 @@
+import { useRoute } from '@react-navigation/native';
+import { useState, useCallback } from 'react';
+
+import { RouteType } from '@cardstack/navigation/types';
+
+interface NavParams {
+  profileUrl: string;
+}
+
+export const useProfileNameScreen = () => {
+  const { params } = useRoute<RouteType<NavParams>>();
+
+  const [profileName, setProfileName] = useState('');
+
+  const profileUrl = params?.profileUrl || 'mandello.card.yxz'; // Temp url
+
+  const onChangeText = useCallback(text => {
+    setProfileName(text);
+  }, []);
+
+  const onContinuePress = useCallback(() => {
+    // TDB
+    console.log({ profileName });
+  }, [profileName]);
+
+  const onSkipPress = useCallback(() => {
+    // TDB
+  }, []);
+
+  return {
+    onSkipPress,
+    onContinuePress,
+    onChangeText,
+    profileUrl,
+    profileName,
+  };
+};

--- a/src/hooks/useDimensions.js
+++ b/src/hooks/useDimensions.js
@@ -1,6 +1,6 @@
 import { useWindowDimensions } from 'react-native';
 
-const deviceDimensions = {
+export const deviceDimensions = {
   iphone6: {
     height: 667,
     width: 375,


### PR DESCRIPTION
### Description

<!-- Please, include a summary of the changes. -->

This PR fixes the devices inconsistency, iOS seems to be running smoothly and with all the items positioned in the same spot regardless of device size, for Android I believe most of the cases are covered, with slight differences on smaller devices, also it hides the description once the value is inputed. It also adds the `useProfileNameScreen` hooks with empty functions until we have the whole flow, and adds the validation on the Continue btn. 

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->


Small android device - Nexus 5: 
<img width="300" alt="image" src="https://user-images.githubusercontent.com/20520102/180065351-f512d210-9a0f-46a6-8142-a5ba91259a7c.png">

Pixel 4a:
![androidddd](https://user-images.githubusercontent.com/20520102/180068085-df915536-fd97-4c54-80cf-4e276b90d23e.gif)


iPhone 8 :
![Simulator Screen Recording - iPhone 8 - 2022-07-20 at 16 19 34](https://user-images.githubusercontent.com/20520102/180066195-2546253a-542b-41d2-af8f-35f48d8f131d.gif)


Iphone 11 Pro:

<img width="300" alt="image" src="https://user-images.githubusercontent.com/20520102/180066779-b5c1f5fc-59e4-494d-9c7f-9aaab2bad874.png">
