### PR TITLE
[CS-4439] RTKQ errors parsing

### DIFF
--- a/cardstack/src/hooks/__tests__/useProfileJobPolling.test.ts
+++ b/cardstack/src/hooks/__tests__/useProfileJobPolling.test.ts
@@ -124,6 +124,12 @@ describe('useProfileJobPolling', () => {
 
     expect(result.current.isCreatingProfile).toBeFalsy();
     expect(result.current.isCreateProfileError).toBeFalsy();
-    expect(result.current.connectionError).toBe({ message: 'CON_ERROR' });
+    expect(result.current.connectionError).toStrictEqual({
+      error: {
+        message: 'CON_ERROR',
+      },
+      errorMessage: 'CON_ERROR',
+      type: 'parsingError',
+    });
   });
 });

--- a/cardstack/src/hooks/__tests__/useProfileJobPolling.test.ts
+++ b/cardstack/src/hooks/__tests__/useProfileJobPolling.test.ts
@@ -124,6 +124,6 @@ describe('useProfileJobPolling', () => {
 
     expect(result.current.isCreatingProfile).toBeFalsy();
     expect(result.current.isCreateProfileError).toBeFalsy();
-    expect(result.current.isConnectionError).toMatch('CON_ERROR');
+    expect(result.current.connectionError).toMatch('CON_ERROR');
   });
 });

--- a/cardstack/src/hooks/__tests__/useProfileJobPolling.test.ts
+++ b/cardstack/src/hooks/__tests__/useProfileJobPolling.test.ts
@@ -119,11 +119,11 @@ describe('useProfileJobPolling', () => {
       useProfileJobPolling(mockJobParams)
     );
 
-    mockUseGetProfileJobStatusQuery(undefined, 'CON_ERROR');
+    mockUseGetProfileJobStatusQuery(undefined, { message: 'CON_ERROR' });
     rerender();
 
     expect(result.current.isCreatingProfile).toBeFalsy();
     expect(result.current.isCreateProfileError).toBeFalsy();
-    expect(result.current.connectionError).toMatch('CON_ERROR');
+    expect(result.current.connectionError).toBe({ message: 'CON_ERROR' });
   });
 });

--- a/cardstack/src/hooks/useProfileJobPolling.ts
+++ b/cardstack/src/hooks/useProfileJobPolling.ts
@@ -5,6 +5,7 @@ import {
   useGetProfileJobStatusQuery,
   usePostProfileJobRetryMutation,
 } from '@cardstack/services';
+import { parseRTKConnectionError } from '@cardstack/services/utils';
 
 import { useBooleanState } from './useBooleanState';
 
