### PR TITLE
[CS-4296]: Fix payLink not clearing after first attempt

### DIFF
--- a/src/handlers/deeplinks.js
+++ b/src/handlers/deeplinks.js
@@ -8,7 +8,7 @@ import {
 import { decodeNestedURI } from '@cardstack/utils';
 import logger from 'logger';
 
-export default function handleDeepLink(url) {
+export default function handleWcDeepLink(url) {
   if (!url || typeof url !== 'string') return;
   const urlObj = new URL(url);
   if (urlObj.protocol === 'https:' || urlObj.protocol === 'cardwallet:') {
@@ -27,7 +27,7 @@ export default function handleDeepLink(url) {
         break;
       }
       default:
-        logger.log('unknown deeplink');
+        logger.log('no wc deeplink');
     }
   } else if (urlObj.protocol === 'wc:') {
     // Handle direct WC deeplink (wc:xxxx)


### PR DESCRIPTION
### Description

This Pr fixes an issue, where if an user opens a payment link, closes the screen, goes to bg and back the same link keeps opening, this was happening because we have a listener to "manually" store the link, and once we have an Url, and call `openLink` the subscription is triggered again thus reopening the same link we just did. Now we have a condition to prevent this behavior.

### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->

![Simulator Screen Recording - iPhone 11 Pro - 2022-07-22 at 12 58 05](https://user-images.githubusercontent.com/20520102/180478087-17b8bfa4-b285-449a-b007-05665b3776c5.gif)

![Simulator Screen Recording - iPhone 11 Pro - 2022-07-22 at 13 00 11](https://user-images.githubusercontent.com/20520102/180478487-a41d1a4a-2f48-404f-b17a-bb0e9a548604.gif)


