### PR TITLE
[CS-4343] Adds sentry log to unhandled purchase errors

### DIFF
--- a/cardstack/src/hooks/usePurchaseProfile.ts
+++ b/cardstack/src/hooks/usePurchaseProfile.ts
@@ -149,6 +149,11 @@ export const usePurchaseProfile = (profile: CreateProfileInfoParams) => {
       currentPurchaseError &&
       currentPurchaseError?.code !== 'E_USER_CANCELLED'
     ) {
+      logger.sentry(
+        'Purchase failed with error: ',
+        JSON.stringify(currentPurchaseError)
+      );
+
       Alert(defaultErrorAlert);
     }
   }, [currentPurchaseError]);


### PR DESCRIPTION
### Description

CS-4343 was raised because I once encountered an unhandled error, but unfortunately I can't replicate. So instead, I'm adding a sentry log for unhandled errors in this PR, so we can monitor eventual purchase problems other than the only handled error `E_USER_CANCELLED`.

- [x] Completes #(CS-4343)

