### PR TITLE
[CS-4353]: Enable iap flow on Android

### DIFF
--- a/cardstack/src/hooks/useProfileJobPolling.ts
+++ b/cardstack/src/hooks/useProfileJobPolling.ts
@@ -21,22 +21,22 @@ interface ProfileJobPollingProps {
  * This hook keeps pooling until the profile is ready.
  */
 export const useProfileJobPolling = ({
-  jobID,
+  jobID = '',
   onJobCompletedCallback,
 }: ProfileJobPollingProps) => {
-  const [polling, startPolling, stopPolling] = useBooleanState();
+  const [polling, startPolling, stopPolling] = useBooleanState(!!jobID);
 
   const { data, error } = useGetProfileJobStatusQuery(
-    { jobTicketID: jobID || '' },
+    { jobTicketID: jobID },
     {
-      pollingInterval: polling ? JOB_POLLING_INTERVAL : undefined,
-      skip: !jobID,
+      pollingInterval: JOB_POLLING_INTERVAL,
+      skip: !jobID || !polling,
     }
   );
 
   const isCreatingProfile = useMemo(
-    () => data?.attributes?.state === 'pending',
-    [data]
+    () => data?.attributes['job-type'] === 'create-profile' && polling,
+    [data, polling]
   );
 
   useEffect(() => {

--- a/cardstack/src/utils/device.ts
+++ b/cardstack/src/utils/device.ts
@@ -26,8 +26,14 @@ const Device = {
     ? ('keyboardWillHide' as const)
     : ('keyboardDidHide' as const),
   enableBackup: true,
-  iapProvider: isIOS ? IAPProviderType.apple : IAPProviderType.google,
-  iapType: isIOS ? 'iap' : 'inapp',
+  iap: {
+    provider: isIOS ? IAPProviderType.apple : IAPProviderType.google,
+    type: isIOS ? ('iap' as const) : ('inapp' as const),
+    receiptKey: isIOS
+      ? ('transactionReceipt' as const)
+      : ('purchaseToken' as const),
+    isConsumable: true,
+  },
 };
 
 export { Device };


### PR DESCRIPTION
### Description

This PR adds the changes based on platform make iap work, it fixes the loading flicker and also makes sure the job type is profile.

Android needs the purchaseToken and iOS the txReceipt, also to be able to buy the same item again, we need to pass the consumable flag to finishTransaction

- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->

https://user-images.githubusercontent.com/20520102/183997149-f657aaa7-1e46-4863-a996-f1dab9e8b424.mp4

