### PR TITLE
[CS-4423] Logic for retry and support for profile creation

### DIFF
--- a/cardstack/src/screens/ProfileScreen/ProfileScreen.tsx
+++ b/cardstack/src/screens/ProfileScreen/ProfileScreen.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { ActivityIndicator, Alert } from 'react-native';
+import React, { useMemo } from 'react';
+import { ActivityIndicator } from 'react-native';
 
 import {
   Button,
@@ -15,14 +15,14 @@ import { useSendFeedback } from '@rainbow-me/hooks';
 import { CreateProfile, CreateProfileError, strings } from './components';
 import { useProfileScreen } from './useProfileScreen';
 
-// Todo: Extract errors from job-ticket api call.
-const isError = false;
-
 const ProfileScreen = () => {
   const {
     primarySafe,
     showLoading,
     isCreatingProfile,
+    isCreateProfileError,
+    retryCurrentCreateProfile,
+    isConnectionError,
     safesCount,
     isFetching,
     network,
@@ -31,6 +31,18 @@ const ProfileScreen = () => {
   } = useProfileScreen();
 
   const onSendSupport = useSendFeedback();
+
+  const error = useMemo(() => {
+    if (isCreateProfileError) {
+      return strings.profileError;
+    }
+
+    if (isConnectionError) {
+      return strings.connectionError;
+    }
+
+    return undefined;
+  }, [isCreateProfileError, isConnectionError]);
 
   const ProfileContent = () => {
     if (isLayer1(network)) {
@@ -51,11 +63,12 @@ const ProfileScreen = () => {
       );
     }
 
-    if (isError) {
+    if (error) {
       return (
         <CreateProfileError
-          onPressRetry={() => Alert.alert('Not available yet')}
+          onPressRetry={retryCurrentCreateProfile}
           onPressSupport={onSendSupport}
+          error={error}
         />
       );
     }

--- a/cardstack/src/screens/ProfileScreen/components/CreateProfileError.tsx
+++ b/cardstack/src/screens/ProfileScreen/components/CreateProfileError.tsx
@@ -10,24 +10,34 @@ import {
 
 import { strings } from './';
 
+interface Error {
+  title: string;
+  message: string;
+}
+
 interface CreateProfileErrorProps {
   onPressRetry: () => void;
   onPressSupport: () => void;
+  error?: Error;
 }
 
 export const CreateProfileError = ({
   onPressRetry,
   onPressSupport,
+  error = {
+    title: strings.profileError.title,
+    message: strings.profileError.message,
+  },
 }: CreateProfileErrorProps) => (
   <Container flex={1} justifyContent="space-between" paddingVertical={10}>
     <Container flex={1} paddingHorizontal={5}>
       <Container flexDirection="row" alignItems="center" paddingBottom={3}>
         <Icon name="info" size={20} color="error" />
         <Text paddingLeft={3} color="white" variant="pageHeader">
-          {strings.profileError.title}
+          {error.title}
         </Text>
       </Container>
-      <Text color="grayText">{strings.profileError.message}</Text>
+      <Text color="grayText">{error.message}</Text>
     </Container>
     <Container>
       <Button marginBottom={6} alignSelf="center" onPress={onPressRetry}>

--- a/cardstack/src/screens/ProfileScreen/components/CreateProfileError.tsx
+++ b/cardstack/src/screens/ProfileScreen/components/CreateProfileError.tsx
@@ -10,7 +10,7 @@ import {
 
 import { strings } from './';
 
-interface Error {
+interface ErrorInfoType {
   title: string;
   message: string;
 }
@@ -18,7 +18,7 @@ interface Error {
 interface CreateProfileErrorProps {
   onPressRetry: () => void;
   onPressSupport: () => void;
-  error?: Error;
+  error: ErrorInfoType;
 }
 
 export const CreateProfileError = ({

--- a/cardstack/src/screens/ProfileScreen/components/strings.ts
+++ b/cardstack/src/screens/ProfileScreen/components/strings.ts
@@ -13,6 +13,11 @@ export const strings = {
     message:
       'There was a problem creating your profile. Please wait a few minutes and then try again. If this problem persists, please get in touch with our support team.',
   },
+  connectionError: {
+    title: 'Connection failed',
+    message:
+      'There was a problem connecting to the profile issuer. Please wait a few minutes and then try again. If this problem persists, please get in touch with our support team.',
+  },
   buttons: {
     continue: 'Continue',
     retry: 'Retry',

--- a/cardstack/src/screens/ProfileScreen/useProfileScreen.ts
+++ b/cardstack/src/screens/ProfileScreen/useProfileScreen.ts
@@ -39,7 +39,12 @@ export const useProfileScreen = () => {
     [refetch]
   );
 
-  const { isCreatingProfile } = useProfileJobPolling({
+  const {
+    isConnectionError,
+    isCreatingProfile,
+    isCreateProfileError,
+    retryCurrentCreateProfile,
+  } = useProfileJobPolling({
     jobID: params?.profileCreationJobID,
     onJobCompletedCallback,
   });
@@ -80,5 +85,8 @@ export const useProfileScreen = () => {
     isFetching,
     refetch,
     redirectToSwitchNetwork,
+    isConnectionError,
+    isCreateProfileError,
+    retryCurrentCreateProfile,
   };
 };

--- a/cardstack/src/services/hub/hub-api.ts
+++ b/cardstack/src/services/hub/hub-api.ts
@@ -159,6 +159,12 @@ export const hubApi = createApi({
         `${routes.profileInfo.jobTicket}/${jobTicketID}`,
       transformResponse: ({ data }) => data,
     }),
+    postProfileJobRetry: builder.mutation<unknown, { jobTicketID: string }>({
+      query: ({ jobTicketID }) => ({
+        url: `${routes.profileInfo.jobTicket}/${jobTicketID}/retry`,
+        method: 'POST',
+      }),
+    }),
   }),
 });
 
@@ -174,5 +180,6 @@ export const {
   useLazyValidateProfileSlugQuery,
   useCreateProfileInfoMutation,
   useGetProfileJobStatusQuery,
+  usePostProfileJobRetryMutation,
   useUpdateProfileInfoMutation,
 } = hubApi;


### PR DESCRIPTION
### Description

This PR adds support and retry handling when connection errors or profile creation job fails.

It's hard to test these states manually, so I'm writing unit tests (trying to). To test UI change the return value for the `error` memo in `ProfileScreen`.

- [x] Completes #(CS-4423)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/185233281-4d5fa64a-c0ac-4b96-ba39-f234bfcb533f.PNG">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/185233273-53770437-d13b-452a-aae9-6da666ea4343.PNG">
