### PR TITLE
[CS-4168] Change app name and show skip on first profile screen

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Cardstack Wallet</string>
+    <string name="app_name">Cardstack</string>
 </resources>

--- a/cardstack/src/screens/Profile/ProfileSlugScreen/ProfileSlugScreen.tsx
+++ b/cardstack/src/screens/Profile/ProfileSlugScreen/ProfileSlugScreen.tsx
@@ -28,7 +28,7 @@ const ProfileSlugScreen = () => {
       paddingHorizontal={5}
       justifyContent="space-between"
     >
-      <InPageHeader showSkipButton={false} />
+      <InPageHeader showLeftIcon={false} />
       <Container flex={0.8}>
         <Container width="90%" paddingBottom={4}>
           <Text variant="pageHeader">{strings.header}</Text>

--- a/ios/Rainbow/Info.plist
+++ b/ios/Rainbow/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Cardstack Wallet</string>
+	<string>Cardstack</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
### Description
This PR solves two things at the same time:

1. Chris asked us to change the name to be "Cardstack" when installing the app;
2. Show the "Skip" button instead of the back button on the first screen of the IAP because it makes more sense for the flow.

- [x] Completes #CS-4168

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

