### PR TITLE
[CS-4427]: Block any type of navigation on lock screen

### DIFF
--- a/cardstack/src/navigation/customNavigator.tsx
+++ b/cardstack/src/navigation/customNavigator.tsx
@@ -1,0 +1,94 @@
+import {
+  createNavigatorFactory,
+  DefaultNavigatorOptions,
+  ParamListBase,
+  StackActionHelpers,
+  StackNavigationState,
+  StackRouter,
+  StackRouterOptions,
+  useNavigationBuilder,
+} from '@react-navigation/native';
+import { StackNavigationOptions, StackView } from '@react-navigation/stack';
+import {
+  StackNavigationConfig,
+  StackNavigationEventMap,
+} from '@react-navigation/stack/lib/typescript/src/types';
+import React from 'react';
+
+import { Routes } from '.';
+
+const SecureStackRouter = (stackOptions: StackRouterOptions) => {
+  const router = StackRouter(stackOptions);
+
+  const defaultGetStateForAction = router.getStateForAction;
+
+  // Replaces stateForAction to avoid new routes when app is locked
+  router.getStateForAction = (currentState, action, options) => {
+    const currentRoute = currentState.routes[currentState.index].name;
+    const isLocked = currentRoute === Routes.UNLOCK_SCREEN;
+    // Get next state to check whether it's a new screen or not, handles push/navigate
+    const nextState = defaultGetStateForAction(currentState, action, options);
+    const screenBeingPushed = (nextState?.index || 0) > currentState.index;
+
+    const preventNavigation = screenBeingPushed && isLocked;
+
+    return preventNavigation ? currentState : nextState;
+  };
+
+  return router;
+};
+
+type Props = DefaultNavigatorOptions<
+  ParamListBase,
+  StackNavigationState<ParamListBase>,
+  StackNavigationOptions,
+  StackNavigationEventMap
+> &
+  StackRouterOptions &
+  StackNavigationConfig;
+
+const StackNavigator = ({
+  id,
+  initialRouteName,
+  children,
+  screenListeners,
+  screenOptions,
+  ...rest
+}: Props) => {
+  const {
+    state,
+    descriptors,
+    navigation,
+    NavigationContent,
+  } = useNavigationBuilder<
+    StackNavigationState<ParamListBase>,
+    StackRouterOptions,
+    StackActionHelpers<ParamListBase>,
+    StackNavigationOptions,
+    StackNavigationEventMap
+  >(SecureStackRouter, {
+    id,
+    initialRouteName,
+    children,
+    screenListeners,
+    screenOptions,
+  });
+
+  return (
+    <NavigationContent>
+      <StackView
+        {...rest}
+        state={state}
+        descriptors={descriptors}
+        navigation={navigation}
+      />
+    </NavigationContent>
+  );
+};
+
+export const createCustomStackNavigator = createNavigatorFactory<
+  StackNavigationState<ParamListBase>,
+  StackNavigationOptions,
+  StackNavigationEventMap,
+  typeof StackNavigator
+>(StackNavigator);

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -2,10 +2,7 @@ import {
   BottomTabNavigationOptions,
   createBottomTabNavigator,
 } from '@react-navigation/bottom-tabs';
-import {
-  createStackNavigator,
-  StackNavigationOptions,
-} from '@react-navigation/stack';
+import { StackNavigationOptions } from '@react-navigation/stack';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { TabBarIcon } from '@cardstack/components';
@@ -33,6 +30,7 @@ import ModalScreen from '@rainbow-me/screens/ModalScreen';
 import PinAuthenticationScreen from '@rainbow-me/screens/PinAuthenticationScreen';
 import RestoreSheet from '@rainbow-me/screens/RestoreSheet';
 
+import { createCustomStackNavigator } from './customNavigator';
 import { useCardstackMainScreens } from './hooks';
 
 import {
@@ -114,7 +112,7 @@ const TabNavigator = () => {
   );
 };
 
-const Stack = createStackNavigator();
+const Stack = createCustomStackNavigator();
 
 const SharedScreens = ({ navigationKey }: { navigationKey: string }) => (
   <Stack.Group navigationKey={navigationKey}>


### PR DESCRIPTION
### Description

<!-- Please, include a summary of the changes. -->

This PR adds a custom router and navigator to be able to filter and conditionally update the navigation state, mainly to avoid any inner screens to pop-up on top of the lock screen,  the custom navigator is derived from the StackNavigator, the only difference is the getStateForAction, please make sure to test on your devices, since it's a global change.

### Checklist

- [x] Tested on iOS
- [x] Tested on Android

