### PR TITLE
[CS-4445] Reward claim step over

### DIFF
--- a/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
@@ -20,7 +20,7 @@ const RewardsCenterScreen = () => {
     hasRewardsAvailable,
     mainPoolTokenInfo,
     isLoading,
-    canClaimAll
+    canClaimAll,
   } = useRewardsCenterScreen();
 
   const mainPoolRowProps = useMemo(
@@ -29,9 +29,8 @@ const RewardsCenterScreen = () => {
       subText: mainPoolTokenInfo?.native.balance.display || '',
       coinSymbol: mainPoolTokenInfo?.token.symbol || '',
       showClaimBtn: canClaimAll,
-      
     }),
-    [mainPoolTokenInfo]
+    [mainPoolTokenInfo, canClaimAll]
   );
 
   return (

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
@@ -27,7 +27,7 @@ const RewardsCenterScreen = () => {
       primaryText: fullBalanceToken?.balance.display || '',
       subText: fullBalanceToken?.native.balance.display || '',
       coinSymbol: fullBalanceToken?.token.symbol || '',
-      showClaimBtn: fullBalanceToken?.isClaimable,
+      isClaimable: !!fullBalanceToken?.isClaimable,
     }),
     [fullBalanceToken]
   );

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
@@ -20,6 +20,7 @@ const RewardsCenterScreen = () => {
     hasRewardsAvailable,
     mainPoolTokenInfo,
     isLoading,
+    canClaimAll
   } = useRewardsCenterScreen();
 
   const mainPoolRowProps = useMemo(
@@ -27,6 +28,8 @@ const RewardsCenterScreen = () => {
       primaryText: mainPoolTokenInfo?.balance.display || '',
       subText: mainPoolTokenInfo?.native.balance.display || '',
       coinSymbol: mainPoolTokenInfo?.token.symbol || '',
+      showClaimBtn: canClaimAll,
+      
     }),
     [mainPoolTokenInfo]
   );

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
@@ -18,19 +18,18 @@ const RewardsCenterScreen = () => {
   const {
     isRegistered,
     hasRewardsAvailable,
-    mainPoolTokenInfo,
+    fullBalanceToken,
     isLoading,
-    canClaimAll,
   } = useRewardsCenterScreen();
 
   const mainPoolRowProps = useMemo(
     () => ({
-      primaryText: mainPoolTokenInfo?.balance.display || '',
-      subText: mainPoolTokenInfo?.native.balance.display || '',
-      coinSymbol: mainPoolTokenInfo?.token.symbol || '',
-      showClaimBtn: canClaimAll,
+      primaryText: fullBalanceToken?.balance.display || '',
+      subText: fullBalanceToken?.native.balance.display || '',
+      coinSymbol: fullBalanceToken?.token.symbol || '',
+      showClaimBtn: fullBalanceToken?.isClaimable,
     }),
-    [mainPoolTokenInfo, canClaimAll]
+    [fullBalanceToken]
   );
 
   return (

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsClaimSheet/useRewardsClaim.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsClaimSheet/useRewardsClaim.ts
@@ -5,8 +5,8 @@ import { defaultErrorAlert } from '@cardstack/constants';
 import { useMutationEffects } from '@cardstack/hooks';
 import { useLoadingOverlay } from '@cardstack/navigation';
 import {
-  useClaimRewardsMutation,
-  useGetClaimRewardsGasEstimateQuery,
+  useClaimAllRewardsMutation,
+  useGetClaimAllRewardsGasEstimateQuery,
 } from '@cardstack/services/rewards-center/rewards-center-api';
 import {
   RewardsClaimData,
@@ -32,19 +32,19 @@ const useRewardsClaim = () => {
   const {
     rewardSafes,
     defaultRewardProgramId,
-    mainPoolTokenInfo,
+    claimSheetTokenInfo,
   } = useRewardsDataFetch();
 
   // flag to avoid rerendering the screen after the claim happened
   const isClaiming = useRef(false);
-  const mainPoolTokenRef = useRef(mainPoolTokenInfo);
+  const mainPoolTokenRef = useRef(claimSheetTokenInfo);
 
   const { dismissLoadingOverlay, showLoadingOverlay } = useLoadingOverlay();
 
   const [
-    claimRewards,
+    claimAllRewards,
     { isSuccess: isClaimSuccess, isError: isClaimError },
-  ] = useClaimRewardsMutation();
+  ] = useClaimAllRewardsMutation();
 
   const rewardSafeForProgram = useMemo(
     () =>
@@ -65,7 +65,7 @@ const useRewardsClaim = () => {
     data: estimatedGasClaim,
     isLoading: loadingEstimatedGasClaim,
     isFetching: fetchingEstimatedGasClaim,
-  } = useGetClaimRewardsGasEstimateQuery(claimParams, {
+  } = useGetClaimAllRewardsGasEstimateQuery(claimParams, {
     refetchOnMountOrArgChange: true,
     skip: isClaiming.current,
   });
@@ -89,8 +89,8 @@ const useRewardsClaim = () => {
     showLoadingOverlay({ title: strings.claim.loading });
 
     isClaiming.current = true;
-    claimRewards(claimParams);
-  }, [showLoadingOverlay, claimRewards, claimParams]);
+    claimAllRewards(claimParams);
+  }, [showLoadingOverlay, claimAllRewards, claimParams]);
 
   const onClaimFulfilledAlert = useCallback(
     ({ title, message, dismiss }: onClaimCallbackProps) => () => {

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsClaimSheet/useRewardsClaim.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsClaimSheet/useRewardsClaim.ts
@@ -32,12 +32,12 @@ const useRewardsClaim = () => {
   const {
     rewardSafes,
     defaultRewardProgramId,
-    claimSheetTokenInfo,
+    claimableBalanceToken,
   } = useRewardsDataFetch();
 
   // flag to avoid rerendering the screen after the claim happened
   const isClaiming = useRef(false);
-  const mainPoolTokenRef = useRef(claimSheetTokenInfo);
+  const claimableBalanceTokenRef = useRef(claimableBalanceToken);
 
   const { dismissLoadingOverlay, showLoadingOverlay } = useLoadingOverlay();
 
@@ -57,7 +57,7 @@ const useRewardsClaim = () => {
   const claimParams = {
     accountAddress,
     rewardProgramId: defaultRewardProgramId,
-    tokenAddress: mainPoolTokenRef.current?.tokenAddress || '',
+    tokenAddress: claimableBalanceTokenRef.current?.tokenAddress || '',
     safeAddress: rewardSafeForProgram?.address || '',
   };
 
@@ -75,11 +75,11 @@ const useRewardsClaim = () => {
       loadingGasEstimate: loadingEstimatedGasClaim || fetchingEstimatedGasClaim,
       type: TransactionConfirmationType.REWARDS_CLAIM,
       estGasFee: estimatedGasClaim || '0.10',
-      ...mainPoolTokenRef.current,
+      ...claimableBalanceTokenRef.current,
     }),
     [
       estimatedGasClaim,
-      mainPoolTokenRef,
+      claimableBalanceTokenRef,
       loadingEstimatedGasClaim,
       fetchingEstimatedGasClaim,
     ]
@@ -131,7 +131,7 @@ const useRewardsClaim = () => {
 
   return {
     onConfirm,
-    data: screenData as RewardsClaimData, // type casting bc mainPoolTokenInfo type has undefined
+    data: screenData as RewardsClaimData, // type casting bc fullBalanceToken type has undefined
     onCancel: goBack,
   };
 };

--- a/cardstack/src/screens/RewardsCenterScreen/__tests__/mocks.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/__tests__/mocks.ts
@@ -25,7 +25,7 @@ export const mockRewardSafeForProgram = [
   },
 ];
 
-export const mockMainPoolTokenInfo = {
+export const mockfullBalanceToken = {
   balance: {
     amount: '52.479664130149567042',
     display: '52.48 CARD.CPXD',
@@ -37,7 +37,7 @@ export const mockMainPoolTokenInfo = {
   tokenAddress: '0x52031d287Bb58E26A379A7Fec2c84acB54f54fe3',
 };
 
-export const mockClaimSheetTokenInfo = {
+export const mockclaimableBalanceToken = {
   balance: {
     amount: '52.479664130149567042',
     display: '52.48 CARD.CPXD',

--- a/cardstack/src/screens/RewardsCenterScreen/__tests__/mocks.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/__tests__/mocks.ts
@@ -36,3 +36,15 @@ export const mockMainPoolTokenInfo = {
   token: { symbol: 'CARD.CPXD' },
   tokenAddress: '0x52031d287Bb58E26A379A7Fec2c84acB54f54fe3',
 };
+
+export const mockClaimSheetTokenInfo = {
+  balance: {
+    amount: '52.479664130149567042',
+    display: '52.48 CARD.CPXD',
+    wei: '02d84d387a295fca42',
+  },
+  native: { balance: { amount: 0.10871897, display: '$0.109 USD' } },
+  rewardProgramId: '0x979C9F171fb6e9BC501Aa7eEd71ca8dC27cF1185',
+  token: { symbol: 'CARD.CPXD' },
+  tokenAddress: '0x52031d287Bb58E26A379A7Fec2c84acB54f54fe3',
+};

--- a/cardstack/src/screens/RewardsCenterScreen/__tests__/useRewardsClaim.test.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/__tests__/useRewardsClaim.test.ts
@@ -3,13 +3,17 @@ import { Alert } from 'react-native';
 import { act } from 'react-test-renderer';
 
 import { defaultErrorAlert } from '@cardstack/constants';
-import { useClaimRewardsMutation } from '@cardstack/services/rewards-center/rewards-center-api';
+import { useClaimAllRewardsMutation } from '@cardstack/services/rewards-center/rewards-center-api';
 
 import useRewardsClaim from '../RewardsClaimSheet/useRewardsClaim';
 import { strings } from '../strings';
 import useRewardsDataFetch from '../useRewardsDataFetch';
 
-import { mockMainPoolTokenInfo, mockRewardSafeForProgram } from './mocks';
+import {
+  mockClaimSheetTokenInfo,
+  mockMainPoolTokenInfo,
+  mockRewardSafeForProgram,
+} from './mocks';
 
 const mockedShowOverlay = jest.fn();
 const mockedDismissOverlay = jest.fn();
@@ -17,6 +21,7 @@ const accountAddress = '0x0000000000000000000';
 const mockedGoBack = jest.fn();
 const rewardSafes = mockRewardSafeForProgram;
 const mainPoolTokenInfo = mockMainPoolTokenInfo;
+const claimSheetTokenInfo = mockClaimSheetTokenInfo;
 const defaultRewardProgramId = '0x979C9F171fb6e9BC501Aa7eEd71ca8dC27cF1185';
 
 jest.mock('@react-navigation/native', () => ({
@@ -39,8 +44,8 @@ jest.mock('@rainbow-me/hooks', () => ({
 }));
 
 jest.mock('@cardstack/services/rewards-center/rewards-center-api', () => ({
-  useClaimRewardsMutation: jest.fn(),
-  useGetClaimRewardsGasEstimateQuery: jest.fn().mockResolvedValue('0.20'),
+  useClaimAllRewardsMutation: jest.fn(),
+  useGetClaimAllRewardsGasEstimateQuery: jest.fn().mockResolvedValue('0.20'),
 }));
 
 jest.mock('../useRewardsDataFetch', () => jest.fn());
@@ -57,6 +62,7 @@ describe('useRewardsClaim', () => {
       rewardSafes,
       defaultRewardProgramId,
       mainPoolTokenInfo,
+      claimSheetTokenInfo,
       ...overwriteProps,
     }));
 
@@ -64,7 +70,7 @@ describe('useRewardsClaim', () => {
     isSuccess: boolean;
     isError: boolean;
   }) => {
-    (useClaimRewardsMutation as jest.Mock).mockImplementation(() => [
+    (useClaimAllRewardsMutation as jest.Mock).mockImplementation(() => [
       mockedClaimRewards.mockResolvedValue(Promise.resolve()),
       {
         isSuccess: true,
@@ -97,12 +103,12 @@ describe('useRewardsClaim', () => {
     expect(mockedClaimRewards).toBeCalledWith({
       accountAddress,
       rewardProgramId: defaultRewardProgramId,
-      tokenAddress: mockMainPoolTokenInfo.tokenAddress,
+      tokenAddress: mockClaimSheetTokenInfo.tokenAddress,
       safeAddress: mockRewardSafeForProgram[0].address,
     });
   });
 
-  it('shoul show Okay button with an onPress action on Alert after successful claim', () => {
+  it('should show Okay button with an onPress action on Alert after successful claim', () => {
     const { result } = renderHook(() => useRewardsClaim());
 
     act(() => {

--- a/cardstack/src/screens/RewardsCenterScreen/__tests__/useRewardsClaim.test.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/__tests__/useRewardsClaim.test.ts
@@ -10,8 +10,8 @@ import { strings } from '../strings';
 import useRewardsDataFetch from '../useRewardsDataFetch';
 
 import {
-  mockClaimSheetTokenInfo,
-  mockMainPoolTokenInfo,
+  mockclaimableBalanceToken,
+  mockfullBalanceToken,
   mockRewardSafeForProgram,
 } from './mocks';
 
@@ -20,8 +20,8 @@ const mockedDismissOverlay = jest.fn();
 const accountAddress = '0x0000000000000000000';
 const mockedGoBack = jest.fn();
 const rewardSafes = mockRewardSafeForProgram;
-const mainPoolTokenInfo = mockMainPoolTokenInfo;
-const claimSheetTokenInfo = mockClaimSheetTokenInfo;
+const fullBalanceToken = mockfullBalanceToken;
+const claimableBalanceToken = mockclaimableBalanceToken;
 const defaultRewardProgramId = '0x979C9F171fb6e9BC501Aa7eEd71ca8dC27cF1185';
 
 jest.mock('@react-navigation/native', () => ({
@@ -61,8 +61,8 @@ describe('useRewardsClaim', () => {
     (useRewardsDataFetch as jest.Mock).mockImplementation(() => ({
       rewardSafes,
       defaultRewardProgramId,
-      mainPoolTokenInfo,
-      claimSheetTokenInfo,
+      fullBalanceToken,
+      claimableBalanceToken,
       ...overwriteProps,
     }));
 
@@ -103,7 +103,7 @@ describe('useRewardsClaim', () => {
     expect(mockedClaimRewards).toBeCalledWith({
       accountAddress,
       rewardProgramId: defaultRewardProgramId,
-      tokenAddress: mockClaimSheetTokenInfo.tokenAddress,
+      tokenAddress: mockclaimableBalanceToken.tokenAddress,
       safeAddress: mockRewardSafeForProgram[0].address,
     });
   });

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -51,6 +51,7 @@ export const ClaimContent = ({ claimList }: ClaimContentProps) => {
           subText={item.subText}
           paddingBottom={index + 1 < claimList.length ? 5 : 0}
           onClaimPress={onClaimPress}
+          showClaimBtn={item.showClaimBtn}
         />
       )),
     [claimList, onClaimPress]

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -50,8 +50,7 @@ export const ClaimContent = ({ claimList }: ClaimContentProps) => {
           primaryText={item.primaryText}
           subText={item.subText}
           paddingBottom={index + 1 < claimList.length ? 5 : 0}
-          onClaimPress={onClaimPress}
-          showClaimBtn={item.showClaimBtn}
+          onClaimPress={item.isClaimable ? onClaimPress : undefined}
         />
       )),
     [claimList, onClaimPress]

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
@@ -16,11 +16,11 @@ type TxStatus = 'claimed' | 'withdrawn' | 'none';
 export interface RewardRowProps extends Omit<TouchableProps, 'children'> {
   coinSymbol: string;
   primaryText: string;
+  isClaimable?: boolean;
   subText?: string;
   onClaimPress?: () => void;
   isLoading?: boolean;
   showWithdrawBtn?: boolean;
-  showClaimBtn?: boolean;
   txStatus?: TxStatus;
 }
 
@@ -33,7 +33,6 @@ export const RewardRow = ({
   onPress,
   isLoading = false,
   showWithdrawBtn = false,
-  showClaimBtn = true,
   ...props
 }: RewardRowProps) => (
   <CardPressable
@@ -74,7 +73,7 @@ export const RewardRow = ({
           )
         }
       </Container>
-      {!!onClaimPress && showClaimBtn && (
+      {!!onClaimPress && (
         <Container paddingTop={4}>
           <Button
             variant="small"

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardRow.tsx
@@ -20,6 +20,7 @@ export interface RewardRowProps extends Omit<TouchableProps, 'children'> {
   onClaimPress?: () => void;
   isLoading?: boolean;
   showWithdrawBtn?: boolean;
+  showClaimBtn?: boolean;
   txStatus?: TxStatus;
 }
 
@@ -32,6 +33,7 @@ export const RewardRow = ({
   onPress,
   isLoading = false,
   showWithdrawBtn = false,
+  showClaimBtn = true,
   ...props
 }: RewardRowProps) => (
   <CardPressable
@@ -72,7 +74,7 @@ export const RewardRow = ({
           )
         }
       </Container>
-      {!!onClaimPress && (
+      {!!onClaimPress && showClaimBtn && (
         <Container paddingTop={4}>
           <Button
             variant="small"

--- a/cardstack/src/screens/RewardsCenterScreen/strings.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/strings.ts
@@ -20,7 +20,7 @@ export const strings = {
     gasInfoBanner: {
       title: 'Claiming Gas Fee',
       message:
-        'Claiming is an on chain transaction which requires a small blockchain gas fee. This is paid from your claimable reward.',
+        'Claiming is an on chain transaction which requires a small blockchain gas fee. This is paid from your claimable reward. If the reward is insufficient to pay for gas, it is possible to see a reward with no claim button.',
     },
     successAlert: {
       title: 'Success',

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -8,9 +8,8 @@ export const useRewardsCenterScreen = () => {
     rewardPoolTokenBalances,
     defaultRewardProgramId,
     isLoading,
-    mainPoolTokenInfo,
+    fullBalanceToken,
     hasRewardsAvailable,
-    canClaimAll,
   } = useRewardsDataFetch();
 
   const registeredPools = useMemo(
@@ -37,8 +36,7 @@ export const useRewardsCenterScreen = () => {
     rewardPoolTokenBalances,
     isRegistered,
     hasRewardsAvailable,
-    mainPoolTokenInfo,
+    fullBalanceToken,
     isLoading,
-    canClaimAll,
   };
 };

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -10,6 +10,7 @@ export const useRewardsCenterScreen = () => {
     isLoading,
     mainPoolTokenInfo,
     hasRewardsAvailable,
+    canClaimAll,
   } = useRewardsDataFetch();
 
   const registeredPools = useMemo(
@@ -38,5 +39,6 @@ export const useRewardsCenterScreen = () => {
     hasRewardsAvailable,
     mainPoolTokenInfo,
     isLoading,
+    canClaimAll,
   };
 };

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+
 import {
   useGetRewardPoolTokenBalancesQuery,
   useGetRewardsSafeQuery,
@@ -7,6 +8,7 @@ import {
 import { isLayer1 } from '@cardstack/utils';
 
 import { networkTypes } from '@rainbow-me/helpers/networkTypes';
+
 import { useAccountSettings } from '@rainbow-me/hooks';
 
 const rewardDefaultProgramId = {

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
@@ -79,7 +79,8 @@ const useRewardsDataFetch = () => {
     const balances = rewardPoolTokenBalances?.find(
       ({ rewardProgramId }) => rewardProgramId === defaultRewardProgramId
     );
-    if (!!balances) {
+
+    if (balances) {
       return {
         ...balances,
         isClaimable: !!claimableBalanceToken && !!claimableBalanceToken.balance,

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
@@ -46,25 +46,16 @@ const useRewardsDataFetch = () => {
     data: { rewardPoolTokenBalances } = {},
   } = useGetRewardPoolTokenBalancesQuery(query.params, query.options);
 
-  const dustQuery = useMemo(
-    () => ({
-      params: {
-        accountAddress,
-        safeAddress: rewardSafes ? rewardSafes[0].address : undefined,
-        nativeCurrency,
-      },
-      options: {
-        skip: !accountAddress || isLayer1(network),
-        refetchOnMountOrArgChange: true,
-      },
-    }),
-    [accountAddress, rewardSafes, nativeCurrency, network]
-  );
-
   const {
     isLoading: isLoadingTokensWithoutDust,
     data: { rewardPoolTokenBalances: rewardPoolTokenBalancesWithoutDust } = {},
-  } = useGetRewardPoolTokenBalancesQuery(dustQuery.params, dustQuery.options);
+  } = useGetRewardPoolTokenBalancesQuery(
+    {
+      ...query.params,
+      safeAddress: rewardSafes ? rewardSafes[0].address : undefined,
+    },
+    query.options
+  );
 
   const claimableBalanceToken = useMemo(
     () =>

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
@@ -4,11 +4,9 @@ import {
   useGetRewardPoolTokenBalancesQuery,
   useGetRewardsSafeQuery,
 } from '@cardstack/services/rewards-center/rewards-center-api';
-
 import { isLayer1 } from '@cardstack/utils';
 
 import { networkTypes } from '@rainbow-me/helpers/networkTypes';
-
 import { useAccountSettings } from '@rainbow-me/hooks';
 
 const rewardDefaultProgramId = {

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
@@ -52,10 +52,9 @@ const useRewardsDataFetch = () => {
   } = useGetRewardPoolTokenBalancesQuery(
     {
       ...query.params,
-      safeAddress:
-        rewardSafes && rewardSafes.length > 0
-          ? rewardSafes[0].address
-          : undefined,
+      safeAddress: rewardSafes?.find(
+        ({ rewardProgramId }) => rewardProgramId === defaultRewardProgramId
+      )?.address,
     },
     query.options
   );

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
@@ -52,7 +52,10 @@ const useRewardsDataFetch = () => {
   } = useGetRewardPoolTokenBalancesQuery(
     {
       ...query.params,
-      safeAddress: rewardSafes ? rewardSafes[0].address : undefined,
+      safeAddress:
+        rewardSafes && rewardSafes.length > 0
+          ? rewardSafes[0].address
+          : undefined,
     },
     query.options
   );

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
@@ -64,7 +64,7 @@ const useRewardsDataFetch = () => {
     data: { rewardPoolTokenBalances: rewardPoolTokenBalancesWithoutDust } = {},
   } = useGetRewardPoolTokenBalancesQuery(dustQuery.params, dustQuery.options);
 
-  // Checks if available tokens matches default program and has amount
+  // Checks if available tokens matches default program
   const mainPoolTokenInfo = useMemo(
     () =>
       rewardPoolTokenBalances?.find(

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-
 import {
   useGetRewardPoolTokenBalancesQuery,
   useGetRewardsSafeQuery,
@@ -59,6 +58,7 @@ const useRewardsDataFetch = () => {
     }),
     [accountAddress, rewardSafes, nativeCurrency, network]
   );
+
   const {
     isLoading: isLoadingTokensWithoutDust,
     data: { rewardPoolTokenBalances: rewardPoolTokenBalancesWithoutDust } = {},
@@ -78,8 +78,9 @@ const useRewardsDataFetch = () => {
       rewardPoolTokenBalancesWithoutDust?.find(
         ({ rewardProgramId }) => rewardProgramId === defaultRewardProgramId
       ),
-    [rewardPoolTokenBalancesWithoutDust, defaultRewardProgramId, rewardSafes]
+    [rewardPoolTokenBalancesWithoutDust, defaultRewardProgramId]
   );
+
   const isLoading = useMemo(
     () =>
       isLoadingSafes ||

--- a/cardstack/src/services/gnosis-service.ts
+++ b/cardstack/src/services/gnosis-service.ts
@@ -273,11 +273,11 @@ export const addNativePriceToToken = async (
     symbol,
   });
 
-  const isAmountDust = nativeBalance < 0.01;
+  const isAmountDust = !acceptDust && nativeBalance < 0.01;
 
-  const amount = acceptDust ? nativeBalance : isAmountDust ? 0 : nativeBalance;
+  const amount = isAmountDust ? 0 : nativeBalance;
 
-  const tokenBalance = acceptDust ? balance : isAmountDust ? 0 : balance;
+  const tokenBalance = isAmountDust ? 0 : balance;
 
   return {
     ...tokenInfo,

--- a/cardstack/src/services/gnosis-service.ts
+++ b/cardstack/src/services/gnosis-service.ts
@@ -259,7 +259,8 @@ export const updateSafeWithTokenPrices = async (
 
 export const addNativePriceToToken = async (
   tokenInfo: TokenInfo,
-  nativeCurrency: NativeCurrency
+  nativeCurrency: NativeCurrency,
+  acceptDust: boolean = false
 ) => {
   const {
     balance,
@@ -274,9 +275,9 @@ export const addNativePriceToToken = async (
 
   const isAmountDust = nativeBalance < 0.01;
 
-  const amount = isAmountDust ? 0 : nativeBalance;
+  const amount = acceptDust ? nativeBalance : isAmountDust ? 0 : nativeBalance;
 
-  const tokenBalance = isAmountDust ? 0 : balance;
+  const tokenBalance = acceptDust ? balance : isAmountDust ? 0 : balance;
 
   return {
     ...tokenInfo,

--- a/cardstack/src/services/gnosis-service.ts
+++ b/cardstack/src/services/gnosis-service.ts
@@ -260,7 +260,7 @@ export const updateSafeWithTokenPrices = async (
 export const addNativePriceToToken = async (
   tokenInfo: TokenInfo,
   nativeCurrency: NativeCurrency,
-  acceptDust: boolean = false
+  acceptDust = false
 ) => {
   const {
     balance,

--- a/cardstack/src/services/rewards-center/rewards-center-api.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-api.ts
@@ -5,9 +5,11 @@ import { queryPromiseWrapper } from '../utils';
 
 import {
   claimRewards,
+  claimAllRewards,
   fetchRewardPoolTokenBalances,
   fetchRewardsSafe,
   getClaimRewardsGasEstimate,
+  getClaimAllRewardsGasEstimate,
   getRegisterGasEstimate,
   getWithdrawGasEstimate,
   registerToRewardProgram,
@@ -142,6 +144,34 @@ const rewardsApi = safesApi.injectEndpoints({
       },
       invalidatesTags: [CacheTags.REWARDS_SAFE, CacheTags.SAFES],
     }),
+    getClaimAllRewardsGasEstimate: builder.query<
+      string,
+      RewardsClaimGasEstimateParams
+    >({
+      async queryFn(params) {
+        return queryPromiseWrapper<string, RewardsClaimGasEstimateParams>(
+          getClaimAllRewardsGasEstimate,
+          params,
+          {
+            errorLogMessage: 'Error fetching reward claim gas fee',
+          }
+        );
+      },
+    }),
+    claimAllRewards: builder.mutation<
+      SuccessfulTransactionReceipt[],
+      RewardsClaimMutationParams
+    >({
+      async queryFn(params) {
+        return queryPromiseWrapper<
+          SuccessfulTransactionReceipt[],
+          RewardsClaimMutationParams
+        >(claimAllRewards, params, {
+          errorLogMessage: 'Error while claiming rewards',
+        });
+      },
+      invalidatesTags: [CacheTags.REWARDS_SAFE, CacheTags.REWARDS_POOL],
+    }),
   }),
 });
 
@@ -154,4 +184,6 @@ export const {
   useWithdrawRewardBalanceMutation,
   useGetRewardWithdrawGasEstimateQuery,
   useGetClaimRewardsGasEstimateQuery,
+  useGetClaimAllRewardsGasEstimateQuery,
+  useClaimAllRewardsMutation,
 } = rewardsApi;

--- a/cardstack/src/services/rewards-center/rewards-center-service.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-service.ts
@@ -215,13 +215,11 @@ export const getClaimAllRewardsGasEstimate = async ({
 
   const totalEstimatedGas = await rewardPoolInstance.claimAllGasEstimate(
     safeAddress,
-    rewardProgramId,
-    tokenAddress
+    tokenAddress,
+    rewardProgramId
   );
 
-  const totalEstimatedGasInEth = fromWei(
-    totalEstimatedGas[0].amount.toString()
-  );
+  const totalEstimatedGasInEth = fromWei(totalEstimatedGas.amount.toString());
 
   const formattedTotalEstimatedGas = parseFloat(totalEstimatedGasInEth).toFixed(
     2

--- a/cardstack/src/services/rewards-center/rewards-center-service.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-service.ts
@@ -210,9 +210,7 @@ export const getClaimAllRewardsGasEstimate = async ({
   safeAddress,
   tokenAddress,
   rewardProgramId,
-  accountAddress,
 }: RewardsClaimGasEstimateParams) => {
-  console.log(accountAddress);
   const rewardPoolInstance = await getRewardsPoolInstance();
 
   const totalEstimatedGas = await rewardPoolInstance.claimAllGasEstimate(

--- a/cardstack/src/services/rewards-center/rewards-center-service.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-service.ts
@@ -220,6 +220,7 @@ export const getClaimAllRewardsGasEstimate = async ({
     rewardProgramId,
     tokenAddress
   );
+
   const totalEstimatedGasInEth = fromWei(
     totalEstimatedGas[0].amount.toString()
   );
@@ -310,6 +311,7 @@ export const claimAllRewards = async ({
   accountAddress,
 }: RewardsClaimMutationParams) => {
   const rewardPoolInstance = await getRewardsPoolInstance({ accountAddress });
+
   const receipts = await rewardPoolInstance.claimAll(
     safeAddress,
     rewardProgramId,
@@ -319,6 +321,7 @@ export const claimAllRewards = async ({
       from: accountAddress,
     }
   );
+
   return receipts;
 };
 

--- a/cardstack/src/services/rewards-center/rewards-center-types.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-types.ts
@@ -17,8 +17,11 @@ export type RewardsSafeType = Omit<RewardSafe, 'tokens'> & {
 export interface RewardsSafeQueryResult {
   rewardSafes: RewardsSafeType[];
 }
+export interface FullBalanceToken extends TokenByProgramID {
+  isClaimable: boolean;
+}
 
-interface TokenByProgramID extends TokenType {
+export interface TokenByProgramID extends TokenType {
   rewardProgramId?: string;
 }
 export interface RewardsTokenBalancesResult {

--- a/cardstack/src/services/rewards-center/rewards-center-types.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-types.ts
@@ -6,6 +6,7 @@ import { TokenType } from '@cardstack/types';
 
 export interface RewardsSafeQueryParams {
   accountAddress: string;
+  safeAddress?: string;
   nativeCurrency: NativeCurrency;
 }
 
@@ -23,7 +24,6 @@ interface TokenByProgramID extends TokenType {
 export interface RewardsTokenBalancesResult {
   rewardPoolTokenBalances: TokenByProgramID[];
 }
-
 interface RewardsPoolSignedBaseParams extends EthersSignerParams {
   accountAddress: string;
   rewardProgramId: string;

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@apollo/client": "^3.4.8",
     "@babel/parser": "^7.13.11",
     "@bankify/react-native-animate-number": "^0.2.1",
-    "@cardstack/cardpay-sdk": "1.0.11",
+    "@cardstack/cardpay-sdk": "1.0.12",
     "@cardstack/did-resolver": "1.0.7",
     "@ethersproject/shims": "^5.6.0",
     "@lavamoat/preinstall-always-fail": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2484,10 +2484,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cardstack/cardpay-sdk@1.0.11":
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@cardstack/cardpay-sdk/-/cardpay-sdk-1.0.11.tgz#edd867a6885342705484bbba2367db501281497a"
-  integrity sha512-9jpHZUGKza9hIJHGa1edc0igNpkkt9NxfMMBsWgM0TUJzszECAoZuIdYd2ZEVY+utIG3VcgZWfalp05Sqc15Jw==
+"@cardstack/cardpay-sdk@1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@cardstack/cardpay-sdk/-/cardpay-sdk-1.0.12.tgz#b02a26f7bc7178b0fadd0cbbd9ba5c870e6fa444"
+  integrity sha512-W5Omh2RuE0Nwyi7uF41CYLrJqelaKJaU2mbpvDBwIhBLglt9H9w8v1pEs+ZLAXj4bzHF+O1LIUDy98YdmqlZhA==
   dependencies:
     "@truffle/hdwallet-provider" "^1.5.0"
     "@trufflesuite/web3-provider-engine" "^15.0.13-1"


### PR DESCRIPTION
### Description

In rewards, the gas fees is taken out from the reward amount. So we have an issue that claims fail when the reward amount < gas fees (crypto dust). We seek to still show users that they have rewards (crypto dust) but we want to ensure that the user can claim all rewards which are not crypto dust. This is important becos we anticipate with staking that there will be lots of crypto dust in ppls rewards.


- `claimSheetTokenInfo` is meant to include reward token balance and claim estimates only including proofs that CAN be claimed -- u will see reward token balance lower bcos it doesn't include crypto dust. This is displayed in `rewardsClaimSheet`. 
- `mainPoolTokenInfo` shows balances regardless of crypto dust and will be displayed in main rewards center screen
- changed text i rewards screen to state there is possibility that claiming is not allowed
- passed `canClaimAll` state which toggles `claim` button in rewards center screen. `canClaim` only means that there is >0 `rewardTokenBalancesWithoutDust`
- Previously, balances were not shown if their dust. Now, we have allowed that by introducing `acceptDust` since in rewards we want to allow that. 

- [x] Completes (#CS-4445)

TODO
- [ ] **Can possibly remove some old functions**
- [ ] **Need to add new sdk version when pr is approved**

### Checklist

- [x] Tested on a simulator


### Screenshots

**1. A person has 0.2 reward token balance (1 proof which is crypto dust). Does see notification for reward but no claim button to proceed.** 

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/8165111/186878051-7f7da984-3099-48e7-88e1-456eae9d42fd.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/8165111/186878070-7115eda1-69a5-4b84-bf85-b59bffcb2767.png">


**1. A person has 10.2 reward token balance (1 proof which is crypto dust, 1 proof which is claimable 10 card worth). The claim sheet only shows 10 card and 0.5 estimate which is the estimate for 1 proof only. Balance recovers to crypto dust**

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/8165111/186880723-c4757d71-b6e2-4698-8e9c-e256172a34a8.png">
<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/8165111/186880722-d7def473-97c5-45b2-b105-8ba299dbffd7.png">
<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/8165111/186880717-072564fe-216d-4491-baf9-16a942a48733.png">
<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/8165111/186881458-d6af5092-2590-4e77-a82d-a67b86e730a7.png">
<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/8165111/186881455-19c258a0-6252-47c4-9943-0b2147708cdd.png">





