### PR TITLE
[FIX] New PRODUCT_NAME breaking pod install

### DIFF
--- a/ios/ButtonManager.m
+++ b/ios/ButtonManager.m
@@ -6,7 +6,7 @@
 //
 
 #import "React/RCTViewManager.h"
-#import "Rainbow-Swift.h"
+#import "CardstackWallet-Swift.h"
 
 @interface RCT_EXTERN_MODULE(ButtonManager, RCTViewManager)
 

--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -745,7 +745,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
-				PRODUCT_NAME = Cardstack Wallet;
+				PRODUCT_NAME = "Cardstack Wallet";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
@@ -801,7 +801,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
-				PRODUCT_NAME = Cardstack Wallet;
+				PRODUCT_NAME = "Cardstack Wallet";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
@@ -892,7 +892,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
-				PRODUCT_NAME = Cardstack Wallet;
+				PRODUCT_NAME = "Cardstack Wallet";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
@@ -984,7 +984,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
-				PRODUCT_NAME = Cardstack Wallet;
+				PRODUCT_NAME = "Cardstack Wallet";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";

--- a/ios/Rainbow.xcodeproj/project.pbxproj
+++ b/ios/Rainbow.xcodeproj/project.pbxproj
@@ -745,7 +745,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
-				PRODUCT_NAME = "Cardstack Wallet";
+				PRODUCT_NAME = CardstackWallet;
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
@@ -801,7 +801,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
-				PRODUCT_NAME = "Cardstack Wallet";
+				PRODUCT_NAME = CardstackWallet;
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
@@ -892,7 +892,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
-				PRODUCT_NAME = "Cardstack Wallet";
+				PRODUCT_NAME = CardstackWallet;
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";
@@ -984,7 +984,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cardstack.cardpay;
-				PRODUCT_NAME = "Cardstack Wallet";
+				PRODUCT_NAME = CardstackWallet;
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.cardstack.cardpay";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rainbow-Bridging-Header.h";

--- a/ios/Rainbow.xcodeproj/xcshareddata/xcschemes/Rainbow.xcscheme
+++ b/ios/Rainbow.xcodeproj/xcshareddata/xcschemes/Rainbow.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-               BuildableName = "Rainbow.app"
+               BuildableName = "CardstackWallet.app"
                BlueprintName = "Rainbow"
                ReferencedContainer = "container:Rainbow.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-            BuildableName = "Rainbow.app"
+            BuildableName = "CardstackWallet.app"
             BlueprintName = "Rainbow"
             ReferencedContainer = "container:Rainbow.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-            BuildableName = "Rainbow.app"
+            BuildableName = "CardstackWallet.app"
             BlueprintName = "Rainbow"
             ReferencedContainer = "container:Rainbow.xcodeproj">
          </BuildableReference>
@@ -88,7 +88,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-            BuildableName = "Rainbow.app"
+            BuildableName = "CardstackWallet.app"
             BlueprintName = "Rainbow"
             ReferencedContainer = "container:Rainbow.xcodeproj">
          </BuildableReference>

--- a/ios/Rainbow.xcodeproj/xcshareddata/xcschemes/Release.xcscheme
+++ b/ios/Rainbow.xcodeproj/xcshareddata/xcschemes/Release.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-               BuildableName = "Rainbow.app"
+               BuildableName = "CardstackWallet.app"
                BlueprintName = "Rainbow"
                ReferencedContainer = "container:Rainbow.xcodeproj">
             </BuildableReference>
@@ -45,7 +45,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-            BuildableName = "Rainbow.app"
+            BuildableName = "CardstackWallet.app"
             BlueprintName = "Rainbow"
             ReferencedContainer = "container:Rainbow.xcodeproj">
          </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-            BuildableName = "Rainbow.app"
+            BuildableName = "CardstackWallet.app"
             BlueprintName = "Rainbow"
             ReferencedContainer = "container:Rainbow.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
### Description

The new PRODUCT_NAME value Cardstack Wallet without quotes was causing `pod install` to fail.

This PR adds quotes around new PRODUCT_NAME on pbxproj file.

Not sure why it didn't error on CI runs, maybe it's the architecture or variation in env.