### PR TITLE
[CS-4170] Handle Skip button on profile creation flow

### DIFF
--- a/cardstack/src/components/MainHeader/InPageHeader.tsx
+++ b/cardstack/src/components/MainHeader/InPageHeader.tsx
@@ -1,5 +1,6 @@
 import { StackActions, useNavigation } from '@react-navigation/native';
 import React, { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
 
 import {
   Container,
@@ -9,6 +10,7 @@ import {
   ContainerProps,
   IconProps,
 } from '@cardstack/components';
+import { skipProfileCreation } from '@cardstack/redux/persistedFlagsSlice';
 
 interface Props extends ContainerProps {
   leftIconProps?: IconProps;
@@ -24,10 +26,12 @@ const InPageHeader = ({
   skipAmount = 1,
 }: Props) => {
   const { goBack, dispatch: navDispatch } = useNavigation();
+  const dispatch = useDispatch();
 
   const onSkipPress = useCallback(() => {
+    dispatch(skipProfileCreation(true));
     navDispatch(StackActions.pop(skipAmount));
-  }, [navDispatch, skipAmount]);
+  }, [navDispatch, skipAmount, dispatch]);
 
   return (
     <Container

--- a/cardstack/src/hooks/onboarding/__tests__/useShowOnboarding.test.ts
+++ b/cardstack/src/hooks/onboarding/__tests__/useShowOnboarding.test.ts
@@ -4,6 +4,7 @@ import { useShowOnboarding } from '@cardstack/hooks/onboarding/useShowOnboarding
 import { Routes } from '@cardstack/navigation/routes';
 import { useAuthSelector } from '@cardstack/redux/authSlice';
 import { usePrimarySafe } from '@cardstack/redux/hooks/usePrimarySafe';
+import { usePersistedFlagsSelector } from '@cardstack/redux/persistedFlagsSlice';
 
 jest.mock('@cardstack/redux/hooks/usePrimarySafe', () => ({
   usePrimarySafe: jest.fn(),
@@ -19,6 +20,12 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('@cardstack/redux/authSlice', () => ({
   useAuthSelector: jest.fn().mockReturnValue({
     hasWallet: true,
+  }),
+}));
+
+jest.mock('@cardstack/redux/persistedFlagsSlice', () => ({
+  usePersistedFlagsSelector: jest.fn().mockReturnValue({
+    hasSkippedProfileCreation: false,
   }),
 }));
 
@@ -88,6 +95,16 @@ describe('useShowOnboarding', () => {
     mockPrimarySafeHelper({
       hasFetchedProfile: true,
       primarySafe: undefined,
+    });
+
+    renderHook(useShowOnboarding);
+
+    expect(mockedNavigate).not.toBeCalled();
+  });
+
+  it('should NOT navigate to profile creation flow if "Skip" was pressed', () => {
+    (usePersistedFlagsSelector as jest.Mock).mockReturnValueOnce({
+      hasSkippedProfileCreation: true,
     });
 
     renderHook(useShowOnboarding);

--- a/cardstack/src/hooks/onboarding/useShowOnboarding.ts
+++ b/cardstack/src/hooks/onboarding/useShowOnboarding.ts
@@ -1,26 +1,33 @@
 import { useNavigation } from '@react-navigation/native';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 import { Routes } from '@cardstack/navigation/routes';
 import { useAuthSelector } from '@cardstack/redux/authSlice';
 import { usePrimarySafe } from '@cardstack/redux/hooks/usePrimarySafe';
+import { usePersistedFlagsSelector } from '@cardstack/redux/persistedFlagsSlice';
 
 export const useShowOnboarding = () => {
   const { primarySafe, hasFetchedProfile } = usePrimarySafe();
+  const { hasSkippedProfileCreation } = usePersistedFlagsSelector();
 
   const { navigate } = useNavigation();
 
   const { hasWallet } = useAuthSelector();
 
-  // TODO: Maybe persist the skip
-  const isOnboarding = useRef(false);
-
   useEffect(() => {
     const noProfile = hasFetchedProfile && !primarySafe;
 
-    if (hasWallet && noProfile && !isOnboarding.current) {
+    const shouldShowProfileCreationFlow =
+      hasWallet && noProfile && !hasSkippedProfileCreation;
+
+    if (shouldShowProfileCreationFlow) {
       navigate(Routes.PROFILE_SLUG);
-      isOnboarding.current = true;
     }
-  }, [hasFetchedProfile, hasWallet, navigate, primarySafe]);
+  }, [
+    hasFetchedProfile,
+    hasWallet,
+    navigate,
+    primarySafe,
+    hasSkippedProfileCreation,
+  ]);
 };

--- a/cardstack/src/redux/persistedFlagsSlice.ts
+++ b/cardstack/src/redux/persistedFlagsSlice.ts
@@ -1,0 +1,35 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { useSelector } from 'react-redux';
+
+import { AppState } from '@rainbow-me/redux/store';
+
+type SliceType = {
+  hasSkippedProfileCreation: boolean;
+};
+
+const initialState: SliceType = {
+  hasSkippedProfileCreation: false,
+};
+
+const slice = createSlice({
+  name: 'persistedFlags',
+  initialState,
+  reducers: {
+    skipProfileCreation(state, action: PayloadAction<boolean>) {
+      state.hasSkippedProfileCreation = action.payload;
+    },
+  },
+});
+
+export const {
+  name: persistedFlagsName,
+  actions: { skipProfileCreation },
+} = slice;
+
+export const usePersistedFlagsSelector = () => {
+  const persistedFlags = useSelector((state: AppState) => state.persistedFlags);
+
+  return persistedFlags;
+};
+
+export default slice.reducer;

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -47,6 +47,7 @@ import {
   updateSecureStorePin,
   wipeSecureStorage,
 } from '@cardstack/models/secure-storage';
+import { skipProfileCreation } from '@cardstack/redux/persistedFlagsSlice';
 import { restartApp } from '@cardstack/utils';
 import { Device } from '@cardstack/utils/device';
 
@@ -55,6 +56,7 @@ import {
   deleteKeychainIntegrityState,
   deletePinAuthAttemptsData,
 } from '@rainbow-me/handlers/localstorage/globalSettings';
+import store from '@rainbow-me/redux/store';
 import logger from 'logger';
 
 const encryptor = new AesEncryptor();
@@ -905,6 +907,9 @@ export const resetWallet = async () => {
       deleteKeychainIntegrityState();
 
       await deletePinAuthAttemptsData();
+
+      // clear profile creation skip
+      store.dispatch(skipProfileCreation(false));
 
       logger.log('Wallet reset done!');
 

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -9,6 +9,7 @@ import wallets from './wallets';
 import appState from '@cardstack/redux/appState';
 import biometryToggle from '@cardstack/redux/biometryToggleSlice';
 import collectibles from '@cardstack/redux/collectibles';
+import persistedFlags from '@cardstack/redux/persistedFlagsSlice';
 import primarySafe from '@cardstack/redux/primarySafeSlice';
 import requests from '@cardstack/redux/requests';
 import welcomeBanner from '@cardstack/redux/welcomeBanner';
@@ -28,4 +29,5 @@ export default {
   primarySafe,
   biometryToggle,
   welcomeBanner,
+  persistedFlags,
 };

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -5,6 +5,7 @@ import { persistReducer, persistStore } from 'redux-persist';
 import reducers from './reducers';
 import { authSlice } from '@cardstack/redux/authSlice';
 import { biometryToggleSliceName } from '@cardstack/redux/biometryToggleSlice';
+import { persistedFlagsName } from '@cardstack/redux/persistedFlagsSlice';
 import { primarySafeSliceName } from '@cardstack/redux/primarySafeSlice';
 import { welcomeBannerSliceName } from '@cardstack/redux/welcomeBanner';
 import { hubApi } from '@cardstack/services/hub/hub-api';
@@ -21,6 +22,7 @@ const persistConfig = {
     primarySafeSliceName,
     biometryToggleSliceName,
     welcomeBannerSliceName,
+    persistedFlagsName,
   ],
 };
 


### PR DESCRIPTION
### Description
This PR adds a new entry to the redux store called `persistedFlags`, which can be used in the future for other things, but for now it's being used to handle the "Skip" button pressing on the profile creation flow. Once the user skips the profile creation flow, it won't be shown again unless they go to the Profile tab.

- [x] Completes #CS-4170

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

