### PR TITLE
[CS-4422] Fix conversion rate on Activity tab

### DIFF
--- a/cardstack/src/services/historical-pricing-service.ts
+++ b/cardstack/src/services/historical-pricing-service.ts
@@ -44,10 +44,9 @@ export const fetchHistoricalPrice = async (
       const { data: USDTRate } = await getExchangeRatesQuery({
         ...defaultParams,
         from: 'USDT',
-        to: tokenSymbol,
       });
 
-      const nativeCurrencyPriceForUSDT = USDTRate?.[tokenSymbol] || 0;
+      const nativeCurrencyPriceForUSDT = USDTRate?.[nativeCurrency] || 0;
 
       return usdtPrice * nativeCurrencyPriceForUSDT;
     }


### PR DESCRIPTION
### Description
This PR fixes a mistake on the historical price fetching service. We were trying to do a conversion with values that doesn't exist (`USDT => CARD.CPXD`, for example).

- [x] Completes #CS-4422

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
