### PR TITLE
[CS-4454]: Fix deeplink locking user

### DIFF
--- a/cardstack/src/navigation/Navigation.ts
+++ b/cardstack/src/navigation/Navigation.ts
@@ -1,11 +1,15 @@
 import {
   CommonActions,
+  getActionFromState,
+  getStateFromPath,
   NavigationContainerRef,
   StackActions,
 } from '@react-navigation/native';
 import { RouteNames, StackParamsList } from 'globals';
 import { get } from 'lodash';
 import React from 'react';
+
+import { linking } from './screens';
 
 export const navigationRef = React.createRef<
   NavigationContainerRef<StackParamsList>
@@ -39,9 +43,30 @@ function handleAction(
   navigationRef.current?.dispatch(action);
 }
 
+const parseUrlToNavigationPath = (url: string) =>
+  url.replace(new RegExp(linking.prefixes.join('|'), 'gi'), '');
+
+const linkTo = (url: string) => {
+  const path = parseUrlToNavigationPath(url);
+
+  //@ts-expect-error not worth to type, linking is verified on navigator already
+  const state = getStateFromPath(path, linking.config);
+
+  if (state) {
+    const action = getActionFromState(state, linking.config);
+
+    if (action !== undefined) {
+      navigationRef.current?.dispatch(action);
+    } else {
+      navigationRef.current?.reset(state);
+    }
+  }
+};
+
 export default {
   getActiveOptions,
   getActiveRoute,
   getActiveRouteName,
   handleAction,
+  linkTo,
 };

--- a/cardstack/src/navigation/Navigation.ts
+++ b/cardstack/src/navigation/Navigation.ts
@@ -43,7 +43,7 @@ function handleAction(
   navigationRef.current?.dispatch(action);
 }
 
-const parseUrlToNavigationPath = (url: string) =>
+export const parseUrlToNavigationPath = (url: string) =>
   url.replace(new RegExp(linking.prefixes.join('|'), 'gi'), '');
 
 const linkTo = (url: string) => {

--- a/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/useScanner.ts
+++ b/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/useScanner.ts
@@ -1,13 +1,16 @@
 import { isValidMerchantPaymentUrl } from '@cardstack/cardpay-sdk';
-import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import {
+  useFocusEffect,
+  useLinkTo,
+  useNavigation,
+} from '@react-navigation/native';
 import { useCallback, useRef } from 'react';
-import { Linking } from 'react-native';
 
 import { useBooleanState } from '@cardstack/hooks';
 import useWalletConnectConnections from '@cardstack/hooks/wallet-connect/useWalletConnectConnections';
+import { parseUrlToNavigationPath } from '@cardstack/navigation/Navigation';
 import { Routes } from '@cardstack/navigation/routes';
 import { WCRedirectTypes } from '@cardstack/screens/sheets/WalletConnectRedirectSheet';
-import { convertDeepLinkToCardWalletProtocol } from '@cardstack/utils';
 
 import { Alert } from '@rainbow-me/components/alerts';
 import { useTimeout } from '@rainbow-me/hooks';
@@ -28,6 +31,7 @@ export const useScanner = ({
   const { navigate } = useNavigation();
   const { walletConnectOnSessionRequest } = useWalletConnectConnections();
   const [startTimeout] = useTimeout();
+  const linkTo = useLinkTo();
   const isWcScanEnabled = useRef(true);
 
   const [
@@ -93,13 +97,16 @@ export const useScanner = ({
     [walletConnectOnSessionRequest, walletConnectOnSessionRequestCallback]
   );
 
-  const handleScanPayMerchant = useCallback(deeplink => {
-    haptics.notificationSuccess();
+  const handleScanPayMerchant = useCallback(
+    deeplink => {
+      haptics.notificationSuccess();
 
-    const updatedDeepLink = convertDeepLinkToCardWalletProtocol(deeplink);
+      const parsedLink = parseUrlToNavigationPath(deeplink);
 
-    Linking.openURL(updatedDeepLink);
-  }, []);
+      linkTo(parsedLink);
+    },
+    [linkTo]
+  );
 
   const handleScanInvalid = useCallback(
     qrCodeData => {

--- a/cardstack/src/utils/url-utils.ts
+++ b/cardstack/src/utils/url-utils.ts
@@ -1,6 +1,3 @@
-import { CARDWALLET_SCHEME } from '@cardstack/cardpay-sdk';
-import Url from 'url-parse';
-
 export const isEncodedUri = (uri = ''): boolean =>
   uri !== decodeURIComponent(uri);
 
@@ -10,15 +7,4 @@ export const decodeNestedURI = (uri: string): string => {
   }
 
   return uri;
-};
-
-// convert https:// to `${CARDWALLET_SCHEME}:/`
-export const convertDeepLinkToCardWalletProtocol = (deepLink: string) => {
-  const url = new Url(deepLink);
-
-  if (url.protocol === 'https:') {
-    return `${CARDWALLET_SCHEME}:/${url.pathname}${url.query || ''}`;
-  }
-
-  return deepLink;
 };

--- a/src/useAppInit.ts
+++ b/src/useAppInit.ts
@@ -86,7 +86,7 @@ export const useAppInit = () => {
     const { url, handled } = deepLink.current;
 
     if (url && !handled && isAuthorized) {
-      Linking.openURL(url);
+      Navigation.linkTo(url);
 
       deepLink.current = { url, handled: true };
     }


### PR DESCRIPTION
### Description

We were using `Linking.openURL` to handle inner app links, but it seems that it  triggers a new Activity on Android, which sets the AppState to `background` even though the app is still open, making the app lock itself. This PR fixes this issue by using react-navigation helpers to use the provided path and navigate to pay merchant, without locking the screen again.

`Navigation.linkTo` was created because `useAppInit` is outside of the NavigationContext, so we're not able to use the same hook we do on `useScanner`.


### Checklist

- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->

https://user-images.githubusercontent.com/20520102/185239699-65a1695f-6a84-4d3f-b0ae-0b2757d162a0.mp4


