### PR TITLE
[CS-4455] Tests for polling hook

### DIFF
--- a/cardstack/src/hooks/__tests__/useProfileJobPolling.test.ts
+++ b/cardstack/src/hooks/__tests__/useProfileJobPolling.test.ts
@@ -49,7 +49,7 @@ describe('useProfileJobPolling', () => {
     mockUsePostProfileJobRetryMutation();
   });
 
-  it('should start hook waiting when jobID not provided', () => {
+  it('should do nothing if jobID is not provided', () => {
     const { result } = renderHook(() =>
       useProfileJobPolling({ ...mockJobParams, jobID: undefined })
     );
@@ -74,7 +74,7 @@ describe('useProfileJobPolling', () => {
     expect(result.current.isCreatingProfile).toBeFalsy();
   });
 
-  it('should return profile error flag on job has failed', () => {
+  it('should return profile error flag once job has failed', () => {
     const { result, rerender } = renderHook(() =>
       useProfileJobPolling(mockJobParams)
     );
@@ -97,7 +97,9 @@ describe('useProfileJobPolling', () => {
       result.current.retryCurrentCreateProfile();
     });
 
-    expect(mockJobRetryMutation).toBeCalled();
+    expect(mockJobRetryMutation).toBeCalledWith({
+      jobTicketID: mockJobParams.jobID,
+    });
   });
 
   it('should resume polling once retry call is successful', () => {

--- a/cardstack/src/hooks/__tests__/useProfileJobPolling.test.ts
+++ b/cardstack/src/hooks/__tests__/useProfileJobPolling.test.ts
@@ -115,4 +115,17 @@ describe('useProfileJobPolling', () => {
 
     expect(result.current.isCreatingProfile).toBeTruthy();
   });
+
+  it('should return isConnectionError on connection error', () => {
+    const { result, rerender } = renderHook(() =>
+      useProfileJobPolling(mockJobParams)
+    );
+
+    mockUseGetProfileJobStatusQuery(undefined, 'CON_ERROR');
+    rerender();
+
+    expect(result.current.isCreatingProfile).toBeFalsy();
+    expect(result.current.isCreateProfileError).toBeFalsy();
+    expect(result.current.isConnectionError).toMatch('CON_ERROR');
+  });
 });

--- a/cardstack/src/hooks/__tests__/useProfileJobPolling.test.ts
+++ b/cardstack/src/hooks/__tests__/useProfileJobPolling.test.ts
@@ -1,0 +1,118 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react-native';
+
+import {
+  useGetProfileJobStatusQuery,
+  usePostProfileJobRetryMutation,
+} from '@cardstack/services';
+
+import { useProfileJobPolling } from '../useProfileJobPolling';
+
+jest.mock('@cardstack/services', () => ({
+  useGetProfileJobStatusQuery: jest.fn(),
+  usePostProfileJobRetryMutation: jest.fn(),
+}));
+
+const mockJobParams = { jobID: 'ANY', onJobCompletedCallback: jest.fn() };
+
+const mockJobRetryMutation = jest.fn();
+
+describe('useProfileJobPolling', () => {
+  const mockUseGetProfileJobStatusQuery = (
+    state: 'pending' | 'success' | 'failed' = 'pending',
+    error?: any
+  ) => {
+    (useGetProfileJobStatusQuery as jest.Mock).mockImplementation(() => ({
+      data: {
+        attributes: {
+          state,
+        },
+      },
+      error,
+    }));
+  };
+
+  // Once isSuccess is true, polling restarts.
+  const mockUsePostProfileJobRetryMutation = (isSuccess = false) => {
+    (usePostProfileJobRetryMutation as jest.Mock).mockImplementation(() => [
+      mockJobRetryMutation,
+      { isSuccess },
+    ]);
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    mockUseGetProfileJobStatusQuery();
+    mockUsePostProfileJobRetryMutation();
+  });
+
+  it('should start hook waiting when jobID not provided', () => {
+    const { result } = renderHook(() =>
+      useProfileJobPolling({ ...mockJobParams, jobID: undefined })
+    );
+
+    expect(result.current.isCreatingProfile).toBeFalsy();
+  });
+
+  it('should start hook polling when jobID provided', () => {
+    const { result } = renderHook(() => useProfileJobPolling(mockJobParams));
+
+    expect(result.current.isCreatingProfile).toBeTruthy();
+  });
+
+  it('should stop polling with no errors on profile success', () => {
+    const { result, rerender } = renderHook(() =>
+      useProfileJobPolling(mockJobParams)
+    );
+
+    mockUseGetProfileJobStatusQuery('success');
+    rerender();
+
+    expect(result.current.isCreatingProfile).toBeFalsy();
+  });
+
+  it('should return profile error flag on job has failed', () => {
+    const { result, rerender } = renderHook(() =>
+      useProfileJobPolling(mockJobParams)
+    );
+
+    mockUseGetProfileJobStatusQuery('failed');
+    rerender();
+
+    expect(result.current.isCreateProfileError).toBeTruthy();
+  });
+
+  it('should be able to call retry function if job has failed', () => {
+    const { result, rerender } = renderHook(() =>
+      useProfileJobPolling(mockJobParams)
+    );
+
+    mockUseGetProfileJobStatusQuery('failed');
+    rerender();
+
+    act(() => {
+      result.current.retryCurrentCreateProfile();
+    });
+
+    expect(mockJobRetryMutation).toBeCalled();
+  });
+
+  it('should resume polling once retry call is successful', () => {
+    const { result, rerender } = renderHook(() =>
+      useProfileJobPolling(mockJobParams)
+    );
+
+    mockUseGetProfileJobStatusQuery('failed');
+    rerender();
+
+    expect(result.current.isCreatingProfile).toBeFalsy();
+
+    mockUsePostProfileJobRetryMutation(true);
+    rerender();
+
+    expect(result.current.isCreatingProfile).toBeTruthy();
+  });
+});


### PR DESCRIPTION
### Description

This PR adds tests to `useProfileJobPolling` hook, checking if job state responses and retry call triggers the right returns.

- [x] Completes #(CS-4455)