### PR TITLE
[CS-4285]: Fix backup restoring after first restore

### DIFF
--- a/cardstack/src/models/__tests__/backup.test.ts
+++ b/cardstack/src/models/__tests__/backup.test.ts
@@ -68,7 +68,6 @@ const password = '12345678';
 
 describe('backup', () => {
   const mockedSeed = 'foo bar foo';
-  const mockedBackupFile = 'latestBackupFile.json';
 
   const encryptAndSaveDataToCloud = jest
     .spyOn(cloudBackup, 'encryptAndSaveDataToCloud')
@@ -112,7 +111,7 @@ describe('backup', () => {
 
   describe('findLatestBackUp', () => {
     it('should return the latest valid cloud backup filename', async () => {
-      const filemame = findLatestBackUp(wallets);
+      const filemame = findLatestBackUp(wallets)?.backupFile;
 
       expect(filemame).toBe('latestBackupFile.json');
     });
@@ -120,7 +119,7 @@ describe('backup', () => {
     it('should return undefined if no wallet is marked as backed up', async () => {
       const filemame = findLatestBackUp({
         wallet_12121212: { ...wallets.wallet_12121212, backedUp: false },
-      });
+      })?.backupFile;
 
       expect(filemame).toBeUndefined();
     });
@@ -171,7 +170,7 @@ describe('backup', () => {
       const seed = await restoreCloudBackup(password, userData);
 
       expect(seed).toEqual({
-        filename: mockedBackupFile,
+        backedUpWallet: wallets.wallet_13131313,
         restoredSeed: mockedSeed,
       });
     });
@@ -193,7 +192,7 @@ describe('backup', () => {
       const seed = await restoreCloudBackup(password, userData);
 
       expect(seed).toEqual({
-        filename: mockedBackupFile,
+        backedUpWallet: wallets.wallet_13131313,
         restoredSeed: mockedSeed,
       });
     });

--- a/cardstack/src/models/backup.ts
+++ b/cardstack/src/models/backup.ts
@@ -60,7 +60,7 @@ export async function backupWalletToCloud(
 
 export function findLatestBackUp(wallets: AllRainbowWallets) {
   let latestBackup: string | undefined;
-  let filename: string | undefined;
+  let backedWallet: RainbowWallet | undefined;
 
   forEach(wallets, wallet => {
     // Check if there's a wallet backed up
@@ -68,13 +68,13 @@ export function findLatestBackUp(wallets: AllRainbowWallets) {
       // If there is one, let's grab the latest backup
       // @ts-expect-error isBackupWallet checks undefined values
       if (!latestBackup || wallet?.backupDate > latestBackup) {
-        filename = wallet.backupFile;
         latestBackup = wallet.backupDate;
+        backedWallet = wallet;
       }
     }
   });
 
-  return filename;
+  return backedWallet;
 }
 
 export async function restoreCloudBackup(
@@ -83,8 +83,9 @@ export async function restoreCloudBackup(
   backupSelected?: string
 ) {
   try {
-    const filename =
-      backupSelected || (userData && findLatestBackUp(userData?.wallets));
+    const backedUpWallet = userData && findLatestBackUp(userData?.wallets);
+
+    const filename = backupSelected || backedUpWallet?.backupFile;
 
     if (!filename) {
       return;
@@ -109,10 +110,10 @@ export async function restoreCloudBackup(
         latestBackedUpWallet?.id
       );
 
-      return { restoredSeed: oldSeedPhrase, filename };
+      return { restoredSeed: oldSeedPhrase, backedUpWallet };
     }
 
-    return { restoredSeed: seedPhrase, filename };
+    return { restoredSeed: seedPhrase, backedUpWallet };
   } catch (e) {
     logger.sentry('Error while restoring back up');
     captureException(e);

--- a/src/components/backup/RestoreCloudStep.js
+++ b/src/components/backup/RestoreCloudStep.js
@@ -62,18 +62,25 @@ export default function RestoreCloudStep({ userData, backupSelected }) {
       showLoadingOverlay({ title: WalletLoadingStates.RESTORING_WALLET });
 
       // restoreCloudBackup needs to return both seed and filename
-      const { restoredSeed, filename } = await restoreCloudBackup(
+      const restoredInfo = await restoreCloudBackup(
         password,
         userData,
         selectedBackupName
       );
 
-      if (isValidSeed(restoredSeed)) {
-        await importWallet({ seed: restoredSeed, backupFilename: filename });
-        return;
-      }
+      if (restoredInfo) {
+        const { restoredSeed, backedUpWallet } = restoredInfo;
 
-      logger.sentry('Error while restoring backup, invalid seed');
+        if (isValidSeed(restoredSeed)) {
+          await importWallet({
+            seed: restoredSeed,
+            backedUpWallet,
+          });
+          return;
+        }
+
+        logger.sentry('Error while restoring backup, invalid seed');
+      }
     } catch (e) {
       setIncorrectPassword(true);
 

--- a/src/hooks/useWallets.ts
+++ b/src/hooks/useWallets.ts
@@ -17,7 +17,7 @@ const walletSelector = createSelector(
     wallets,
   }),
   ({ selectedWallet, walletNames, wallets }) => ({
-    latestBackup: findLatestBackUp(wallets) || false,
+    latestBackup: findLatestBackUp(wallets)?.backupFile || false,
     selectedWallet,
     walletNames,
     wallets,


### PR DESCRIPTION
### Description

There was a missing property (backupDate) after restoring the backup, and the data was being overwritten which caused the backup structure to be invalid when we tried to restore the same backup again, on a different device for example. In other to keep the data as consistent as possible, I'm passing the whole backedUp wallet so we overwrite just the new fields and keep the backupDate.  

The best way to test it is to have an old backup from 1.1.3, restore on this version, and then try to restore it again.
