### PR TITLE
Enhance showOnboarding hook to not show when importing an account

### DIFF
--- a/cardstack/src/hooks/onboarding/useShowOnboarding.ts
+++ b/cardstack/src/hooks/onboarding/useShowOnboarding.ts
@@ -4,19 +4,22 @@ import { usePrimarySafe } from '@cardstack/redux/hooks/usePrimarySafe';
 import { remoteFlags } from '@cardstack/services/remote-config';
 
 export const useShowOnboarding = () => {
-  const { primarySafe, isFetching, isLoading } = usePrimarySafe();
+  const {
+    primarySafe,
+    isFetching,
+    isLoading,
+    isUninitialized,
+  } = usePrimarySafe();
 
   // Using a callback instead of memo to pull the feature flag value on call.
   // That is because the flag is stateles and does not causes react's side-effects,
   // so it will not update the memo value.
   const shouldPresentOnboarding = useCallback(() => {
     return (
-      !isLoading &&
-      !isFetching &&
-      !primarySafe &&
+      !(isLoading && isFetching && primarySafe && isUninitialized) &&
       remoteFlags().featureProfilePurchaseOnboarding
     );
-  }, [isLoading, isFetching, primarySafe]);
+  }, [isLoading, isFetching, primarySafe, isUninitialized]);
 
   return {
     shouldPresentOnboarding,


### PR DESCRIPTION
### Description
This PR adds a new flag to the `shouldPresentOnboarding` so that the IAP flow doesn't show when the user is importing a wallet.  

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
