### PR TITLE
[CS-4341]: Add nonStacking nav anim on iap flow, and replace popping with opacity btn

### DIFF
--- a/cardstack/src/components/AnimatedPressable/AnimatedPressable.tsx
+++ b/cardstack/src/components/AnimatedPressable/AnimatedPressable.tsx
@@ -4,8 +4,8 @@ import {
   PressableProps,
   Animated,
   ViewStyle,
-  StyleSheet,
   GestureResponderEvent,
+  Easing,
 } from 'react-native';
 import ReactNativeHapticFeedback, {
   HapticFeedbackTypes,
@@ -14,23 +14,15 @@ import ReactNativeHapticFeedback, {
 import { delayLongPressMs } from '@cardstack/constants';
 import { Device } from '@cardstack/utils';
 
-enum Scale {
-  grow = 0,
-  shrink = 1,
+enum Opacity {
+  fadeIn = 0,
+  fadeOut = 1,
 }
 
-const scaleRatio = {
+const opacityRange = {
   full: 1,
-  decreased: 0.9,
+  decreased: 0.7,
 };
-
-const styles = StyleSheet.create({
-  centeredContainer: {
-    flexShrink: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-});
 
 interface AnimatedPressableProps extends PressableProps {
   enableHapticFeedback?: boolean;
@@ -43,14 +35,14 @@ const AnimatedPressable = ({
   hapticType = 'selection',
   ...props
 }: AnimatedPressableProps) => {
-  const animatedValue = useRef(new Animated.Value(Scale.grow)).current;
+  const animatedValue = useRef(new Animated.Value(Opacity.fadeOut)).current;
 
   const onPressAnimate = useCallback(
-    (toValue: Scale) => () => {
-      Animated.spring(animatedValue, {
+    (toValue: Opacity) => () => {
+      Animated.timing(animatedValue, {
         toValue,
-        bounciness: 3,
-        speed: 100,
+        duration: 100,
+        easing: Easing.inOut(Easing.quad),
         useNativeDriver: true,
       }).start();
     },
@@ -59,15 +51,10 @@ const AnimatedPressable = ({
 
   const animatedStyle: Animated.WithAnimatedObject<ViewStyle> = useMemo(
     () => ({
-      ...styles,
-      transform: [
-        {
-          scale: animatedValue.interpolate({
-            inputRange: [Scale.grow, Scale.shrink],
-            outputRange: [scaleRatio.full, scaleRatio.decreased],
-          }),
-        },
-      ],
+      opacity: animatedValue.interpolate({
+        inputRange: [Opacity.fadeIn, Opacity.fadeOut],
+        outputRange: [opacityRange.decreased, opacityRange.full],
+      }),
     }),
     [animatedValue]
   );
@@ -100,8 +87,8 @@ const AnimatedPressable = ({
     <Animated.View style={animatedStyle} pointerEvents="box-none">
       <Pressable
         {...props}
-        onPressIn={onPressAnimate(Scale.shrink)}
-        onPressOut={onPressAnimate(Scale.grow)}
+        onPressIn={onPressAnimate(Opacity.fadeIn)}
+        onPressOut={onPressAnimate(Opacity.fadeOut)}
         onPress={handleOnPress}
         onLongPress={handleLongPress}
         delayLongPress={delayLongPressMs}

--- a/cardstack/src/navigation/presetOptions.ts
+++ b/cardstack/src/navigation/presetOptions.ts
@@ -3,7 +3,7 @@ import {
   StackCardInterpolationProps,
   StackNavigationOptions,
 } from '@react-navigation/stack';
-import { Keyboard } from 'react-native';
+import { Animated, Keyboard } from 'react-native';
 
 import { colors } from '@cardstack/theme';
 import { Device } from '@cardstack/utils';
@@ -13,6 +13,38 @@ import { ScreenNavigation } from './screens';
 export const horizontalInterpolator: StackNavigationOptions = {
   cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
   gestureDirection: 'horizontal',
+};
+
+export const horizontalNonStackingInterpolator: StackNavigationOptions = {
+  cardStyleInterpolator: ({ current, next, inverted, layouts: { screen } }) => {
+    const translateFocused = Animated.multiply(
+      current.progress.interpolate({
+        inputRange: [0, 1],
+        outputRange: [screen.width, 0],
+      }),
+      inverted
+    );
+
+    const translateUnfocused = next
+      ? Animated.multiply(
+          next.progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0, -screen.width],
+          }),
+          inverted
+        )
+      : 0;
+
+    return {
+      cardStyle: {
+        transform: [
+          {
+            translateX: Animated.add(translateFocused, translateUnfocused),
+          },
+        ],
+      },
+    };
+  },
 };
 
 const forFade = ({ current }: StackCardInterpolationProps) => ({

--- a/cardstack/src/navigation/profileScreenGroup.tsx
+++ b/cardstack/src/navigation/profileScreenGroup.tsx
@@ -9,10 +9,16 @@ import {
 
 import { StackType } from './types';
 
-import { horizontalInterpolator, Routes } from '.';
+import { horizontalNonStackingInterpolator, Routes } from '.';
 
 export const ProfileScreenGroup = ({ Stack }: { Stack: StackType }) => (
-  <Stack.Group screenOptions={horizontalInterpolator}>
+  <Stack.Group
+    screenOptions={{
+      ...horizontalNonStackingInterpolator,
+      presentation: 'card',
+      detachPreviousScreen: false,
+    }}
+  >
     <Stack.Screen component={ProfileNameScreen} name={Routes.PROFILE_NAME} />
     <Stack.Screen component={ProfileSlugScreen} name={Routes.PROFILE_SLUG} />
     <Stack.Screen


### PR DESCRIPTION
### Description
This PR adds a new nav animation without overlapping, it also replaces the scaling btn animation with an opacity one, this change though affects the whole app so let's be aware of possible bugs.


### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->

![Simulator Screen Recording - iPhone 11 Pro - 2022-07-29 at 08 49 48](https://user-images.githubusercontent.com/20520102/181752683-c3873291-b46e-491c-9c2b-68d9c053263a.gif)


