### PR TITLE
[CS-4079]: Add color picker on new profile

### DIFF
--- a/cardstack/src/screens/ColorPickerModal.tsx
+++ b/cardstack/src/screens/ColorPickerModal.tsx
@@ -12,7 +12,7 @@ import {
   Touchable,
 } from '@cardstack/components';
 import { RouteType } from '@cardstack/navigation/types';
-import { aspectRatio, screenHeight } from '@cardstack/utils';
+import { aspectRatio, hitSlop, screenHeight } from '@cardstack/utils';
 
 const COLOR_LENGTH = 7;
 
@@ -87,7 +87,7 @@ const ColorPickerModal = () => {
         borderRadius={layouts.dot.radius}
         flex={0.4}
       >
-        <Touchable onPress={onSelect}>
+        <Touchable onPress={onSelect} hitSlop={hitSlop.small}>
           <Text fontSize={14} textAlign="right" fontWeight="bold">
             Done
           </Text>

--- a/cardstack/src/screens/ColorPickerModal.tsx
+++ b/cardstack/src/screens/ColorPickerModal.tsx
@@ -1,10 +1,36 @@
 import { useNavigation, useRoute } from '@react-navigation/native';
-import React, { useCallback, useEffect, memo, useState } from 'react';
+import chroma from 'chroma-js';
+import React, { useCallback, useEffect, memo, useState, useMemo } from 'react';
 import { Keyboard } from 'react-native';
 import ColorPicker from 'react-native-wheel-color-picker';
 
-import { Button, Container, Sheet } from '@cardstack/components';
+import {
+  CenteredContainer,
+  Container,
+  Input,
+  Text,
+  Touchable,
+} from '@cardstack/components';
 import { RouteType } from '@cardstack/navigation/types';
+import { aspectRatio, screenHeight } from '@cardstack/utils';
+
+const COLOR_LENGTH = 7;
+
+const layouts = {
+  dot: {
+    size: 20,
+    radius: 20,
+  },
+  wrapper: {
+    paddingTop: '30%',
+  },
+  wheelStyle: {
+    minHeight: undefined,
+    maxWidth: undefined,
+    justifyContent: 'flex-start',
+    height: screenHeight * aspectRatio * 0.12,
+  },
+};
 
 type ColorPickerModalRouteType = RouteType<{
   defaultColor?: string;
@@ -29,22 +55,84 @@ const ColorPickerModal = () => {
     goBack();
   }, [goBack, onSelectColor, selectedColor]);
 
+  const onColorChange = useCallback(color => {
+    setSelectedColor(color.toUpperCase());
+  }, []);
+
+  const onChangeColorText = useCallback(
+    text => {
+      if (text.length === COLOR_LENGTH && chroma.valid(text)) {
+        onColorChange(chroma(text).hex());
+      }
+    },
+    [onColorChange]
+  );
+
+  const colorDotStyle = useMemo(() => ({ backgroundColor: selectedColor }), [
+    selectedColor,
+  ]);
+
   return (
-    <Sheet scrollEnabled={false}>
-      <Container paddingHorizontal={5}>
-        <ColorPicker
-          color={selectedColor}
-          onColorChangeComplete={setSelectedColor}
-          thumbSize={40}
-          sliderSize={20}
-          noSnap={true}
-          row={false}
-        />
-        <Container alignItems="center" marginTop={8}>
-          <Button onPress={onSelect}>Select</Button>
+    <Container
+      flex={1}
+      justifyContent="flex-end"
+      flexDirection="column-reverse"
+      alignItems="center"
+      style={layouts.wrapper}
+    >
+      <Container
+        padding={5}
+        width="70%"
+        backgroundColor="white"
+        borderRadius={layouts.dot.radius}
+        flex={0.4}
+      >
+        <Touchable onPress={onSelect}>
+          <Text fontSize={14} textAlign="right" fontWeight="bold">
+            Done
+          </Text>
+        </Touchable>
+        <Container flex={1} paddingVertical={5}>
+          <ColorPicker
+            //@ts-expect-error custom patched property
+            wheelStyle={layouts.wheelStyle}
+            color={selectedColor}
+            onColorChange={onColorChange}
+            thumbSize={layouts.dot.size}
+            sliderSize={15}
+            swatches={false}
+            gapSize={0}
+            shadeSliderThumb
+            autoResetSlider
+            noSnap
+            row
+          />
         </Container>
+        <CenteredContainer
+          alignItems="center"
+          justifyContent="center"
+          width="85%"
+          flexDirection="row"
+        >
+          <Container
+            marginRight={2}
+            borderRadius={layouts.dot.radius}
+            height={layouts.dot.size}
+            width={layouts.dot.size}
+            style={colorDotStyle}
+            borderColor="black"
+            borderWidth={0.2}
+          />
+          <Input
+            fontSize={18}
+            defaultValue={selectedColor}
+            onChangeText={onChangeColorText}
+            maxLength={COLOR_LENGTH}
+            autoCapitalize="characters"
+          />
+        </CenteredContainer>
       </Container>
-    </Sheet>
+    </Container>
   );
 };
 

