### PR TITLE
[CS-4435] Update Rewards notification to use same rule as Rewards screen

### DIFF
--- a/cardstack/src/components/AssetList/AssetList.tsx
+++ b/cardstack/src/components/AssetList/AssetList.tsx
@@ -27,7 +27,7 @@ export const AssetList = () => {
     onRefresh,
     refreshing,
     networkName,
-    mainPoolTokenInfo,
+    hasRewardsAvailable,
   } = useAssetList({ sectionListRef });
 
   const renderSectionHeader = useCallback(
@@ -76,7 +76,7 @@ export const AssetList = () => {
       <SectionList
         ListHeaderComponent={
           <RewardsPromoBanner
-            hasUnclaimedRewards={!!mainPoolTokenInfo}
+            hasUnclaimedRewards={hasRewardsAvailable}
             paddingTop={2}
           />
         }

--- a/cardstack/src/components/AssetList/useAssetList.ts
+++ b/cardstack/src/components/AssetList/useAssetList.ts
@@ -28,7 +28,7 @@ export const useAssetList = ({
   const { params } = useRoute<AssetListRouteType>();
 
   const {
-    mainPoolTokenInfo,
+    hasRewardsAvailable,
     isLoading: rewardsFetchLoading,
   } = useRewardsDataFetch();
 
@@ -122,6 +122,6 @@ export const useAssetList = ({
     goToBuyPrepaidCard,
     onRefresh,
     networkName,
-    mainPoolTokenInfo,
+    hasRewardsAvailable,
   };
 };

--- a/cardstack/src/components/MainHeader/MainHeader.tsx
+++ b/cardstack/src/components/MainHeader/MainHeader.tsx
@@ -34,7 +34,7 @@ const MainHeader = ({
 }: Props) => {
   const { navigate } = useNavigation();
   const { network } = useAccountSettings();
-  const { rewardPoolTokenBalances } = useRewardsDataFetch();
+  const { mainPoolTokenInfo } = useRewardsDataFetch();
 
   const onMenuPress = useCallback(() => navigate(Routes.SETTINGS_MODAL), [
     navigate,
@@ -44,7 +44,7 @@ const MainHeader = ({
     navigate(Routes.REWARDS_CENTER_SCREEN);
   }, [navigate]);
 
-  const availableRewards = rewardPoolTokenBalances?.length;
+  const availableRewards = !!mainPoolTokenInfo;
 
   return (
     <MainHeaderWrapper {...containerProps}>

--- a/cardstack/src/components/MainHeader/MainHeader.tsx
+++ b/cardstack/src/components/MainHeader/MainHeader.tsx
@@ -36,6 +36,9 @@ const MainHeader = ({
   const { network } = useAccountSettings();
   const { hasRewardsAvailable } = useRewardsDataFetch();
 
+  // this should use the rewards pool length in the future as more rewards programs are added
+  const rewardsQuantity = 1;
+
   const onMenuPress = useCallback(() => navigate(Routes.SETTINGS_MODAL), [
     navigate,
   ]);
@@ -83,7 +86,7 @@ const MainHeader = ({
           {hasRewardsAvailable && (
             <Container>
               <Text color="teal" fontSize={18} weight="bold" marginLeft={2}>
-                1
+                {rewardsQuantity}
               </Text>
             </Container>
           )}

--- a/cardstack/src/components/MainHeader/MainHeader.tsx
+++ b/cardstack/src/components/MainHeader/MainHeader.tsx
@@ -34,7 +34,7 @@ const MainHeader = ({
 }: Props) => {
   const { navigate } = useNavigation();
   const { network } = useAccountSettings();
-  const { mainPoolTokenInfo } = useRewardsDataFetch();
+  const { hasRewardsAvailable } = useRewardsDataFetch();
 
   const onMenuPress = useCallback(() => navigate(Routes.SETTINGS_MODAL), [
     navigate,
@@ -43,8 +43,6 @@ const MainHeader = ({
   const onRewardPress = useCallback(() => {
     navigate(Routes.REWARDS_CENTER_SCREEN);
   }, [navigate]);
-
-  const availableRewards = !!mainPoolTokenInfo;
 
   return (
     <MainHeaderWrapper {...containerProps}>
@@ -82,10 +80,10 @@ const MainHeader = ({
           onPress={onRewardPress}
         >
           <Icon color="teal" iconSize="medium" size={26} name="rewards" />
-          {!!availableRewards && (
+          {hasRewardsAvailable && (
             <Container>
               <Text color="teal" fontSize={18} weight="bold" marginLeft={2}>
-                {availableRewards}
+                1
               </Text>
             </Container>
           )}

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -9,6 +9,7 @@ export const useRewardsCenterScreen = () => {
     defaultRewardProgramId,
     isLoading,
     mainPoolTokenInfo,
+    hasRewardsAvailable,
   } = useRewardsDataFetch();
 
   const registeredPools = useMemo(
@@ -34,7 +35,7 @@ export const useRewardsCenterScreen = () => {
     registeredPools,
     rewardPoolTokenBalances,
     isRegistered,
-    hasRewardsAvailable: !!mainPoolTokenInfo,
+    hasRewardsAvailable,
     mainPoolTokenInfo,
     isLoading,
   };

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
@@ -63,12 +63,19 @@ const useRewardsDataFetch = () => {
     [isLoadingSafes, isLoadingTokens, isUninitialized, network]
   );
 
+  /**
+   * For now, the available rewards are the ones inside the Cardstack pool
+   * In the future, this will change once we add more reward programs
+   */
+  const hasRewardsAvailable = !!mainPoolTokenInfo;
+
   return {
     isLoading,
     rewardSafes,
     rewardPoolTokenBalances,
     mainPoolTokenInfo,
     defaultRewardProgramId,
+    hasRewardsAvailable,
   };
 };
 


### PR DESCRIPTION
### Description
This PR fixes the Rewards notification icon we have on the Tab navigation header to use the same rule as the Rewards screen (checking for the existence of `mainPoolTokenInfo` instead of something in the `rewardPoolTokenBalances` (which can contain rewards not yet available for claiming for N reasons).

- [x] Completes #CS-4435

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
