### PR TITLE
[CS-4122]: Add prepaidCard btn on profile flow

### DIFF
--- a/cardstack/src/screens/Profile/PurchaseCTAScreen/PurchaseCTAScreen.tsx
+++ b/cardstack/src/screens/Profile/PurchaseCTAScreen/PurchaseCTAScreen.tsx
@@ -28,6 +28,8 @@ const PurchaseCTAScreen = () => {
     onPressChargeExplanation,
     onPressBuy,
     localizedValue,
+    onPressPrepaidCards,
+    showPrepaidCardOption,
   } = usePurchaseCTAScreen();
 
   const BenefitsItem = useCallback(
@@ -48,7 +50,7 @@ const PurchaseCTAScreen = () => {
     []
   );
 
-  const buttonLabel = `${strings.button} ${localizedValue}`;
+  const purchaseBtnLabel = `${strings.button.purchase} ${localizedValue}`;
 
   return (
     <SafeAreaView
@@ -80,7 +82,16 @@ const PurchaseCTAScreen = () => {
           style={styles.iapPreview}
           resizeMode="contain"
         />
-        <Button onPress={onPressBuy}>{buttonLabel}</Button>
+        <Button onPress={onPressBuy}>{purchaseBtnLabel}</Button>
+        {showPrepaidCardOption && (
+          <Button
+            onPress={onPressPrepaidCards}
+            variant="primaryWhite"
+            borderColor="teal"
+          >
+            {strings.button.prepaidCard}
+          </Button>
+        )}
         <Touchable onPress={onPressChargeExplanation} alignSelf="center">
           <Text color="white" fontSize={16} weight="semibold">
             {strings.whyCharge}

--- a/cardstack/src/screens/Profile/PurchaseCTAScreen/strings.ts
+++ b/cardstack/src/screens/Profile/PurchaseCTAScreen/strings.ts
@@ -7,6 +7,9 @@ export const strings = {
     cardProfile: `Setup a profile page on ${cardSpaceSuffix}`,
     rewards: 'Earn Rewards in the Card Ecosystem',
   },
-  button: 'Buy for',
+  button: {
+    purchase: 'Buy for',
+    prepaidCard: 'Buy with Prepaid Cards',
+  },
   whyCharge: 'Why is there a charge?',
 };

--- a/cardstack/src/screens/Profile/PurchaseCTAScreen/usePurchaseCTAScreen.ts
+++ b/cardstack/src/screens/Profile/PurchaseCTAScreen/usePurchaseCTAScreen.ts
@@ -4,7 +4,11 @@ import { useCallback, useMemo } from 'react';
 import { usePurchaseProfile } from '@cardstack/hooks/usePurchaseProfile';
 import { Routes } from '@cardstack/navigation';
 import { RouteType } from '@cardstack/navigation/types';
+import { useGetSafesDataQuery } from '@cardstack/services';
 import { CreateProfileInfoParams } from '@cardstack/services/hub/hub-types';
+import { isLayer1 } from '@cardstack/utils';
+
+import { useAccountSettings } from '@rainbow-me/hooks';
 
 const defaultPrice = '$0.99';
 interface NavParams {
@@ -13,6 +17,19 @@ interface NavParams {
 
 export const usePurchaseCTAScreen = () => {
   const { navigate } = useNavigation();
+
+  const { network, accountAddress, nativeCurrency } = useAccountSettings();
+
+  const { hasPrepaidCards: showPrepaidCardOption } = useGetSafesDataQuery(
+    { address: accountAddress, nativeCurrency },
+
+    {
+      selectFromResult: ({ data }) => ({
+        hasPrepaidCards: !!data?.prepaidCards?.length,
+      }),
+      skip: isLayer1(network) || !accountAddress,
+    }
+  );
 
   const {
     params: { profile },
@@ -29,9 +46,15 @@ export const usePurchaseCTAScreen = () => {
     navigate(Routes.PROFILE_CHARGE_EXPLANATION, { localizedValue });
   }, [localizedValue, navigate]);
 
+  const onPressPrepaidCards = useCallback(() => {
+    // TBD
+  }, []);
+
   return {
     onPressChargeExplanation,
     onPressBuy: purchaseProfile,
+    onPressPrepaidCards,
+    showPrepaidCardOption,
     localizedValue,
   };
 };


### PR DESCRIPTION
### Description

This PR adds the PrepaidCard option on new profile flow, if the user has any prepaidCards. The logic will be handled on CS-4332, even though it was described on this ticket, it makes more sense to handle on 4332 to avoid duplicating code. 

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->

<img width="350" alt="image" src="https://user-images.githubusercontent.com/20520102/182248138-87b90b69-bbe8-4e76-b23d-528bd6762408.png">