--- a/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
+++ b/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
@@ -1,3 +1,4 @@
+import { useIsFocused } from '@react-navigation/native';
 import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   Animated,
@@ -55,26 +56,33 @@ const styles = StyleSheet.create({
 
 export const ProfileNameScreen = () => {
   const {
-    profileUrl,
-    profileName,
+    profile,
     onSkipPress,
     onContinuePress,
     onChangeText,
+    onPressEditColor,
   } = useProfileNameScreen();
 
   const animated = useRef(new Animated.Value(0)).current;
 
   const { height, width } = useWindowDimensions();
 
+  const isFocused = useIsFocused();
+
   const animatePhoneOnKeyboardEvent = useCallback(
     (toValue: Animation) => () => {
+      // avoid animating on background of color picker
+      if (!isFocused) {
+        return;
+      }
+
       Animated.timing(animated, {
         toValue,
         duration: 250,
         useNativeDriver: true,
       }).start();
     },
-    [animated]
+    [animated, isFocused]
   );
 
   useEffect(() => {
@@ -190,7 +198,12 @@ export const ProfileNameScreen = () => {
           <Text fontSize={12} color="grayText" paddingBottom={2}>
             {strings.editColor}
           </Text>
-          <Button variant="smallTertiary" height={40} width={110}>
+          <Button
+            variant="smallTertiary"
+            height={40}
+            width={110}
+            onPress={onPressEditColor}
+          >
             Placeholder
           </Button>
         </CenteredContainer>
@@ -203,12 +216,15 @@ export const ProfileNameScreen = () => {
       >
         <Animated.View style={phonePreviewStyles}>
           <ProfilePhonePreview
-            profileUrl={profileUrl}
-            profileName={profileName || strings.input.placeholder}
+            url={profile.slug}
+            name={profile.name || strings.input.placeholder}
+            color={profile.color}
+            textColor={profile['text-color']}
           />
         </Animated.View>
       </Container>
       <KeyboardAvoidingView
+        enabled={isFocused}
         behavior="position"
         style={styles.avoidViewContainer}
         contentContainerStyle={styles.avoidViewContent}
@@ -240,7 +256,7 @@ export const ProfileNameScreen = () => {
         </Container>
       </KeyboardAvoidingView>
       <CenteredContainer flex={0.2} paddingBottom={2}>
-        <Button disabled={!profileName} onPress={onContinuePress}>
+        <Button disabled={!profile.name} onPress={onContinuePress}>
           {strings.btns.continue}
         </Button>
       </CenteredContainer>

--- a/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
+++ b/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
@@ -17,9 +17,13 @@ import {
   Input,
   SafeAreaView,
   Text,
+  Touchable,
 } from '@cardstack/components';
-import { colors, SPACING_MULTIPLIER } from '@cardstack/theme';
-import { fontFamilyVariants } from '@cardstack/theme/fontFamilyVariants';
+import {
+  colors,
+  SPACING_MULTIPLIER,
+  fontFamilyVariants,
+} from '@cardstack/theme';
 import { Device } from '@cardstack/utils';
 
 import { deviceDimensions } from '@rainbow-me/hooks/useDimensions';
@@ -36,6 +40,10 @@ enum Animation {
 const layouts = {
   defaultPadding: 5,
   keyboardVerticalOffset: Device.isIOS ? 15 : 95,
+  dot: {
+    size: 24,
+    radius: 50,
+  },
 };
 
 const styles = StyleSheet.create({
@@ -173,6 +181,10 @@ export const ProfileNameScreen = () => {
     [animated]
   );
 
+  const colorDotStyle = useMemo(() => ({ backgroundColor: profile.color }), [
+    profile.color,
+  ]);
+
   return (
     <SafeAreaView
       backgroundColor="backgroundDarkPurple"
@@ -198,14 +210,27 @@ export const ProfileNameScreen = () => {
           <Text fontSize={12} color="grayText" paddingBottom={2}>
             {strings.editColor}
           </Text>
-          <Button
-            variant="smallTertiary"
-            height={40}
-            width={110}
+          <Touchable
+            borderColor="borderBlue"
+            borderWidth={1}
+            borderRadius={20}
+            padding={2}
             onPress={onPressEditColor}
           >
-            Placeholder
-          </Button>
+            <Container flexDirection="row" justifyContent="space-between">
+              <Container
+                borderRadius={layouts.dot.radius}
+                height={layouts.dot.size}
+                width={layouts.dot.size}
+                style={colorDotStyle}
+                borderColor="white"
+                borderWidth={2}
+              />
+              <Text paddingLeft={3} fontSize={18} color="grayText">
+                {profile.color}
+              </Text>
+            </Container>
+          </Touchable>
         </CenteredContainer>
       </Animated.View>
       <Container

--- a/cardstack/src/screens/Profile/ProfileNameScreen/components/ProfilePhonePreview.tsx
+++ b/cardstack/src/screens/Profile/ProfileNameScreen/components/ProfilePhonePreview.tsx
@@ -2,18 +2,22 @@ import * as React from 'react';
 import { ImageSourcePropType } from 'react-native';
 import Svg, { Rect, Image, G, Path, Text, TSpan } from 'react-native-svg';
 
+import { contrastingTextColor } from '@cardstack/utils';
+
 import QRCodePreview from './QRCodePreview';
 
 interface Props {
-  profileUrl: string;
-  profileName: string;
-  profileColor?: string;
+  url: string;
+  name: string;
+  color?: string;
+  textColor?: string;
 }
 
 const ProfilePhonePreview = ({
-  profileName,
-  profileUrl = 'mandello123.card.xyz',
-  profileColor = '#0089f9',
+  name,
+  url = 'mandello123.card.xyz',
+  color = '#0089f9',
+  textColor = contrastingTextColor(color),
 }: Props) => (
   <Svg width="100%" height="100%" viewBox="0 0 431 520">
     <G data-name="Group 14578" transform="translate(-35 0)">
@@ -28,7 +32,7 @@ const ProfilePhonePreview = ({
       <Path
         data-name="Mobile - Color platter"
         d="M90 226h323a25 25 0 0 1 25 25v619H65V251a25 25 0 0 1 25-25Z"
-        fill={profileColor}
+        fill={color}
       />
       <G data-name="Mask Group" transform="translate(-255 -266)">
         <G fill="#fff">
@@ -39,7 +43,9 @@ const ProfilePhonePreview = ({
             fontSize={13}
             letterSpacing=".015em"
           >
-            <TSpan textAnchor="middle">{profileUrl}</TSpan>
+            <TSpan textAnchor="middle" fill={textColor}>
+              {url}
+            </TSpan>
           </Text>
           <Text
             fontWeight={700}
@@ -47,8 +53,9 @@ const ProfilePhonePreview = ({
             transform="translate(507 539)"
             fontSize={24}
             letterSpacing="-.025em"
+            fill={textColor}
           >
-            <TSpan textAnchor="middle">{profileName}</TSpan>
+            <TSpan textAnchor="middle">{name}</TSpan>
           </Text>
         </G>
         <G data-name="QR module" transform="translate(339 601)">
@@ -172,7 +179,7 @@ const ProfilePhonePreview = ({
                   fontFamily="Helvetica"
                 >
                   <TSpan textAnchor="middle" fill="black">
-                    {profileUrl}
+                    {url}
                   </TSpan>
                 </Text>
               </G>

--- a/cardstack/src/screens/Profile/ProfileNameScreen/useProfileNameScreen.ts
+++ b/cardstack/src/screens/Profile/ProfileNameScreen/useProfileNameScreen.ts
@@ -1,7 +1,9 @@
-import { useRoute } from '@react-navigation/native';
-import { useState, useCallback } from 'react';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { useState, useCallback, useMemo } from 'react';
 
+import { Routes } from '@cardstack/navigation';
 import { RouteType } from '@cardstack/navigation/types';
+import { contrastingTextColor } from '@cardstack/utils';
 
 interface NavParams {
   profileUrl: string;
@@ -9,14 +11,33 @@ interface NavParams {
 
 export const useProfileNameScreen = () => {
   const { params } = useRoute<RouteType<NavParams>>();
+  const { navigate } = useNavigation();
 
   const [profileName, setProfileName] = useState('');
+  const [profileColor, setProfileColor] = useState('#0089f9');
 
   const profileUrl = params?.profileUrl || 'mandello.card.yxz'; // Temp url
+
+  const profile = useMemo(
+    () => ({
+      name: profileName,
+      slug: profileUrl,
+      color: profileColor,
+      'text-color': contrastingTextColor(profileColor),
+    }),
+    [profileColor, profileName, profileUrl]
+  );
 
   const onChangeText = useCallback(text => {
     setProfileName(text);
   }, []);
+
+  const onPressEditColor = useCallback(() => {
+    navigate(Routes.COLOR_PICKER_MODAL, {
+      defaultColor: profileColor,
+      onSelectColor: setProfileColor,
+    });
+  }, [navigate, profileColor]);
 
   const onContinuePress = useCallback(() => {
     // TDB
@@ -31,7 +52,7 @@ export const useProfileNameScreen = () => {
     onSkipPress,
     onContinuePress,
     onChangeText,
-    profileUrl,
-    profileName,
+    onPressEditColor,
+    profile,
   };
 };

--- a/cardstack/src/screens/Profile/ProfileNameScreen/useProfileNameScreen.ts
+++ b/cardstack/src/screens/Profile/ProfileNameScreen/useProfileNameScreen.ts
@@ -14,7 +14,7 @@ export const useProfileNameScreen = () => {
   const { navigate } = useNavigation();
 
   const [profileName, setProfileName] = useState('');
-  const [profileColor, setProfileColor] = useState('#0089f9');
+  const [profileColor, setProfileColor] = useState('#0089F9');
 
   const profileUrl = params?.profileUrl || 'mandello.card.yxz'; // Temp url
 

--- a/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/components/QRCodeOverlay.tsx
+++ b/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/components/QRCodeOverlay.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Svg, { Defs, ClipPath, Path, Rect, Mask } from 'react-native-svg';
 
 import { colors } from '@cardstack/theme';
-import { screenHeight, screenWidth } from '@cardstack/utils';
+import { screenHeight, screenWidth, aspectRatio } from '@cardstack/utils';
 
 const halfScreen = screenWidth / 2;
 
@@ -10,8 +10,6 @@ const fullScreenSizeProps = {
   height: '100%',
   width: '100%',
 };
-
-const aspectRatio = screenHeight / screenWidth;
 
 // CrossHair
 export const CROSSHAIR_SIZE = screenWidth * 0.68;

--- a/cardstack/src/utils/dimension-utils.ts
+++ b/cardstack/src/utils/dimension-utils.ts
@@ -2,3 +2,5 @@ import { Dimensions } from 'react-native';
 
 export const screenWidth = Dimensions.get('screen').width;
 export const screenHeight = Dimensions.get('screen').height;
+
+export const aspectRatio = screenHeight / screenWidth;

--- a/patches/react-native-wheel-color-picker+1.2.0.patch
+++ b/patches/react-native-wheel-color-picker+1.2.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-wheel-color-picker/ColorPicker.js b/node_modules/react-native-wheel-color-picker/ColorPicker.js
+index fd72231..0f4bd10 100644
+--- a/node_modules/react-native-wheel-color-picker/ColorPicker.js
++++ b/node_modules/react-native-wheel-color-picker/ColorPicker.js
+@@ -599,7 +599,7 @@ module.exports = class ColorPicker extends Component {
+ 		return (
+ 			<View style={[ss.root,row?{flexDirection:'row'}:{},style]}>
+ 				{ swatches && !swatchesLast && <View style={[ss.swatches,swatchStyle,swatchFirstStyle]} key={'SW'}>{ this.swatches }</View> }
+-				{ !swatchesOnly && <View style={[ss.wheel]} key={'$1'} onLayout={this.onSquareLayout}>
++				{ !swatchesOnly && <View style={[ss.wheel, this.props.wheelStyle]} key={'$1'} onLayout={this.onSquareLayout}>
+ 					{ this.wheelWidth>0 && <View style={[{padding:thumbSize/2,width:this.wheelWidth,height:this.wheelWidth}]}>
+ 						<View style={[ss.wheelWrap]}>
+ 							<Image style={ss.wheelImg} source={srcWheel} />


### PR DESCRIPTION
### Description

This PR restyles  the color picker modal and handles the color background change on the new profile, the color-picker wheel had a fixed value which was problematic on small devices, so unfortunately I had to apply a patch in order to customize it, there are not a lot of options for this type of wheel, so we'll go with this for now, and if needed we can build our own color-picker, the design is slightly different across devices sizes.

<!-- Please, include a summary of the changes. -->

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots
<img width="300" alt="Screen Shot 2022-07-25 at 17 33 12" src="https://user-images.githubusercontent.com/20520102/180875818-502dfc53-9092-4b14-b9c3-47c86ec566dc.png">
<img width="300" alt="Screen Shot 2022-07-25 at 18 10 44" src="https://user-images.githubusercontent.com/20520102/180875833-cd1befc7-1065-40f2-8c19-5370578be8db.png">



<img width="300" alt="Screen Shot 2022-07-25 at 17 33 18" src="https://user-images.githubusercontent.com/20520102/180875802-4beb9b89-8f49-4da2-99e6-0aa30edc3bb4.png">

![Simulator Screen Recording - iPhone 11 Pro - 2022-07-25 at 18 11 15](https://user-images.githubusercontent.com/20520102/180875721-bb362860-d907-4877-969a-a67d0a1b1ee5.gif)