### PR TITLE
[CS-4499] Add returnKeyType DONE to Profile Creation inputs

### DIFF
--- a/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
+++ b/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
@@ -57,6 +57,7 @@ const SuffixedInput = ({
       allowFontScaling={false}
       onChangeText={onChangeText}
       value={value}
+      returnKeyType="done"
     />
     <Text
       style={styles.textStyle}

--- a/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
+++ b/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
@@ -263,6 +263,7 @@ export const ProfileNameScreen = () => {
             paddingBottom={4}
             onChangeText={onChangeText}
             value={profile.name}
+            returnKeyType="done"
           />
           <Container width="80%" flex={1}>
             <Text fontSize={12} color="grayText">


### PR DESCRIPTION
### Description
This PR enhances the user experience on the Profile Creation flow, changing the keyboard action key to be "Done" (iOS) or a checkmark (Android), instead of the default action key.

- [x] Completes #CS-4499

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/186518438-873e0bb0-8dcd-434c-8321-7cb3f49afd22.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/186517564-991872b5-2c61-4720-8d4b-50f673c3ff4d.png">
