### PR TITLE
[CS-4299] Adds blocked state to Button component

### DIFF
--- a/cardstack/src/components/Button/Button.tsx
+++ b/cardstack/src/components/Button/Button.tsx
@@ -9,6 +9,7 @@ import {
   border,
   BorderProps,
   backgroundColor,
+  opacity,
 } from '@shopify/restyle';
 import React, { ReactNode, useMemo } from 'react';
 import { ActivityIndicator, StyleSheet } from 'react-native';
@@ -35,6 +36,7 @@ interface ButtonProps extends RestyleProps {
   onPress?: () => void;
   onLongPress?: () => void;
   loading?: boolean;
+  blocked?: boolean;
   disablePress?: boolean;
   testID?: string;
 }
@@ -48,7 +50,7 @@ const VariantRestyleComponent = createVariant({
 const AnimatedButton = createRestyleComponent<ButtonProps, Theme>(
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  [layout, spacing, border, VariantRestyleComponent, backgroundColor],
+  [layout, spacing, border, opacity, VariantRestyleComponent, backgroundColor],
   AnimatedPressable
 );
 
@@ -69,6 +71,7 @@ export const Button = ({
   disablePress = false,
   iconPosition = 'left',
   loading,
+  blocked,
   onPress,
   onLongPress,
   ...props
@@ -96,8 +99,9 @@ export const Button = ({
     () => ({
       ...mergedStyles,
       ...(disabled ? { ...disabledVariantStyles } : {}),
+      opacity: blocked ? 0.35 : 1.0,
     }),
-    [disabled, disabledVariantStyles, mergedStyles]
+    [disabled, blocked, disabledVariantStyles, mergedStyles]
   );
 
   const disabledTextProps = disabled ? disabledTextStyle : {};
@@ -106,7 +110,7 @@ export const Button = ({
     <AnimatedButton
       {...variantMergedStyles}
       {...props}
-      disabled={disabled || disablePress || loading}
+      disabled={disabled || disablePress || loading || blocked}
       onPress={onPress}
       onLongPress={onLongPress}
     >

--- a/cardstack/src/screens/Dev/DesignSystemScreen.tsx
+++ b/cardstack/src/screens/Dev/DesignSystemScreen.tsx
@@ -23,7 +23,7 @@ const DesignSystemScreen = () => {
       data: ['slug'],
     },
     {
-      title: 'Buttom States',
+      title: 'Button States',
       data: ['longPress', 'loading', 'blocked'],
     },
     {
@@ -75,7 +75,7 @@ const DesignSystemScreen = () => {
             </CenteredContainer>
           );
 
-        case 'Buttom States':
+        case 'Button States':
           return (
             <CenteredContainer padding={2}>
               {renderButtonStates(item)}

--- a/cardstack/src/screens/Dev/DesignSystemScreen.tsx
+++ b/cardstack/src/screens/Dev/DesignSystemScreen.tsx
@@ -23,8 +23,8 @@ const DesignSystemScreen = () => {
       data: ['slug'],
     },
     {
-      title: 'Hold to confirm Button',
-      data: ['1'],
+      title: 'Buttom States',
+      data: ['longPress', 'loading', 'blocked'],
     },
     {
       title: 'Biometric Switch',
@@ -41,6 +41,24 @@ const DesignSystemScreen = () => {
     Alert.alert('long press');
   };
 
+  const renderButtonStates = useCallback(
+    item => {
+      switch (item) {
+        case 'longPress':
+          return (
+            <Button loading={loading} onLongPress={longPress}>
+              Hold for action
+            </Button>
+          );
+        case 'loading':
+          return <Button loading>{item}</Button>;
+        case 'blocked':
+          return <Button blocked>{item}</Button>;
+      }
+    },
+    [loading]
+  );
+
   const renderItem = useCallback(
     ({ item, section: { title } }) => {
       switch (title) {
@@ -56,12 +74,11 @@ const DesignSystemScreen = () => {
               <Button variant={item}>{item}</Button>
             </CenteredContainer>
           );
-        case 'Hold to confirm Button':
+
+        case 'Buttom States':
           return (
             <CenteredContainer padding={2}>
-              <Button loading={loading} onLongPress={longPress}>
-                Hold for action
-              </Button>
+              {renderButtonStates(item)}
             </CenteredContainer>
           );
         case 'Biometric Switch':
@@ -72,7 +89,7 @@ const DesignSystemScreen = () => {
           );
       }
     },
-    [loading]
+    [renderButtonStates]
   );
 
   return (


### PR DESCRIPTION
### Description

This PR adds the new `blocked` button state. It's a state instead of a variant because we want to be able to apply the state to any variant. It sets an opacity to the button and blocks interactions.

- [x] Completes #(CS-4299)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/181096302-4fd78b51-6a34-4699-a3b6-01c163b46dd4.png">
