### PR TITLE
fix: isUpdating needs to check for property inside currentProfile

### DIFF
--- a/cardstack/src/screens/Profile/ProfileNameScreen/useProfileNameScreen.ts
+++ b/cardstack/src/screens/Profile/ProfileNameScreen/useProfileNameScreen.ts
@@ -65,7 +65,7 @@ export const useProfileNameScreen = () => {
 
   const onContinuePress = useCallback(() => {
     // creation flow
-    if (!currentProfile) {
+    if (!currentProfile.name) {
       navigate(Routes.PROFILE_PURCHASE_CTA, { profile });
 
       return;
@@ -85,7 +85,7 @@ export const useProfileNameScreen = () => {
     onChangeText,
     onPressEditColor,
     profile,
-    isUpdating: currentProfile,
+    isUpdating: !!currentProfile.name,
     isBlocked,
   };
 };


### PR DESCRIPTION
### Description
`currentProfile`, when destructuring, is an empty object and it's a truthy value. This PR fixes that.

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
