### PR TITLE
[CS-3445] Removes SPEND from BuyPrepaidCard screen

### DIFF
--- a/cardstack/src/screens/BuyPrepaidCard/BuyPrepaidCard.tsx
+++ b/cardstack/src/screens/BuyPrepaidCard/BuyPrepaidCard.tsx
@@ -52,7 +52,6 @@ const BuyPrepaidCard = () => {
           onPress={() => onSelectCard(item, index)}
           isSelected={item?.isSelected}
           amount={item?.amount}
-          faceValue={item?.attributes?.['face-value']}
           quantity={item.attributes?.quantity}
         />
       ),

--- a/cardstack/src/screens/BuyPrepaidCard/Components.tsx
+++ b/cardstack/src/screens/BuyPrepaidCard/Components.tsx
@@ -53,7 +53,6 @@ export const CardContent = ({
   const borderColor = isSelected ? 'buttonPrimaryBorder' : 'borderBlue';
   const variant = isSelected ? 'squareSelected' : 'square';
   const titleColor = isSelected ? 'black' : 'white';
-  const subtitleColor = isSelected ? 'black' : 'buttonSecondaryBorder';
 
   return (
     <CenteredContainer {...styles.cardContainer}>
@@ -63,24 +62,24 @@ export const CardContent = ({
         onPress={onPress}
         disablePress={isSoldOut}
       >
-        <Text
-          color={isSoldOut ? 'blueText' : titleColor}
-          fontSize={28}
-          textAlign="center"
-        >
-          $ {amount}
-        </Text>
-        {isSoldOut && (
+        <Container flexDirection="column">
           <Text
-            color={isSoldOut ? 'buttonSecondaryBorder' : subtitleColor}
-            fontSize={14}
+            color={isSoldOut ? 'blueText' : titleColor}
+            fontSize={28}
             textAlign="center"
-            weight="regular"
           >
-            {`\n`}
-            SOLD OUT
+            $ {amount}
           </Text>
-        )}
+          {isSoldOut && (
+            <Text
+              color="buttonSecondaryBorder"
+              fontSize={14}
+              textAlign="center"
+            >
+              SOLD OUT
+            </Text>
+          )}
+        </Container>
       </Button>
     </CenteredContainer>
   );

--- a/cardstack/src/screens/BuyPrepaidCard/Components.tsx
+++ b/cardstack/src/screens/BuyPrepaidCard/Components.tsx
@@ -40,12 +40,10 @@ export const CardContent = ({
   onPress,
   amount,
   isSelected,
-  faceValue,
   quantity,
 }: {
   onPress: () => void;
   amount: number;
-  faceValue: number;
   isSelected: boolean;
   quantity: number;
 }) => {
@@ -72,15 +70,17 @@ export const CardContent = ({
         >
           $ {amount}
         </Text>
-        <Text
-          color={isSoldOut ? 'buttonSecondaryBorder' : subtitleColor}
-          fontSize={14}
-          textAlign="center"
-          weight="regular"
-        >
-          {`\n`}
-          {isSoldOut ? 'SOLD OUT' : `${faceValue} SPEND`}
-        </Text>
+        {isSoldOut && (
+          <Text
+            color={isSoldOut ? 'buttonSecondaryBorder' : subtitleColor}
+            fontSize={14}
+            textAlign="center"
+            weight="regular"
+          >
+            {`\n`}
+            SOLD OUT
+          </Text>
+        )}
       </Button>
     </CenteredContainer>
   );


### PR DESCRIPTION
### Description

SPEND as face value is deprecated. The screen for purchasing prepaid cards using Apple Pay was still showing SPEND, this PR removes it.

- [x] Completes #(CS-3445)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
~Tested on Android~

### Screenshots

<!-- Use tag bellow to format image size -->

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/183650504-3b8f2bab-8cbd-47d9-bbd7-588715b3d0b5.jpeg">