@@ -69,7 +70,7 @@ export const useProfileJobPolling = ({
   }, [isFailedJob, retryJobID, jobID]);
 
   return {
-    isConnectionError: error,
+    connectionError: parseRTKConnectionError(error),
     isCreatingProfile: polling,
     isCreateProfileError: isFailedJob,
     retryCurrentCreateProfile,

--- a/cardstack/src/screens/ProfileScreen/ProfileScreen.tsx
+++ b/cardstack/src/screens/ProfileScreen/ProfileScreen.tsx
@@ -22,7 +22,7 @@ const ProfileScreen = () => {
     isCreatingProfile,
     isCreateProfileError,
     retryCurrentCreateProfile,
-    isConnectionError,
+    connectionError,
     safesCount,
     isFetching,
     network,
@@ -37,12 +37,12 @@ const ProfileScreen = () => {
       return strings.profileError;
     }
 
-    if (isConnectionError) {
-      return strings.connectionError;
+    if (connectionError) {
+      return strings.connectionError.message(connectionError.errorMessage);
     }
 
     return undefined;
-  }, [isCreateProfileError, isConnectionError]);
+  }, [isCreateProfileError, connectionError]);
 
   const renderProfileContent = useMemo(() => {
     if (isLayer1(network)) {

--- a/cardstack/src/screens/ProfileScreen/ProfileScreen.tsx
+++ b/cardstack/src/screens/ProfileScreen/ProfileScreen.tsx
@@ -38,7 +38,7 @@ const ProfileScreen = () => {
     }
 
     if (connectionError) {
-      return strings.connectionError.message(connectionError.errorMessage);
+      return strings.connectionError(connectionError.errorMessage);
     }
 
     return undefined;

--- a/cardstack/src/screens/ProfileScreen/components/strings.ts
+++ b/cardstack/src/screens/ProfileScreen/components/strings.ts
@@ -15,8 +15,8 @@ export const strings = {
   },
   connectionError: {
     title: 'Connection failed',
-    message:
-      'There was a problem connecting to the profile issuer. Please wait a few minutes and then try again. If this problem persists, please get in touch with our support team.',
+    message: (errorMessage: string) =>
+      `There was a problem connecting to the profile issuer. Please wait a few minutes and then try again. If this problem persists, please get in touch with our support team.\nError message: ${errorMessage}`,
   },
   buttons: {
     continue: 'Continue',

--- a/cardstack/src/screens/ProfileScreen/components/strings.ts
+++ b/cardstack/src/screens/ProfileScreen/components/strings.ts
@@ -13,11 +13,10 @@ export const strings = {
     message:
       'There was a problem creating your profile. Please wait a few minutes and then try again. If this problem persists, please get in touch with our support team.',
   },
-  connectionError: {
+  connectionError: (errorMessage: string) => ({
     title: 'Connection failed',
-    message: (errorMessage: string) =>
-      `There was a problem connecting to the profile issuer. Please wait a few minutes and then try again. If this problem persists, please get in touch with our support team.\nError message: ${errorMessage}`,
-  },
+    message: `There was a problem connecting to the profile issuer. Please wait a few minutes and then try again. If this problem persists, please get in touch with our support team.\nError message: ${errorMessage}`,
+  }),
   buttons: {
     continue: 'Continue',
     retry: 'Retry',

--- a/cardstack/src/screens/ProfileScreen/useProfileScreen.ts
+++ b/cardstack/src/screens/ProfileScreen/useProfileScreen.ts
@@ -39,7 +39,7 @@ export const useProfileScreen = () => {
   });
 
   const {
-    isConnectionError,
+    connectionError,
     isCreatingProfile,
     isCreateProfileError,
     retryCurrentCreateProfile,
@@ -85,7 +85,7 @@ export const useProfileScreen = () => {
     isFetching,
     refetch,
     redirectToSwitchNetwork,
-    isConnectionError,
+    connectionError,
     isCreateProfileError,
     retryCurrentCreateProfile,
   };

--- a/cardstack/src/services/utils/index.ts
+++ b/cardstack/src/services/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './query-promise-wrapper';
 export * from './filter-incident';
+export * from './parse-error';

--- a/cardstack/src/services/utils/parse-error.ts
+++ b/cardstack/src/services/utils/parse-error.ts
@@ -1,0 +1,48 @@
+import type { SerializedError } from '@reduxjs/toolkit';
+import { FetchBaseQueryError } from '@reduxjs/toolkit/query/react';
+
+export type RTKErrorType = SerializedError | FetchBaseQueryError | undefined;
+
+export interface ConnectionError {
+  error: RTKErrorType;
+  errorMessage: string;
+  type: ErrorType;
+}
+
+export enum ErrorType {
+  connectionError = 'connectionError',
+  parsingError = 'parsingError',
+  unknownError = 'unknownError',
+}
+
+const defaultErrorMessage = 'Connection error. Please try again soon.';
+
+export const parseRTKConnectionError = (
+  error: RTKErrorType
+): ConnectionError | undefined => {
+  if (!error) return undefined;
+
+  // FetchBaseQueryError properties
+  if ('status' in error) {
+    const errorMessage =
+      'error' in error ? error.error : JSON.stringify(error.data);
+
+    return { error, errorMessage, type: ErrorType.connectionError };
+  }
+
+  // SerializedError properties
+  if (error.message) {
+    return {
+      error,
+      errorMessage: error.message,
+      type: ErrorType.parsingError,
+    };
+  }
+
+  // No defined error message present.
+  return {
+    error,
+    errorMessage: defaultErrorMessage,
+    type: ErrorType.unknownError,
+  };
+};


### PR DESCRIPTION
### Description

This PR adds a starting point for parsing errors returned from RTKQuery service calls. It also changes Profile Screen to show the parsed error.

- [x] Completes #(CS-4439)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

Note: I'm trying to test error responses with Proxyman but hub staging is not accepting the intercepted SSL handshake. Will continue in a bit.