### PR TITLE
[CS-4293] Create custom header for IAP screens

### DIFF
--- a/cardstack/src/components/MainHeader/InPageHeader.tsx
+++ b/cardstack/src/components/MainHeader/InPageHeader.tsx
@@ -17,7 +17,7 @@ interface Props extends ContainerProps {
   onSkipPress?: () => void;
 }
 
-const ProfileHeader = ({
+const InPageHeader = ({
   leftIconProps,
   showLeftIcon = true,
   showSkipButton = true,
@@ -53,4 +53,4 @@ const ProfileHeader = ({
   );
 };
 
-export default ProfileHeader;
+export default InPageHeader;

--- a/cardstack/src/components/MainHeader/ProfileHeader.tsx
+++ b/cardstack/src/components/MainHeader/ProfileHeader.tsx
@@ -1,0 +1,56 @@
+import { useNavigation } from '@react-navigation/native';
+import React from 'react';
+
+import {
+  Container,
+  Icon,
+  Text,
+  Touchable,
+  ContainerProps,
+  IconProps,
+} from '@cardstack/components';
+
+interface Props extends ContainerProps {
+  leftIconProps?: IconProps;
+  showLeftIcon?: boolean;
+  showSkipButton?: boolean;
+  onSkipPress?: () => void;
+}
+
+const ProfileHeader = ({
+  leftIconProps,
+  showLeftIcon = true,
+  showSkipButton = true,
+  onSkipPress,
+}: Props) => {
+  const { goBack } = useNavigation();
+
+  return (
+    <Container
+      flexDirection="row"
+      alignItems="center"
+      justifyContent={showLeftIcon ? 'space-between' : 'flex-end'}
+      flex={0.1}
+    >
+      {showLeftIcon && (
+        <Icon
+          color="teal"
+          name="chevron-left"
+          onPress={goBack}
+          size={30}
+          left={-8}
+          {...leftIconProps}
+        />
+      )}
+      {showSkipButton && (
+        <Touchable onPress={onSkipPress || goBack}>
+          <Text fontSize={13} color="teal" weight="semibold">
+            Skip
+          </Text>
+        </Touchable>
+      )}
+    </Container>
+  );
+};
+
+export default ProfileHeader;

--- a/cardstack/src/components/MainHeader/index.ts
+++ b/cardstack/src/components/MainHeader/index.ts
@@ -1,3 +1,4 @@
 export { default as MainHeader } from './MainHeader';
 export { default as NavigationStackHeader } from './NavigationStackHeader';
 export { default as MainHeaderWrapper } from './components/MainHeaderWrapper';
+export { default as ProfileHeader } from './ProfileHeader';

--- a/cardstack/src/components/MainHeader/index.ts
+++ b/cardstack/src/components/MainHeader/index.ts
@@ -1,4 +1,4 @@
 export { default as MainHeader } from './MainHeader';
 export { default as NavigationStackHeader } from './NavigationStackHeader';
 export { default as MainHeaderWrapper } from './components/MainHeaderWrapper';
-export { default as ProfileHeader } from './ProfileHeader';
+export { default as InPageHeader } from './InPageHeader';

--- a/cardstack/src/screens/Profile/ProfileSlugScreen/ProfileSlugScreen.tsx
+++ b/cardstack/src/screens/Profile/ProfileSlugScreen/ProfileSlugScreen.tsx
@@ -5,7 +5,7 @@ import {
   Text,
   SafeAreaView,
   Button,
-  ProfileHeader,
+  InPageHeader,
 } from '@cardstack/components';
 import SuffixedInput from '@cardstack/components/Input/SuffixedInput/SuffixedInput';
 
@@ -28,7 +28,7 @@ const ProfileSlugScreen = () => {
       paddingHorizontal={5}
       justifyContent="space-between"
     >
-      <ProfileHeader showSkipButton={false} />
+      <InPageHeader showSkipButton={false} />
       <Container flex={0.8}>
         <Container width="90%" paddingBottom={4}>
           <Text variant="pageHeader">{strings.header}</Text>

--- a/cardstack/src/screens/Profile/ProfileSlugScreen/ProfileSlugScreen.tsx
+++ b/cardstack/src/screens/Profile/ProfileSlugScreen/ProfileSlugScreen.tsx
@@ -4,9 +4,8 @@ import {
   Container,
   Text,
   SafeAreaView,
-  Touchable,
-  Icon,
   Button,
+  ProfileHeader,
 } from '@cardstack/components';
 import SuffixedInput from '@cardstack/components/Input/SuffixedInput/SuffixedInput';
 
@@ -19,8 +18,6 @@ const ProfileSlugScreen = () => {
     username,
     onUsernameChange,
     invalidUsernameMessage,
-    onGoBackPressed,
-    onSkipPressed,
     onContinuePress,
   } = useProfileSlugScreen();
 
@@ -29,23 +26,10 @@ const ProfileSlugScreen = () => {
       backgroundColor="backgroundDarkPurple"
       flex={1}
       paddingHorizontal={5}
+      justifyContent="space-between"
     >
-      <Container
-        alignItems="center"
-        justifyContent="space-between"
-        flexDirection="row"
-        flex={0.15}
-      >
-        <Touchable onPress={onGoBackPressed}>
-          <Icon name="chevron-left" color="teal" size={30} left={-6} />
-        </Touchable>
-        <Touchable onPress={onSkipPressed}>
-          <Text fontSize={13} color="teal" variant="semibold">
-            {strings.buttons.skip}
-          </Text>
-        </Touchable>
-      </Container>
-      <Container flex={1}>
+      <ProfileHeader showSkipButton={false} />
+      <Container flex={0.8}>
         <Container width="90%" paddingBottom={4}>
           <Text variant="pageHeader">{strings.header}</Text>
         </Container>

--- a/cardstack/src/screens/Profile/ProfileSlugScreen/useProfileSlugScreen.ts
+++ b/cardstack/src/screens/Profile/ProfileSlugScreen/useProfileSlugScreen.ts
@@ -11,10 +11,6 @@ export const useProfileSlugScreen = () => {
     // TODO
   }, []);
 
-  const onSkipPressed = useCallback(() => {
-    // TODO
-  }, []);
-
   const onContinuePress = useCallback(() => {
     // TODO
   }, []);
@@ -28,7 +24,6 @@ export const useProfileSlugScreen = () => {
     username,
     onUsernameChange,
     onGoBackPressed,
-    onSkipPressed,
     onContinuePress,
     invalidUsernameMessage,
   };

--- a/cardstack/src/screens/Profile/PurchaseCTAScreen/PurchaseCTAScreen.tsx
+++ b/cardstack/src/screens/Profile/PurchaseCTAScreen/PurchaseCTAScreen.tsx
@@ -10,6 +10,7 @@ import {
   SafeAreaView,
   Text,
   Touchable,
+  ProfileHeader,
 } from '@cardstack/components';
 
 import profilePreview from '../../../assets/profile-preview.png';
@@ -28,7 +29,6 @@ interface BenefitsItem {
 const PurchaseCTAScreen = () => {
   const {
     onPressSkip,
-    goBack,
     onPressChargeExplanation,
     onPressBuy,
   } = usePurchaseCTAScreen();
@@ -59,40 +59,20 @@ const PurchaseCTAScreen = () => {
       flex={1}
       paddingHorizontal={5}
     >
-      <Container
-        alignItems="center"
-        justifyContent="space-between"
-        flexDirection="row"
-        flex={0.1}
-      >
-        <Touchable onPress={goBack}>
-          <Icon name="chevron-left" color="teal" size={30} />
-        </Touchable>
-        <Touchable onPress={onPressSkip}>
-          <Text fontSize={13} color="teal" weight="semibold">
-            {strings.skip}
-          </Text>
-        </Touchable>
-      </Container>
+      <ProfileHeader onSkipPress={onPressSkip} />
       <Container
         flex={1}
         flexDirection="column"
         justifyContent="space-between"
         paddingBottom={3}
       >
-        <Text
-          color="white"
-          fontSize={24}
-          fontFamily="OpenSans-Light"
-          paddingLeft={2}
-        >
+        <Text color="white" fontSize={24} fontFamily="OpenSans-Light">
           {strings.title}
         </Text>
         <Container
           flexDirection="column"
           justifyContent="space-between"
           flex={0.25}
-          paddingLeft={2}
         >
           <BenefitsItem iconName="pay" copy={strings.benefits.payments} />
           <BenefitsItem iconName="house" copy={strings.benefits.cardProfile} />

--- a/cardstack/src/screens/Profile/PurchaseCTAScreen/PurchaseCTAScreen.tsx
+++ b/cardstack/src/screens/Profile/PurchaseCTAScreen/PurchaseCTAScreen.tsx
@@ -10,7 +10,7 @@ import {
   SafeAreaView,
   Text,
   Touchable,
-  ProfileHeader,
+  InPageHeader,
 } from '@cardstack/components';
 
 import profilePreview from '../../../assets/profile-preview.png';
@@ -59,7 +59,7 @@ const PurchaseCTAScreen = () => {
       flex={1}
       paddingHorizontal={5}
     >
-      <ProfileHeader onSkipPress={onPressSkip} />
+      <InPageHeader onSkipPress={onPressSkip} />
       <Container
         flex={1}
         flexDirection="column"

--- a/cardstack/src/screens/Profile/PurchaseCTAScreen/usePurchaseCTAScreen.ts
+++ b/cardstack/src/screens/Profile/PurchaseCTAScreen/usePurchaseCTAScreen.ts
@@ -1,9 +1,6 @@
-import { useNavigation } from '@react-navigation/native';
 import { useCallback } from 'react';
 
 export const usePurchaseCTAScreen = () => {
-  const { goBack } = useNavigation();
-
   // TODO: change this
   const onPressSkip = useCallback(() => {
     console.log('Go wherever skips needs to go');
@@ -19,5 +16,5 @@ export const usePurchaseCTAScreen = () => {
     console.log('Start IAP process');
   }, []);
 
-  return { goBack, onPressChargeExplanation, onPressBuy, onPressSkip };
+  return { onPressChargeExplanation, onPressBuy, onPressSkip };
 };

--- a/cardstack/src/screens/Profile/index.ts
+++ b/cardstack/src/screens/Profile/index.ts
@@ -1,2 +1,3 @@
 export { default as ProfileNameScreen } from './ProfileNameScreen/ProfileNameScreen';
 export { default as ProfileSlugScreen } from './ProfileSlugScreen/ProfileSlugScreen';
+export { default as PurchaseCTAScreen } from './PurchaseCTAScreen/PurchaseCTAScreen';


### PR DESCRIPTION
### Description
This PR aims to create a custom header that covers all the cases we currently have for the In-app purchase screens. The only screen of this flow that's not using it yet is the `ProfileNameScreen` since Dani is changing things on this screen.

I'm not super fan of using negative margins to solve alignment issues, but I think it's okay to use it in this particular case.
Other thing that's worth noting is that I'm not using `SafeAreaView` on the component because all of the screens we are building already use that component.

- [x] Completes #CS-4293

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

### Android
<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/180865719-4b13ee99-f36f-4db7-85a9-21b8c76b2c96.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/180865724-6e13818d-afdd-4dc0-b234-0cc1bd8b0050.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/180866416-9bcc7f8c-befd-4d6d-95f0-426550d7f24a.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/180866415-20dd7556-4586-4e24-9157-f378603cdda5.png">


### iOS
<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/180865726-bc23d87e-d4bf-42d1-a015-ce2efc222460.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/180865728-b039358c-4a52-42d7-af5a-3a22242fd309.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/180866410-9910976f-fb31-485e-becd-c103fb2b883a.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/180866407-e8c16cee-5d62-4bf8-aae3-80d4a5f31243.png">
