### PR TITLE
[CS-4478]: Fix payment schema scan

### DIFF
--- a/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/useScanner.ts
+++ b/cardstack/src/screens/QRScannerScreen/pages/QRCodeScanner/useScanner.ts
@@ -1,14 +1,10 @@
 import { isValidMerchantPaymentUrl } from '@cardstack/cardpay-sdk';
-import {
-  useFocusEffect,
-  useLinkTo,
-  useNavigation,
-} from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { useCallback, useRef } from 'react';
 
 import { useBooleanState } from '@cardstack/hooks';
 import useWalletConnectConnections from '@cardstack/hooks/wallet-connect/useWalletConnectConnections';
-import { parseUrlToNavigationPath } from '@cardstack/navigation/Navigation';
+import Navigation from '@cardstack/navigation/Navigation';
 import { Routes } from '@cardstack/navigation/routes';
 import { WCRedirectTypes } from '@cardstack/screens/sheets/WalletConnectRedirectSheet';
 
@@ -31,7 +27,7 @@ export const useScanner = ({
   const { navigate } = useNavigation();
   const { walletConnectOnSessionRequest } = useWalletConnectConnections();
   const [startTimeout] = useTimeout();
-  const linkTo = useLinkTo();
+
   const isWcScanEnabled = useRef(true);
 
   const [
@@ -97,16 +93,11 @@ export const useScanner = ({
     [walletConnectOnSessionRequest, walletConnectOnSessionRequestCallback]
   );
 
-  const handleScanPayMerchant = useCallback(
-    deeplink => {
-      haptics.notificationSuccess();
+  const handleScanPayMerchant = useCallback(deeplink => {
+    haptics.notificationSuccess();
 
-      const parsedLink = parseUrlToNavigationPath(deeplink);
-
-      linkTo(parsedLink);
-    },
-    [linkTo]
-  );
+    Navigation.linkTo(deeplink);
+  }, []);
 
   const handleScanInvalid = useCallback(
     qrCodeData => {


### PR DESCRIPTION
### Description

The QR code inside the app, is generated with `cardwallet://`, when we crop the prefixes, the remaining path, doesn't start with `/` which triggers [this error ](https://github.com/react-navigation/react-navigation/blob/4ae53e1705e39aee75041928c07a56ec110bfd05/packages/native/src/useLinkTo.tsx#L45)on react navigation, BUT, this check seems useless giving that `getStateFromPath ` knows how to handle a path that doesn't start with `/` as we can see [here](https://github.com/react-navigation/react-navigation/blob/e8c374e0643a1521566c654e0052b53f2fd0667a/packages/core/src/__tests__/getStateFromPath.test.tsx#L137) , anyways, since we have our own linkTo implementation we'll be using that for now inside the app too.


### Checklist

- [x] Tested on iOS
- [x] Tested on Android

