### PR TITLE
[Fix]: Avoid showing onboarding on import flow

### DIFF
--- a/cardstack/src/hooks/merchant/__tests__/useShowOnboarding.test.ts
+++ b/cardstack/src/hooks/merchant/__tests__/useShowOnboarding.test.ts
@@ -1,0 +1,121 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useShowOnboarding } from '@cardstack/hooks/onboarding/useShowOnboarding';
+import { usePrimarySafe } from '@cardstack/redux/hooks/usePrimarySafe';
+import { remoteFlags } from '@cardstack/services/remote-config';
+
+jest.mock('@cardstack/redux/hooks/usePrimarySafe', () => ({
+  usePrimarySafe: jest.fn(),
+}));
+
+jest.mock('@cardstack/services/remote-config', () => ({
+  remoteFlags: jest.fn().mockReturnValue({
+    featureProfilePurchaseOnboarding: true,
+  }),
+}));
+
+const mockPrimarySafeHelper = (overwriteParams?: any) =>
+  (usePrimarySafe as jest.Mock).mockImplementation(() => ({
+    primarySafe: undefined,
+    isFetching: false,
+    isLoading: false,
+    isUninitialized: true,
+    ...overwriteParams,
+  }));
+
+describe('useShowOnboarding', () => {
+  it('should have shouldPresentOnboarding flag as FALSE when it`s uninitialized', () => {
+    mockPrimarySafeHelper();
+
+    const {
+      result: {
+        current: { shouldPresentOnboarding },
+      },
+    } = renderHook(() => useShowOnboarding());
+
+    expect(shouldPresentOnboarding()).toBe(false);
+  });
+
+  it('should have shouldPresentOnboarding flag as FALSE while it`s loading', () => {
+    mockPrimarySafeHelper({ isLoading: true, isUninitialized: false });
+
+    const {
+      result: {
+        current: { shouldPresentOnboarding },
+      },
+    } = renderHook(() => useShowOnboarding());
+
+    expect(shouldPresentOnboarding()).toBe(false);
+  });
+
+  it('should have shouldPresentOnboarding flag as FALSE while it`s fetching', () => {
+    mockPrimarySafeHelper({
+      isFetching: true,
+      isLoading: false,
+      isUninitialized: false,
+    });
+
+    const {
+      result: {
+        current: { shouldPresentOnboarding },
+      },
+    } = renderHook(() => useShowOnboarding());
+
+    expect(shouldPresentOnboarding()).toBe(false);
+  });
+
+  it('should have shouldPresentOnboarding flag as FALSE when user already has profile', () => {
+    mockPrimarySafeHelper({
+      primarySafe: { slug: '12323' },
+      isLoading: false,
+      isUninitialized: false,
+    });
+
+    const {
+      result: {
+        current: { shouldPresentOnboarding },
+      },
+    } = renderHook(() => useShowOnboarding());
+
+    expect(shouldPresentOnboarding()).toBe(false);
+  });
+
+  it('should have shouldPresentOnboarding flag as FALSE if remote flag is disabled', () => {
+    (remoteFlags as jest.Mock).mockReturnValueOnce({
+      featureProfilePurchaseOnboarding: false,
+    });
+
+    mockPrimarySafeHelper({
+      primarySafe: undefined,
+      isLoading: false,
+      isUninitialized: false,
+    });
+
+    const {
+      result: {
+        current: { shouldPresentOnboarding },
+      },
+    } = renderHook(() => useShowOnboarding());
+
+    expect(shouldPresentOnboarding()).toBe(false);
+  });
+
+  it('should have shouldPresentOnboarding flag as TRUE when remote flag is enabled, info has been fetched AND user doesn`t own a profile', () => {
+    (remoteFlags as jest.Mock).mockReturnValueOnce({
+      featureProfilePurchaseOnboarding: true,
+    });
+
+    mockPrimarySafeHelper({
+      primarySafe: undefined,
+      isUninitialized: false,
+    });
+
+    const {
+      result: {
+        current: { shouldPresentOnboarding },
+      },
+    } = renderHook(() => useShowOnboarding());
+
+    expect(shouldPresentOnboarding()).toBe(true);
+  });
+});

--- a/cardstack/src/hooks/onboarding/useShowOnboarding.ts
+++ b/cardstack/src/hooks/onboarding/useShowOnboarding.ts
@@ -16,7 +16,10 @@ export const useShowOnboarding = () => {
   // so it will not update the memo value.
   const shouldPresentOnboarding = useCallback(() => {
     return (
-      !(isLoading && isFetching && primarySafe && isUninitialized) &&
+      !isLoading &&
+      !isFetching &&
+      !primarySafe &&
+      !isUninitialized &&
       remoteFlags().featureProfilePurchaseOnboarding
     );
   }, [isLoading, isFetching, primarySafe, isUninitialized]);


### PR DESCRIPTION
### Description

This PR fixes the issue while importing an account which already contains a profile asking to create a new one, the parentheses on the negation matters, and we actually want to check each flag individually. It also adds tests to make sure the expected behavior is correct.
