### PR TITLE
[CS-4262] Adds SuffixedInput component for username

### DIFF
--- a/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
+++ b/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
@@ -8,16 +8,20 @@ import {
   Text,
   TextProps,
 } from '@cardstack/components';
+import { Device } from '@cardstack/utils';
 import { fontFamilyVariants, colors } from '@cardstack/theme';
 
 const styles = StyleSheet.create({
   input: {
-    top: 0.5, // Input comp. renders inner text slightly above Text comp.
     color: colors.teal,
-    minWidth: '32%',
-    fontSize: 24,
+    // Input's font on android is rendering a lot smaller, not sure why.
+    minWidth: Device.isAndroid ? '40%' : '32%',
+    fontSize: Device.isAndroid ? 32 : 24,
+    padding: 0, // Clears phantom padding on android. Keep it consistent on ios.
+    left: 0,
+    ...fontFamilyVariants.bold,
   },
-  textFont: {
+  suffix: {
     fontSize: 24,
     ...fontFamilyVariants.bold,
   },
@@ -40,25 +44,31 @@ const SuffixedInput = forwardRef(
     }: SuffixedInputProps,
     ref
   ) => (
-    <Container flexDirection="row" flexWrap="wrap">
+    <Container
+      width="100%"
+      flexDirection="row"
+      flexWrap="wrap"
+      justifyContent="flex-start"
+      alignItems="center"
+    >
       <Input
         ref={ref}
+        style={styles.input}
+        placeholderTextColor={colors.secondaryText}
+        paddingRight={1}
         autoFocus
-        autoCapitalize="none"
         multiline={false}
         spellCheck={false}
         autoCorrect={false}
         maxLength={maxLength}
-        style={[styles.input, styles.textFont]}
+        autoCapitalize="none"
         placeholder="username"
         textContentType="username"
-        underlineColorAndroid="transparent"
         keyboardType="twitter"
-        paddingRight={1}
-        placeholderTextColor={colors.secondaryText}
+        underlineColorAndroid="transparent"
         {...props}
       />
-      <Text style={styles.textFont} color="white" {...suffixTextProps}>
+      <Text style={styles.suffix} color="white" {...suffixTextProps}>
         {suffixText}
       </Text>
     </Container>

--- a/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
+++ b/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
@@ -1,15 +1,11 @@
-import React, { memo, forwardRef } from 'react';
-import { StyleSheet } from 'react-native';
+import React, { memo } from 'react';
+import { StyleSheet, TextInput, TextInputProps } from 'react-native';
 
-import {
-  Container,
-  Input,
-  InputProps,
-  Text,
-  TextProps,
-} from '@cardstack/components';
+import { Container, Text, TextProps } from '@cardstack/components';
 import { fontFamilyVariants, colors } from '@cardstack/theme';
 import { Device } from '@cardstack/utils';
+
+import { strings } from './strings';
 
 const styles = StyleSheet.create({
   input: {
@@ -19,6 +15,7 @@ const styles = StyleSheet.create({
     fontSize: Device.isAndroid ? 32 : 24,
     padding: 0, // Clears phantom padding on android. Keep it consistent on ios.
     left: 0,
+    paddingRight: 4,
     ...fontFamilyVariants.bold,
   },
   suffix: {
@@ -27,52 +24,43 @@ const styles = StyleSheet.create({
   },
 });
 
-interface SuffixedInputProps extends InputProps {
+interface SuffixedInputProps extends TextInputProps {
   suffixText?: string;
   suffixTextProps?: TextProps;
 }
 
 const DEFAULT_MAX_LENGTH = 25;
 
-const SuffixedInput = forwardRef(
-  (
-    {
-      suffixText,
-      suffixTextProps,
-      maxLength = DEFAULT_MAX_LENGTH,
-      ...props
-    }: SuffixedInputProps,
-    ref
-  ) => (
-    <Container
-      width="100%"
-      flexDirection="row"
-      flexWrap="wrap"
-      justifyContent="flex-start"
-      alignItems="center"
-    >
-      <Input
-        ref={ref}
-        style={styles.input}
-        placeholderTextColor={colors.secondaryText}
-        paddingRight={1}
-        autoFocus
-        multiline={false}
-        spellCheck={false}
-        autoCorrect={false}
-        maxLength={maxLength}
-        autoCapitalize="none"
-        placeholder="username"
-        textContentType="username"
-        keyboardType="twitter"
-        underlineColorAndroid="transparent"
-        {...props}
-      />
-      <Text style={styles.suffix} color="white" {...suffixTextProps}>
-        {suffixText}
-      </Text>
-    </Container>
-  )
+const SuffixedInput = ({
+  suffixText,
+  suffixTextProps,
+  maxLength = DEFAULT_MAX_LENGTH,
+  placeholder = strings.defaultPlaceholder,
+}: SuffixedInputProps) => (
+  <Container
+    width="100%"
+    flexDirection="row"
+    flexWrap="wrap"
+    justifyContent="flex-start"
+    alignItems="center"
+  >
+    <TextInput
+      style={styles.input}
+      placeholderTextColor={colors.secondaryText}
+      autoFocus
+      multiline={false}
+      spellCheck={false}
+      autoCorrect={false}
+      maxLength={maxLength}
+      autoCapitalize="none"
+      placeholder={placeholder}
+      textContentType="username"
+      underlineColorAndroid="transparent"
+    />
+    <Text style={styles.suffix} color="white" {...suffixTextProps}>
+      {suffixText}
+    </Text>
+  </Container>
 );
 
 export default memo(SuffixedInput);

--- a/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
+++ b/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
@@ -8,8 +8,8 @@ import {
   Text,
   TextProps,
 } from '@cardstack/components';
-import { Device } from '@cardstack/utils';
 import { fontFamilyVariants, colors } from '@cardstack/theme';
+import { Device } from '@cardstack/utils';
 
 const styles = StyleSheet.create({
   input: {

--- a/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
+++ b/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
@@ -9,7 +9,7 @@ import { strings } from './strings';
 const styles = StyleSheet.create({
   input: {
     color: colors.teal,
-    minWidth: '34%',
+    minWidth: '36%',
     padding: 0, // Clears phantom padding on android. Keep it consistent on ios.
     left: 0,
     paddingRight: 4,
@@ -52,8 +52,14 @@ const SuffixedInput = ({
       placeholder={placeholder}
       textContentType="username"
       underlineColorAndroid="transparent"
+      allowFontScaling={false}
     />
-    <Text style={styles.textStyle} color="white" {...suffixTextProps}>
+    <Text
+      style={styles.textStyle}
+      allowFontScaling={false}
+      color="white"
+      {...suffixTextProps}
+    >
       {suffixText}
     </Text>
   </Container>

--- a/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
+++ b/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
@@ -3,22 +3,18 @@ import { StyleSheet, TextInput, TextInputProps } from 'react-native';
 
 import { Container, Text, TextProps } from '@cardstack/components';
 import { fontFamilyVariants, colors } from '@cardstack/theme';
-import { Device } from '@cardstack/utils';
 
 import { strings } from './strings';
 
 const styles = StyleSheet.create({
   input: {
     color: colors.teal,
-    // Input's font on android is rendering a lot smaller, not sure why.
-    minWidth: Device.isAndroid ? '40%' : '32%',
-    fontSize: Device.isAndroid ? 32 : 24,
+    minWidth: '34%',
     padding: 0, // Clears phantom padding on android. Keep it consistent on ios.
     left: 0,
     paddingRight: 4,
-    ...fontFamilyVariants.bold,
   },
-  suffix: {
+  textStyle: {
     fontSize: 24,
     ...fontFamilyVariants.bold,
   },
@@ -45,7 +41,7 @@ const SuffixedInput = ({
     alignItems="center"
   >
     <TextInput
-      style={styles.input}
+      style={[styles.input, styles.textStyle]}
       placeholderTextColor={colors.secondaryText}
       autoFocus
       multiline={false}
@@ -57,7 +53,7 @@ const SuffixedInput = ({
       textContentType="username"
       underlineColorAndroid="transparent"
     />
-    <Text style={styles.suffix} color="white" {...suffixTextProps}>
+    <Text style={styles.textStyle} color="white" {...suffixTextProps}>
       {suffixText}
     </Text>
   </Container>

--- a/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
+++ b/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
@@ -1,0 +1,68 @@
+import React, { memo, forwardRef } from 'react';
+import { StyleSheet } from 'react-native';
+
+import {
+  Container,
+  Input,
+  InputProps,
+  Text,
+  TextProps,
+} from '@cardstack/components';
+import { fontFamilyVariants, colors } from '@cardstack/theme';
+
+const styles = StyleSheet.create({
+  input: {
+    top: 0.5, // Input comp. renders inner text slightly above Text comp.
+    color: colors.teal,
+    minWidth: '32%',
+    fontSize: 24,
+  },
+  textFont: {
+    fontSize: 24,
+    ...fontFamilyVariants.bold,
+  },
+});
+
+interface SuffixedInputProps extends InputProps {
+  suffixText?: string;
+  suffixTextProps?: TextProps;
+}
+
+const DEFAULT_MAX_LENGTH = 25;
+
+const SuffixedInput = forwardRef(
+  (
+    {
+      suffixText,
+      suffixTextProps,
+      maxLength = DEFAULT_MAX_LENGTH,
+      ...props
+    }: SuffixedInputProps,
+    ref
+  ) => (
+    <Container flexDirection="row" flexWrap="wrap">
+      <Input
+        ref={ref}
+        autoFocus
+        autoCapitalize="none"
+        multiline={false}
+        spellCheck={false}
+        autoCorrect={false}
+        maxLength={maxLength}
+        style={[styles.input, styles.textFont]}
+        placeholder="username"
+        textContentType="username"
+        underlineColorAndroid="transparent"
+        keyboardType="twitter"
+        paddingRight={1}
+        placeholderTextColor={colors.secondaryText}
+        {...props}
+      />
+      <Text style={styles.textFont} color="white" {...suffixTextProps}>
+        {suffixText}
+      </Text>
+    </Container>
+  )
+);
+
+export default memo(SuffixedInput);

--- a/cardstack/src/components/Input/SuffixedInput/strings.ts
+++ b/cardstack/src/components/Input/SuffixedInput/strings.ts
@@ -1,0 +1,3 @@
+export const strings = {
+  defaultPlaceholder: 'username',
+};

--- a/cardstack/src/components/Input/index.ts
+++ b/cardstack/src/components/Input/index.ts
@@ -3,4 +3,3 @@ export * from './InputAmount/InputAmount';
 export * from './InputAmount/useInputAmountHelper';
 export { default as FormInput } from './FormInput';
 export { default as PinInput } from './PinInput/PinInput';
-export { default as SuffixedInput } from './SuffixedInput/SuffixedInput';

--- a/cardstack/src/components/Input/index.ts
+++ b/cardstack/src/components/Input/index.ts
@@ -3,3 +3,4 @@ export * from './InputAmount/InputAmount';
 export * from './InputAmount/useInputAmountHelper';
 export { default as FormInput } from './FormInput';
 export { default as PinInput } from './PinInput/PinInput';
+export { default as SuffixedInput } from './SuffixedInput/SuffixedInput';

--- a/cardstack/src/screens/Dev/DesignSystemScreen.tsx
+++ b/cardstack/src/screens/Dev/DesignSystemScreen.tsx
@@ -46,9 +46,9 @@ const DesignSystemScreen = () => {
       switch (title) {
         case 'Input':
           return (
-            <CenteredContainer padding={2}>
+            <Container padding={2}>
               <SuffixedInput suffixText=".card.xyz" />
-            </CenteredContainer>
+            </Container>
           );
         case 'Buttons':
           return (

--- a/cardstack/src/screens/Dev/DesignSystemScreen.tsx
+++ b/cardstack/src/screens/Dev/DesignSystemScreen.tsx
@@ -8,6 +8,7 @@ import {
   Container,
   Text,
 } from '@cardstack/components';
+import SuffixedInput from '@cardstack/components/Input/SuffixedInput/SuffixedInput';
 import { buttonVariants } from '@cardstack/theme';
 
 const themes = ['light', 'dark'];
@@ -17,6 +18,10 @@ const DesignSystemScreen = () => {
   const [loading, setLoading] = useState(false);
 
   const sections = [
+    {
+      title: 'Input',
+      data: ['slug'],
+    },
     {
       title: 'Hold to confirm Button',
       data: ['1'],
@@ -39,6 +44,12 @@ const DesignSystemScreen = () => {
   const renderItem = useCallback(
     ({ item, section: { title } }) => {
       switch (title) {
+        case 'Input':
+          return (
+            <CenteredContainer padding={2}>
+              <SuffixedInput suffixText=".card.xyz" />
+            </CenteredContainer>
+          );
         case 'Buttons':
           return (
             <CenteredContainer padding={2}>
@@ -65,7 +76,7 @@ const DesignSystemScreen = () => {
   );
 
   return (
-    <Container backgroundColor="overlayGray">
+    <Container backgroundColor="backgroundDarkPurple">
       <SectionList
         renderItem={renderItem as any}
         sections={sections}

--- a/cardstack/src/theme/index.ts
+++ b/cardstack/src/theme/index.ts
@@ -26,6 +26,7 @@ export * from './breakpoints';
 export * from './fontSizes';
 export * from './fontWeights';
 export * from './customFunctions';
+export * from './fontFamilyVariants';
 
 export type Theme = typeof theme;
 export default theme;


### PR DESCRIPTION
### Description

Adds `SuffixedInput` component that renders a customizable input with a Text label after it that wraps to new line as text gets bigger.

Known issue: Android text input field starts to squeeze the text to the left after it starts expanding horizontally and I can't find a fix, I'll get back to it once we have a testable version ready.

- [x] Completes #(CS-4262)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

https://user-images.githubusercontent.com/129619/180076904-5095bf13-c970-4ec9-8e00-c9a30acf5357.mp4

https://user-images.githubusercontent.com/129619/180076988-bdd9181b-5b41-49d9-be00-ef562d395144.mp4

