### PR TITLE
[CS-4304]: Add inPageHeader to ProfileNameScreen

### DIFF
--- a/cardstack/src/components/MainHeader/InPageHeader.tsx
+++ b/cardstack/src/components/MainHeader/InPageHeader.tsx
@@ -29,8 +29,8 @@ const InPageHeader = ({
     <Container
       flexDirection="row"
       alignItems="center"
+      minHeight="5%"
       justifyContent={showLeftIcon ? 'space-between' : 'flex-end'}
-      flex={0.1}
     >
       {showLeftIcon && (
         <Icon

--- a/cardstack/src/components/MainHeader/InPageHeader.tsx
+++ b/cardstack/src/components/MainHeader/InPageHeader.tsx
@@ -44,7 +44,7 @@ const InPageHeader = ({
       )}
       {showSkipButton && (
         <Touchable onPress={onSkipPress || goBack}>
-          <Text fontSize={13} color="teal" weight="semibold">
+          <Text fontSize={13} color="teal" variant="semibold">
             Skip
           </Text>
         </Touchable>

--- a/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
+++ b/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
@@ -172,7 +172,6 @@ export const ProfileNameScreen = () => {
 
   const animatedHeaderStyles = useMemo(
     () => ({
-      paddingTop: 10,
       flex: 0.4,
       justifyContent: 'space-between' as const,
       opacity: animated.interpolate({
@@ -194,8 +193,8 @@ export const ProfileNameScreen = () => {
       paddingHorizontal={layouts.defaultPadding}
       justifyContent="space-between"
     >
-      <InPageHeader onSkipPress={onSkipPress} showLeftIcon={false} />
       <Animated.View style={animatedHeaderStyles}>
+        <InPageHeader onSkipPress={onSkipPress} showLeftIcon={false} />
         <Text fontSize={24} color="white" {...fontFamilyVariants.light}>
           {strings.header}
         </Text>

--- a/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
+++ b/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
@@ -14,6 +14,7 @@ import {
   Button,
   CenteredContainer,
   Container,
+  InPageHeader,
   Input,
   SafeAreaView,
   Text,
@@ -171,6 +172,7 @@ export const ProfileNameScreen = () => {
 
   const animatedHeaderStyles = useMemo(
     () => ({
+      paddingTop: 10,
       flex: 0.4,
       justifyContent: 'space-between' as const,
       opacity: animated.interpolate({
@@ -192,16 +194,7 @@ export const ProfileNameScreen = () => {
       paddingHorizontal={layouts.defaultPadding}
       justifyContent="space-between"
     >
-      <Container flex={0.15} alignItems="flex-end" paddingVertical={2}>
-        <Text
-          fontSize={13}
-          color="teal"
-          onPress={onSkipPress}
-          fontWeight="bold"
-        >
-          {strings.btns.skip}
-        </Text>
-      </Container>
+      <InPageHeader onSkipPress={onSkipPress} showLeftIcon={false} />
       <Animated.View style={animatedHeaderStyles}>
         <Text fontSize={24} color="white" {...fontFamilyVariants.light}>
           {strings.header}


### PR DESCRIPTION
### Description

This PR adds the InPageHeader to the ProfileNameScreen, I modified the header to use minHeight instead of flex, since flex is relative to the screen, `flex=0.1`  gives diff height on screens with different flex positions. Also it fixes the skip button not being bold on Android.


### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->

<img width="300" alt="image" src="https://user-images.githubusercontent.com/20520102/181103050-c6d50ac4-015b-4743-86c3-909728a3230a.png">

![Simulator Screen Recording - iPhone 11 Pro - 2022-07-26 at 16 52 24](https://user-images.githubusercontent.com/20520102/181103092-46d131cb-9c01-4ec0-843d-0cd70faaf0e4.gif)

