### PR TITLE
[CS-4482] Disabling confirm button while loading data

### DIFF
--- a/cardstack/src/components/TransactionConfirmationSheet/TransactionConfirmationSheet.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/TransactionConfirmationSheet.tsx
@@ -124,6 +124,7 @@ const Header = ({
 const SheetFooter = ({
   onConfirm,
   onCancel,
+  loading,
   onConfirmLoading = false,
   disabledConfirmButton,
 }: TransactionConfirmationDisplayProps) => (
@@ -146,7 +147,7 @@ const SheetFooter = ({
         {strings.buttons.cancel}
       </Button>
       <Button
-        loading={onConfirmLoading}
+        loading={onConfirmLoading || loading}
         variant="small"
         onPress={onConfirm}
         disabled={disabledConfirmButton}

--- a/cardstack/src/components/TransactionConfirmationSheet/TransactionConfirmationSheet.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/TransactionConfirmationSheet.tsx
@@ -147,10 +147,10 @@ const SheetFooter = ({
         {strings.buttons.cancel}
       </Button>
       <Button
-        loading={onConfirmLoading || loading}
+        loading={onConfirmLoading}
         variant="small"
         onPress={onConfirm}
-        disabled={disabledConfirmButton}
+        disabled={disabledConfirmButton || loading}
       >
         {strings.buttons.submit}
       </Button>

--- a/cardstack/src/components/TransactionConfirmationSheet/displays/Merchant/RegisterMerchantDisplay.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/displays/Merchant/RegisterMerchantDisplay.tsx
@@ -5,6 +5,7 @@ import { useMerchantInfoFromDID } from '@cardstack/hooks/merchant/useMerchantInf
 import { RegisterMerchantDecodedData } from '@cardstack/types';
 
 import { strings } from '../../strings';
+import { ProfileSectionSkeleton } from '../components/ProfileSectionSkeleton';
 import TransactionListItem from '../components/TransactionListItem';
 import { PayThisAmountSection } from '../components/sections/PayThisAmountSection';
 import { PrepaidCardTransactionSection } from '../components/sections/PrepaidCardTransactionSection';
@@ -15,6 +16,7 @@ interface RegisterMerchantDisplayProps
 }
 
 export const RegisterMerchantDisplay = ({
+  disabledConfirmButton: isLoading,
   data: { infoDID, merchantInfo, prepaidCard, spendAmount },
 }: RegisterMerchantDisplayProps) => {
   const { merchantInfoDID } = useMerchantInfoFromDID(infoDID);
@@ -28,7 +30,9 @@ export const RegisterMerchantDisplay = ({
           title={merchantInfoData.name || strings.createProfile.profileName}
           avatarInfo={merchantInfoData}
         />
-      ) : null}
+      ) : (
+        <ProfileSectionSkeleton headerText={strings.createProfile.create} />
+      )}
       <PrepaidCardTransactionSection
         headerText={strings.createProfile.from}
         prepaidCardAddress={prepaidCard}
@@ -36,6 +40,7 @@ export const RegisterMerchantDisplay = ({
       <PayThisAmountSection
         headerText={strings.createProfile.payThisAmount}
         spendAmount={spendAmount}
+        isLoading={isLoading}
       />
     </>
   );

--- a/cardstack/src/components/TransactionConfirmationSheet/displays/components/ProfileSectionSkeleton.tsx
+++ b/cardstack/src/components/TransactionConfirmationSheet/displays/components/ProfileSectionSkeleton.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { Container, Skeleton, HorizontalDivider } from '@cardstack/components';
+
+import { SectionHeaderText } from './SectionHeaderText';
+
+export const ProfileSectionSkeleton = ({ headerText = '' }) => (
+  <>
+    <SectionHeaderText>{headerText}</SectionHeaderText>
+    <Container flexDirection="row" marginTop={5} marginLeft={2}>
+      <Skeleton width="8%" height={18} light marginRight={4} borderRadius={7} />
+      <Skeleton width="35%" height={18} light />
+    </Container>
+    <HorizontalDivider />
+  </>
+);

--- a/cardstack/src/hooks/prepaid-card/usePrepaidCard.ts
+++ b/cardstack/src/hooks/prepaid-card/usePrepaidCard.ts
@@ -1,18 +1,25 @@
-import { useGetPrepaidCardsQuery } from '@cardstack/services';
+import { useGetSafesDataQuery } from '@cardstack/services';
+import { isLayer1 } from '@cardstack/utils';
 
 import { useAccountSettings } from '@rainbow-me/hooks';
 
 import { useSpendToNativeDisplay } from '../currencies/useSpendDisplay';
 
 export const usePrepaidCard = (address: string) => {
-  const { accountAddress, nativeCurrency } = useAccountSettings();
+  const { accountAddress, network, nativeCurrency } = useAccountSettings();
 
-  const { prepaidCard, isLoading } = useGetPrepaidCardsQuery(
-    { accountAddress, nativeCurrency },
+  const { isLoading = true, prepaidCard } = useGetSafesDataQuery(
+    { address: accountAddress, nativeCurrency },
     {
-      selectFromResult: ({ data, ...rest }) => ({
+      refetchOnMountOrArgChange: 60,
+      skip: isLayer1(network) || !accountAddress,
+      selectFromResult: ({
+        data,
+        isLoading: isLoadingCards,
+        isUninitialized,
+      }) => ({
         prepaidCard: data?.prepaidCards?.find(card => card.address === address),
-        ...rest,
+        isLoading: isLoadingCards || isUninitialized,
       }),
     }
   );


### PR DESCRIPTION
### Description

PR to improve data loading on RegisterMerchantDisplay transaction sheet.

- Changes `usePrepaidCard` hook to use `useGetSafesDataQuery` that has probably already cached safes, instead of `useGetPrepaidCardsQuery` that would be a new query;
- Adds isLoading for `PayThisAmountSection` on `RegisterMerchantDisplay` too;
- Adds skeleton to Profile header info;
- Passes `disabledConfirmButton` on Register to disable pay section until loading done.

Note:

As it is now, we can't determine for certain when individual sections finish loading, they don't have a way to report back. It's imperceptible, but confirm button is still being enabled before all is loaded. Fixing this is honestly not worth it since loading is shown in all sections now and it's usually fast.

- [x] Completes #(CS-4482)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

https://user-images.githubusercontent.com/129619/186911011-41d25b37-8d52-4570-ac8a-6aab37bdf882.mp4


