### PR TITLE
[CS-4260] Create navigator for In-app purchase screens

### DIFF
--- a/cardstack/src/navigation/hooks.tsx
+++ b/cardstack/src/navigation/hooks.tsx
@@ -1,11 +1,11 @@
 import { useNavigation } from '@react-navigation/native';
-import { createStackNavigator } from '@react-navigation/stack';
 import React, { useCallback } from 'react';
 import { InteractionManager } from 'react-native';
 
 import Navigation from './Navigation';
 import { MainRoutes, Routes } from './routes';
 import { MainScreens, ScreenNavigation } from './screens';
+import { StackType } from './types';
 
 // Not a big fan of returning components inside hooks,
 // but react-navigation does not allow components other than Screen
@@ -13,7 +13,7 @@ import { MainScreens, ScreenNavigation } from './screens';
 const getScreens = (
   routes: Record<string, string>,
   screens: Record<string, ScreenNavigation>,
-  Stack: ReturnType<typeof createStackNavigator>
+  Stack: StackType
 ) =>
   Object.entries(screens).map(([name, props]) => (
     <Stack.Screen
@@ -23,9 +23,8 @@ const getScreens = (
     />
   ));
 
-export const useCardstackMainScreens = (
-  Stack: ReturnType<typeof createStackNavigator>
-) => getScreens(MainRoutes, MainScreens, Stack);
+export const useCardstackMainScreens = (Stack: StackType) =>
+  getScreens(MainRoutes, MainScreens, Stack);
 
 // Once we merge the routes, we can type it better
 export const useDismissCurrentRoute = (routeName: string) => {

--- a/cardstack/src/navigation/index.ts
+++ b/cardstack/src/navigation/index.ts
@@ -2,6 +2,6 @@ export * from './hooks';
 export * from './routes';
 export * from './screens';
 export * from './presetOptions';
-export * from './profileNavigator';
+export * from './profileScreenGroup';
 export { default as AppContainer } from './navigator';
 export { default as Navigation } from './Navigation';

--- a/cardstack/src/navigation/index.ts
+++ b/cardstack/src/navigation/index.ts
@@ -2,5 +2,6 @@ export * from './hooks';
 export * from './routes';
 export * from './screens';
 export * from './presetOptions';
+export * from './profileNavigator';
 export { default as AppContainer } from './navigator';
 export { default as Navigation } from './Navigation';

--- a/cardstack/src/navigation/profileNavigator.tsx
+++ b/cardstack/src/navigation/profileNavigator.tsx
@@ -1,4 +1,3 @@
-import { createStackNavigator } from '@react-navigation/stack';
 import React from 'react';
 
 import {
@@ -7,13 +6,11 @@ import {
   ProfilePurchaseCTA,
 } from '@cardstack/screens';
 
+import { StackType } from './types';
+
 import { horizontalInterpolator, Routes } from '.';
 
-export const ProfileNavigation = ({
-  Stack,
-}: {
-  Stack: ReturnType<typeof createStackNavigator>;
-}) => (
+export const ProfileNavigation = ({ Stack }: { Stack: StackType }) => (
   <Stack.Group screenOptions={horizontalInterpolator}>
     <Stack.Screen component={ProfileNameScreen} name={Routes.PROFILE_NAME} />
     <Stack.Screen component={ProfileSlugScreen} name={Routes.PROFILE_SLUG} />

--- a/cardstack/src/navigation/profileNavigator.tsx
+++ b/cardstack/src/navigation/profileNavigator.tsx
@@ -1,0 +1,42 @@
+import { createStackNavigator } from '@react-navigation/stack';
+import React from 'react';
+
+import {
+  ProfileNameScreen,
+  ProfileSlugScreen,
+  ProfilePurchaseCTA,
+} from '@cardstack/screens';
+
+import { horizontalInterpolator, Routes } from '.';
+
+export const ProfileNavigation = ({
+  Stack,
+}: {
+  Stack: ReturnType<typeof createStackNavigator>;
+}) => (
+  <Stack.Group>
+    <Stack.Screen
+      component={ProfileNameScreen}
+      name={Routes.PROFILE_NAME}
+      options={horizontalInterpolator}
+    />
+    <Stack.Screen
+      component={ProfileSlugScreen}
+      name={Routes.PROFILE_SLUG}
+      options={horizontalInterpolator}
+    />
+    <Stack.Screen
+      component={ProfilePurchaseCTA}
+      name={Routes.PROFILE_PURCHASE_CTA}
+      options={horizontalInterpolator}
+    />
+    <Stack.Screen
+      component={() => {
+        // TODO replace this with the correct screen
+        return null;
+      }}
+      name={Routes.PROFILE_CHARGE_EXPLANATION}
+      options={horizontalInterpolator}
+    />
+  </Stack.Group>
+);

--- a/cardstack/src/navigation/profileNavigator.tsx
+++ b/cardstack/src/navigation/profileNavigator.tsx
@@ -14,21 +14,12 @@ export const ProfileNavigation = ({
 }: {
   Stack: ReturnType<typeof createStackNavigator>;
 }) => (
-  <Stack.Group>
-    <Stack.Screen
-      component={ProfileNameScreen}
-      name={Routes.PROFILE_NAME}
-      options={horizontalInterpolator}
-    />
-    <Stack.Screen
-      component={ProfileSlugScreen}
-      name={Routes.PROFILE_SLUG}
-      options={horizontalInterpolator}
-    />
+  <Stack.Group screenOptions={horizontalInterpolator}>
+    <Stack.Screen component={ProfileNameScreen} name={Routes.PROFILE_NAME} />
+    <Stack.Screen component={ProfileSlugScreen} name={Routes.PROFILE_SLUG} />
     <Stack.Screen
       component={ProfilePurchaseCTA}
       name={Routes.PROFILE_PURCHASE_CTA}
-      options={horizontalInterpolator}
     />
     <Stack.Screen
       component={() => {
@@ -36,7 +27,6 @@ export const ProfileNavigation = ({
         return null;
       }}
       name={Routes.PROFILE_CHARGE_EXPLANATION}
-      options={horizontalInterpolator}
     />
   </Stack.Group>
 );

--- a/cardstack/src/navigation/profileScreenGroup.tsx
+++ b/cardstack/src/navigation/profileScreenGroup.tsx
@@ -10,7 +10,7 @@ import { StackType } from './types';
 
 import { horizontalInterpolator, Routes } from '.';
 
-export const ProfileNavigation = ({ Stack }: { Stack: StackType }) => (
+export const ProfileScreenGroup = ({ Stack }: { Stack: StackType }) => (
   <Stack.Group screenOptions={horizontalInterpolator}>
     <Stack.Screen component={ProfileNameScreen} name={Routes.PROFILE_NAME} />
     <Stack.Screen component={ProfileSlugScreen} name={Routes.PROFILE_SLUG} />

--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -33,10 +33,6 @@ export const MainRoutes = {
   SUPPORT_AND_FEES: 'SupportAndFeesSheet',
   AVAILABLE_BALANCE_SHEET: 'AvailableBalanceSheet',
   TOKEN_WITH_CHART_SHEET: 'TokenWithChartSheet',
-  PROFILE_SLUG: 'ProfileSlug',
-  PROFILE_PURCHASE_CTA: 'ProfilePurchaseCTA',
-  PROFILE_NAME: 'ProfileName',
-  PROFILE_CHARGE_EXPLANATION: 'ProfileChargeExplanation',
 } as const;
 
 const TabRoutes = {
@@ -67,10 +63,18 @@ export const NonAuthRoutes = {
   WELCOME_SCREEN: 'WelcomeScreen',
 } as const;
 
+const ProfileRoutes = {
+  PROFILE_SLUG: 'ProfileSlug',
+  PROFILE_PURCHASE_CTA: 'ProfilePurchaseCTA',
+  PROFILE_NAME: 'ProfileName',
+  PROFILE_CHARGE_EXPLANATION: 'ProfileChargeExplanation',
+};
+
 export const Routes = {
   UNLOCK_SCREEN: 'UnlockScreen',
   ...SharedRoutes,
   ...NonMigratedRoutes,
   ...TabRoutes,
   ...MainRoutes,
+  ...ProfileRoutes,
 } as const;

--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -33,6 +33,10 @@ export const MainRoutes = {
   SUPPORT_AND_FEES: 'SupportAndFeesSheet',
   AVAILABLE_BALANCE_SHEET: 'AvailableBalanceSheet',
   TOKEN_WITH_CHART_SHEET: 'TokenWithChartSheet',
+  PROFILE_SLUG: 'ProfileSlug',
+  PROFILE_PURCHASE_CTA: 'ProfilePurchaseCTA',
+  PROFILE_NAME: 'ProfileName',
+  PROFILE_CHARGE_EXPLANATION: 'ProfileChargeExplanation',
 } as const;
 
 const TabRoutes = {

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -40,6 +40,7 @@ import {
   horizontalInterpolator,
   NonAuthRoutes,
   overlayPreset,
+  ProfileNavigation,
   Routes,
   sheetPreset,
 } from '.';
@@ -237,6 +238,7 @@ export const StackNavigator = () => {
         </>
       )}
       {SharedScreens({ navigationKey: !hasWallet ? 'non-auth' : 'auth' })}
+      {ProfileNavigation({ Stack })}
     </Stack.Navigator>
   );
 };

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -40,7 +40,7 @@ import {
   horizontalInterpolator,
   NonAuthRoutes,
   overlayPreset,
-  ProfileNavigation,
+  ProfileScreenGroup,
   Routes,
   sheetPreset,
 } from '.';
@@ -238,7 +238,7 @@ export const StackNavigator = () => {
         </>
       )}
       {SharedScreens({ navigationKey: !hasWallet ? 'non-auth' : 'auth' })}
-      {ProfileNavigation({ Stack })}
+      {ProfileScreenGroup({ Stack })}
     </Stack.Navigator>
   );
 };

--- a/cardstack/src/navigation/types.ts
+++ b/cardstack/src/navigation/types.ts
@@ -1,5 +1,9 @@
+import { createStackNavigator } from '@react-navigation/stack';
+
 export interface RouteType<Params> {
   params: Params;
   key: string;
   name: string;
 }
+
+export type StackType = ReturnType<typeof createStackNavigator>;

--- a/cardstack/src/screens/Profile/ProfileSlugScreen/strings.ts
+++ b/cardstack/src/screens/Profile/ProfileSlugScreen/strings.ts
@@ -7,7 +7,6 @@ export const strings = {
       'This unique ID will be used to identify your payment profile. Please note this ID cannot be changed once the profile is created and may be used as a contact address.',
   },
   buttons: {
-    skip: 'Skip',
     continue: 'Continue',
   },
 };

--- a/cardstack/src/screens/Profile/PurchaseCTAScreen/strings.ts
+++ b/cardstack/src/screens/Profile/PurchaseCTAScreen/strings.ts
@@ -1,5 +1,4 @@
 export const strings = {
-  skip: 'Skip',
   title: 'Purchase a CardSpace\nProfile to do the following:',
   benefits: {
     payments: 'Accept payments from customers',

--- a/cardstack/src/screens/Profile/index.ts
+++ b/cardstack/src/screens/Profile/index.ts
@@ -1,3 +1,3 @@
 export { default as ProfileNameScreen } from './ProfileNameScreen/ProfileNameScreen';
 export { default as ProfileSlugScreen } from './ProfileSlugScreen/ProfileSlugScreen';
-export { default as PurchaseCTAScreen } from './PurchaseCTAScreen/PurchaseCTAScreen';
+export { default as ProfilePurchaseCTA } from './PurchaseCTAScreen/PurchaseCTAScreen';


### PR DESCRIPTION
### Description
This PR creates a navigator for the In-app purchase screens. There's no particular order defined yet, so I went with the order we have implemented the screens.

While in the area, I noticed that I forgot to delete the `skip` copy from the screens that are using the `InPageHeader` component, so I'm removing them too.

- [x] Completes #CS-4260

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
