### PR TITLE
[CS-4426]: Handle pending/failed profile job on init 

### DIFF
--- a/cardstack/src/hooks/__tests__/useProfileJobPolling.test.ts
+++ b/cardstack/src/hooks/__tests__/useProfileJobPolling.test.ts
@@ -13,7 +13,7 @@ jest.mock('@cardstack/services', () => ({
   usePostProfileJobRetryMutation: jest.fn(),
 }));
 
-const mockJobParams = { jobID: 'ANY', onJobCompletedCallback: jest.fn() };
+const mockJobParams = { jobID: 'ANY' };
 
 const mockJobRetryMutation = jest.fn();
 
@@ -23,11 +23,7 @@ describe('useProfileJobPolling', () => {
     error?: any
   ) => {
     (useGetProfileJobStatusQuery as jest.Mock).mockImplementation(() => ({
-      data: {
-        attributes: {
-          state,
-        },
-      },
+      data: state,
       error,
     }));
   };

--- a/cardstack/src/screens/ProfileScreen/useProfileScreen.ts
+++ b/cardstack/src/screens/ProfileScreen/useProfileScreen.ts
@@ -31,16 +31,6 @@ export const useProfileScreen = () => {
     hasProfile,
   } = usePrimarySafe();
 
-  // When the new profile is done, we need to refresh the safes list.
-  const onJobCompletedCallback = useCallback(
-    error => {
-      if (!error) {
-        refetch();
-      }
-    },
-    [refetch]
-  );
-
   const {
     data: pendingJobId,
     isLoading: isLoadingProfileJobs,
@@ -55,7 +45,6 @@ export const useProfileScreen = () => {
     retryCurrentCreateProfile,
   } = useProfileJobPolling({
     jobID: params?.profileCreationJobID || pendingJobId,
-    onJobCompletedCallback,
   });
 
   const { network } = useAccountSettings();

--- a/cardstack/src/screens/ProfileScreen/useProfileScreen.ts
+++ b/cardstack/src/screens/ProfileScreen/useProfileScreen.ts
@@ -8,6 +8,7 @@ import {
 import { Routes } from '@cardstack/navigation';
 import { RouteType } from '@cardstack/navigation/types';
 import { usePrimarySafe } from '@cardstack/redux/hooks/usePrimarySafe';
+import { useGetProfileUnfulfilledJobQuery } from '@cardstack/services';
 
 import { useAccountSettings } from '@rainbow-me/hooks';
 import { SettingsPages } from '@rainbow-me/screens/SettingsModal';
@@ -27,6 +28,7 @@ export const useProfileScreen = () => {
     safesCount,
     isLoading,
     isUninitialized,
+    hasProfile,
   } = usePrimarySafe();
 
   // When the new profile is done, we need to refresh the safes list.
@@ -40,12 +42,19 @@ export const useProfileScreen = () => {
   );
 
   const {
+    data: pendingJobId,
+    isLoading: isLoadingProfileJobs,
+  } = useGetProfileUnfulfilledJobQuery(undefined, {
+    skip: isLoading || isUninitialized || hasProfile,
+  });
+
+  const {
     isConnectionError,
     isCreatingProfile,
     isCreateProfileError,
     retryCurrentCreateProfile,
   } = useProfileJobPolling({
-    jobID: params?.profileCreationJobID,
+    jobID: params?.profileCreationJobID || pendingJobId,
     onJobCompletedCallback,
   });
 
@@ -59,14 +68,16 @@ export const useProfileScreen = () => {
       isUninitialized ||
       isRefreshingForNewAccount ||
       isCreatingProfile ||
+      isLoadingProfileJobs ||
       (isFetching && !primarySafe),
     [
-      isFetching,
       isLoading,
-      isRefreshingForNewAccount,
       isUninitialized,
-      primarySafe,
+      isRefreshingForNewAccount,
       isCreatingProfile,
+      isLoadingProfileJobs,
+      isFetching,
+      primarySafe,
     ]
   );
 

--- a/cardstack/src/services/hub/hub-api.ts
+++ b/cardstack/src/services/hub/hub-api.ts
@@ -26,8 +26,8 @@ import {
   GetValidateProfileSlugParams,
   CreateProfileInfoParams,
   PostProfilePurchaseQueryResult,
-  JobTicketResult,
   UpdateProfileInfoParams,
+  JobTicketTypeResult,
 } from './hub-types';
 
 const routes = {
@@ -152,7 +152,7 @@ export const hubApi = createApi({
       },
     }),
     getProfileJobStatus: builder.query<
-      JobTicketResult,
+      JobTicketTypeResult,
       { jobTicketID: string }
     >({
       query: ({ jobTicketID }) =>
@@ -164,6 +164,18 @@ export const hubApi = createApi({
         url: `${routes.profileInfo.jobTicket}/${jobTicketID}/retry`,
         method: 'POST',
       }),
+    }),
+    getProfileUnfulfilledJob: builder.query<string | undefined, void>({
+      query: () => `${routes.profileInfo.jobTicket}`,
+      transformResponse: ({ data }: { data: JobTicketTypeResult[] }) => {
+        const unfulfilledJob = data.find(
+          ({ attributes }) =>
+            attributes['job-type'] === 'create-profile' &&
+            attributes.state !== 'success'
+        );
+
+        return unfulfilledJob?.id;
+      },
     }),
   }),
 });
@@ -182,4 +194,5 @@ export const {
   useGetProfileJobStatusQuery,
   usePostProfileJobRetryMutation,
   useUpdateProfileInfoMutation,
+  useGetProfileUnfulfilledJobQuery,
 } = hubApi;

--- a/cardstack/src/services/hub/hub-types.ts
+++ b/cardstack/src/services/hub/hub-types.ts
@@ -80,7 +80,7 @@ export interface PostProfilePurchaseQueryResult {
   ];
 }
 
-type JobStateType = 'pending' | 'success' | 'failed' | undefined;
+export type JobStateType = 'pending' | 'success' | 'failed';
 
 export interface JobTicketTypeResult {
   id: string;

--- a/cardstack/src/services/hub/hub-types.ts
+++ b/cardstack/src/services/hub/hub-types.ts
@@ -82,16 +82,14 @@ export interface PostProfilePurchaseQueryResult {
 
 type JobStateType = 'pending' | 'success' | 'failed' | undefined;
 
-interface JobTicketType {
+export interface JobTicketTypeResult {
   id: string;
   type: string;
   attributes: {
-    'job-type': string;
+    'job-type': string | 'create-profile';
     state: JobStateType;
     result: {
       id: string;
     };
   };
 }
-
-export type JobTicketResult = KebabToCamelCaseKeys<JobTicketType>;


### PR DESCRIPTION
### Description

This PR adds the query to check if there's any pending or failed job on profile init, it also updates the profilejobPolling to invalidate the cache on the api, instead of having a callback.

<!-- Please, include a summary of the changes. -->

### Checklist

- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->

Video on [Linear ticket](https://linear.app/cardstack/issue/CS-4426/[logic]-get-job-tickets-for-type-creation-profile-for-a-eoa-on-opening)
