### PR TITLE
Moves profile purchase test-drive option under DEV

### DIFF
--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -207,13 +207,13 @@ export default function SettingsSection({
             label="Design System"
             onPress={onPressDS}
           />
+          <ListItem
+            icon={<Icon color="black" name="shopping-cart" />}
+            label="Profile Purchase Test-Drive"
+            onPress={onPressIAP}
+          />
         </>
       )}
-      <ListItem
-        icon={<Icon color="black" name="shopping-cart" />}
-        label="Profile Purchase Test-Drive"
-        onPress={onPressIAP}
-      />
       <CenteredContainer flex={1} paddingBottom={8} paddingTop={2}>
         <AppVersionStamp />
       </CenteredContainer>


### PR DESCRIPTION
### Description

This PR removes Profile Purchase Test-Drive option from settings menu.

Onboarding will be accessible by iOS users on 1.1.6 version, defined in Remote Config.

*update* Reverted removal, now still present but only in DEV.