### PR TITLE
[CS-4391] Avoid showing empty create profile state when opening profile tab from purchase

### DIFF
--- a/cardstack/src/hooks/useProfileJobPolling.ts
+++ b/cardstack/src/hooks/useProfileJobPolling.ts
@@ -1,6 +1,6 @@
 import { SerializedError } from '@reduxjs/toolkit';
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query/react';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 
 import { useGetProfileJobStatusQuery } from '@cardstack/services';
 

--- a/cardstack/src/hooks/useProfileJobPolling.ts
+++ b/cardstack/src/hooks/useProfileJobPolling.ts
@@ -34,11 +34,6 @@ export const useProfileJobPolling = ({
     }
   );
 
-  const isCreatingProfile = useMemo(
-    () => data?.attributes['job-type'] === 'create-profile' && polling,
-    [data, polling]
-  );
-
   useEffect(() => {
     if (jobID) {
       startPolling();
@@ -53,6 +48,6 @@ export const useProfileJobPolling = ({
   }, [data, error, stopPolling, onJobCompletedCallback]);
 
   return {
-    isCreatingProfile,
+    isCreatingProfile: polling,
   };
 };


### PR DESCRIPTION
### Description

Loading state here is tricky, if we wait for the first polling query to return, the screen show show the "empty profile" state for a split second. Using polling state from start fixes it.

- [x] Completes #(CS-4391)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

https://user-images.githubusercontent.com/129619/184452351-66434296-849d-4160-bba3-a9a851f68120.mov


