### PR TITLE
[CS-4518] Staking tag only on Depot

### DIFF
--- a/cardstack/src/components/BalanceSection/BalanceSection.tsx
+++ b/cardstack/src/components/BalanceSection/BalanceSection.tsx
@@ -5,6 +5,7 @@ import { ScrollView } from 'react-native';
 import { Container, TokenBalance } from '@cardstack/components';
 import { Routes } from '@cardstack/navigation';
 import { TokenType } from '@cardstack/types';
+import { isBridgedCardToken } from '@cardstack/utils';
 
 interface BalancesProps {
   tokens: TokenType[];
@@ -35,7 +36,7 @@ export const BalanceSection = ({
     () =>
       tokens.map(token => (
         <TokenBalance
-          isOnDepot={isDepot}
+          isStaking={isBridgedCardToken(token.token.symbol) && isDepot}
           key={token.tokenAddress}
           address={token.tokenAddress}
           includeBorder

--- a/cardstack/src/components/BalanceSection/BalanceSection.tsx
+++ b/cardstack/src/components/BalanceSection/BalanceSection.tsx
@@ -9,9 +9,14 @@ import { TokenType } from '@cardstack/types';
 interface BalancesProps {
   tokens: TokenType[];
   safeAddress: string;
+  isDepot?: boolean;
 }
 
-export const BalanceSection = ({ tokens, safeAddress }: BalancesProps) => {
+export const BalanceSection = ({
+  tokens,
+  safeAddress,
+  isDepot = false,
+}: BalancesProps) => {
   const { navigate } = useNavigation();
 
   const onPress = useCallback(
@@ -30,6 +35,7 @@ export const BalanceSection = ({ tokens, safeAddress }: BalancesProps) => {
     () =>
       tokens.map(token => (
         <TokenBalance
+          isOnDepot={isDepot}
           key={token.tokenAddress}
           address={token.tokenAddress}
           includeBorder
@@ -41,7 +47,7 @@ export const BalanceSection = ({ tokens, safeAddress }: BalancesProps) => {
           zIndex={1}
         />
       )),
-    [onPress, tokens]
+    [onPress, tokens, isDepot]
   );
 
   return (

--- a/cardstack/src/components/Depot/Depot.tsx
+++ b/cardstack/src/components/Depot/Depot.tsx
@@ -51,6 +51,7 @@ const Bottom = ({ tokens }: DepotProps) => {
       {firstThreeTokens.map((item, index) => (
         <Container key={`token-balance-${index}`}>
           <TokenBalance
+            isOnDepot
             address={item.tokenAddress}
             tokenSymbol={item.token.symbol}
             tokenBalance={item.balance.display}

--- a/cardstack/src/components/Depot/Depot.tsx
+++ b/cardstack/src/components/Depot/Depot.tsx
@@ -9,6 +9,7 @@ import {
 } from '@cardstack/components';
 import { Routes } from '@cardstack/navigation';
 import { DepotType } from '@cardstack/types';
+import { isBridgedCardToken } from '@cardstack/utils';
 
 import { HorizontalDivider } from '../HorizontalDivider';
 import { MoreItemsFooter } from '../MoreItemsFooter';
@@ -51,7 +52,7 @@ const Bottom = ({ tokens }: DepotProps) => {
       {firstThreeTokens.map((item, index) => (
         <Container key={`token-balance-${index}`}>
           <TokenBalance
-            isOnDepot
+            isStaking={isBridgedCardToken(item.token.symbol)}
             address={item.tokenAddress}
             tokenSymbol={item.token.symbol}
             tokenBalance={item.balance.display}

--- a/cardstack/src/components/TokenBalance/TokenBalance.tsx
+++ b/cardstack/src/components/TokenBalance/TokenBalance.tsx
@@ -26,7 +26,7 @@ export interface TokenBalanceProps extends ContainerProps {
   includeBorder?: boolean;
   isLastItemIfList?: boolean;
   size?: number;
-  isOnDepot?: boolean;
+  isStaking?: boolean;
 }
 
 const borderStyle = {
@@ -49,14 +49,12 @@ export const TokenBalance = (props: TokenBalanceProps) => {
     includeBorder,
     isLastItemIfList = true,
     size = 40,
-    isOnDepot = false,
+    isStaking = false,
     ...containerProps
   } = props;
 
   const borderProps = includeBorder ? borderStyle : {};
   const Wrapper = onPress ? Touchable : Container;
-
-  const isCardCPXD = tokenSymbol === 'CARD.CPXD';
 
   return (
     <Wrapper onPress={onPress} {...borderProps} {...containerProps}>
@@ -93,7 +91,7 @@ export const TokenBalance = (props: TokenBalanceProps) => {
               <Text variant="subText">{nativeBalance}</Text>
             </Container>
           </Container>
-          {isOnDepot && isCardCPXD && <FloatingTag copy={strings.staking} />}
+          {isStaking && <FloatingTag copy={strings.staking} />}
         </Container>
       </Container>
     </Wrapper>

--- a/cardstack/src/components/TokenBalance/TokenBalance.tsx
+++ b/cardstack/src/components/TokenBalance/TokenBalance.tsx
@@ -26,6 +26,7 @@ export interface TokenBalanceProps extends ContainerProps {
   includeBorder?: boolean;
   isLastItemIfList?: boolean;
   size?: number;
+  isOnDepot?: boolean;
 }
 
 const borderStyle = {
@@ -48,6 +49,7 @@ export const TokenBalance = (props: TokenBalanceProps) => {
     includeBorder,
     isLastItemIfList = true,
     size = 40,
+    isOnDepot = false,
     ...containerProps
   } = props;
 
@@ -91,7 +93,7 @@ export const TokenBalance = (props: TokenBalanceProps) => {
               <Text variant="subText">{nativeBalance}</Text>
             </Container>
           </Container>
-          {isCardCPXD && <FloatingTag copy={strings.staking} />}
+          {isOnDepot && isCardCPXD && <FloatingTag copy={strings.staking} />}
         </Container>
       </Container>
     </Wrapper>

--- a/cardstack/src/screens/DepotScreen.tsx
+++ b/cardstack/src/screens/DepotScreen.tsx
@@ -149,7 +149,7 @@ export default function DepotScreen() {
           backgroundColor="white"
           zIndex={getTabStackOrder(Tabs.BALANCES)}
         >
-          <BalanceSection tokens={tokens} safeAddress={address} />
+          <BalanceSection isDepot tokens={tokens} safeAddress={address} />
         </AbsoluteFullScreenContainer>
         <Container
           flex={1}

--- a/cardstack/src/utils/depot-utils.ts
+++ b/cardstack/src/utils/depot-utils.ts
@@ -18,3 +18,6 @@ export const reshapeDepotTokensToAssets = (depot: DepotType) =>
 
     return tokens;
   }, []);
+
+export const isBridgedCardToken = (tokenSymbol: string) =>
+  tokenSymbol === 'CARD.CPXD';


### PR DESCRIPTION
### Description

PR adds flags isDepot to BalanceSection and isOnDepot on TokenBalance to only show staking tag when it's in a depot.

- [x] Completes #(CS-4518)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<img width="300" src="https://user-images.githubusercontent.com/129619/186684229-9de314f5-e941-49b8-b653-027053684540.jpg">

<img width="300" src="https://user-images.githubusercontent.com/129619/186684249-0347fa65-8d85-4120-9f68-1c15b217fbfc.jpg">

<img width="300" src="https://user-images.githubusercontent.com/129619/186698743-f8fb92ce-e7cf-46f0-9827-0c99b427cafb.jpg">

