### PR TITLE
[CS-4346] Add Staking label to CARD.CPXD balance on Depot

### DIFF
--- a/cardstack/src/components/FloatingTag/FloatingTag.tsx
+++ b/cardstack/src/components/FloatingTag/FloatingTag.tsx
@@ -1,0 +1,28 @@
+import { ResponsiveValue } from '@shopify/restyle';
+import React from 'react';
+
+import { Text, CenteredContainer } from '@cardstack/components';
+import { Theme } from '@cardstack/theme';
+
+// import { ColorTypes } from '@cardstack/theme';
+
+interface FloatingTagProps {
+  theme?: {
+    backgroundColor: ResponsiveValue<keyof Theme['colors'], Theme>;
+    color: ResponsiveValue<keyof Theme['colors'], Theme>;
+  };
+  copy: string;
+}
+
+export const FloatingTag = ({ theme, copy }: FloatingTagProps) => (
+  <CenteredContainer
+    backgroundColor={theme?.backgroundColor || 'tealDark'}
+    borderRadius={5}
+    height={17}
+    width={64}
+  >
+    <Text variant="floatingTag" color={theme?.color || 'white'}>
+      {copy}
+    </Text>
+  </CenteredContainer>
+);

--- a/cardstack/src/components/FloatingTag/index.ts
+++ b/cardstack/src/components/FloatingTag/index.ts
@@ -1,0 +1,1 @@
+export * from './FloatingTag';

--- a/cardstack/src/components/TokenBalance/TokenBalance.tsx
+++ b/cardstack/src/components/TokenBalance/TokenBalance.tsx
@@ -7,8 +7,13 @@ import {
   Text,
   Touchable,
   CoinIcon,
+  FloatingTag,
 } from '@cardstack/components';
 import { Theme } from '@cardstack/theme';
+
+const strings = {
+  staking: 'Staking',
+};
 
 export interface TokenBalanceProps extends ContainerProps {
   onPress?: () => void;
@@ -49,6 +54,8 @@ export const TokenBalance = (props: TokenBalanceProps) => {
   const borderProps = includeBorder ? borderStyle : {};
   const Wrapper = onPress ? Touchable : Container;
 
+  const isCardCPXD = tokenSymbol === 'CARD.CPXD';
+
   return (
     <Wrapper onPress={onPress} {...borderProps} {...containerProps}>
       <Container
@@ -57,7 +64,12 @@ export const TokenBalance = (props: TokenBalanceProps) => {
         alignItems="center"
         marginBottom={isLastItemIfList ? 0 : 4}
       >
-        <Container>
+        <Container
+          flexDirection="row"
+          justifyContent="space-between"
+          width="100%"
+          alignItems="flex-end"
+        >
           <Container flexDirection="row" alignItems="center">
             {Icon ? (
               Icon
@@ -79,6 +91,7 @@ export const TokenBalance = (props: TokenBalanceProps) => {
               <Text variant="subText">{nativeBalance}</Text>
             </Container>
           </Container>
+          {isCardCPXD && <FloatingTag copy={strings.staking} />}
         </Container>
       </Container>
     </Wrapper>

--- a/cardstack/src/components/index.ts
+++ b/cardstack/src/components/index.ts
@@ -52,3 +52,4 @@ export * from './CtaBanner';
 export { default as RewardsPromoBanner } from './RewardsPromoBanner/RewardsPromoBanner';
 export * from './BiometricSwitch';
 export * from './ValidationMessage';
+export * from './FloatingTag';

--- a/cardstack/src/theme/textVariants.ts
+++ b/cardstack/src/theme/textVariants.ts
@@ -69,4 +69,11 @@ export const textVariants = {
     color: 'grayText',
     fontSize: 12,
   },
+  floatingTag: {
+    fontSize: 9,
+    letterSpacing: 0.9,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    ...fontFamilyVariants.bold,
+  },
 };


### PR DESCRIPTION
### Description
This PR adds a tag "Staking" to inform the users that staking is active in their CARD.CPXD balance.  

- [x] Completes #CS-4346

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

### Android
<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/184251606-bffa88fe-41bd-469d-8a62-b18ad32cd759.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/184251600-7ae23d2e-5377-425e-b4c5-078886dd80fe.png">


### iOS
<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/184251753-55dca290-4429-49b3-9f5b-7fdb9fcde62d.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/184251761-3e9fcce3-c3b5-4c15-8d06-e4fcd5066a70.png">
