### PR TITLE
[CS-4347] Enabling BETA Access outside DEV

### DIFF
--- a/cardstack/src/services/analytics/analytics.ts
+++ b/cardstack/src/services/analytics/analytics.ts
@@ -4,5 +4,10 @@ export enum UserAccessType {
   BETA = 'BETA',
 }
 
-export const setUserAccessType = async (userAccessType: UserAccessType) =>
-  analytics().setUserProperty('user_access_type', userAccessType);
+/**
+ * setUserAccessType: Sets or clears access type to current analytics user.
+ * @param userAccessType user type (BETA) or null to clear property for user.
+ */
+export const setUserAccessType = async (
+  userAccessType: UserAccessType | null
+) => analytics().setUserProperty('user_access_type', userAccessType);

--- a/cardstack/src/services/remote-config/remote-config-service.ts
+++ b/cardstack/src/services/remote-config/remote-config-service.ts
@@ -36,4 +36,5 @@ export const remoteFlags = (): { [K in ConfigKey]: RemoteConfigValues[K] } => ({
   featureProfilePurchaseOnboarding: getRemoteConfigAsBoolean(
     'featureProfilePurchaseOnboarding'
   ),
+  betaAccessGranted: getRemoteConfigAsBoolean('betaAccessGranted'),
 });

--- a/cardstack/src/services/remote-config/remoteConfigDefaults.ts
+++ b/cardstack/src/services/remote-config/remoteConfigDefaults.ts
@@ -6,4 +6,5 @@ export const remoteConfigDefaults = {
   maintenanceMessage: `${appName} is going through scheduled maintenance, please try again later.`,
   featurePrepaidCardDrop: false,
   featureProfilePurchaseOnboarding: false,
+  betaAccessGranted: false,
 };


### PR DESCRIPTION
### Description

PR enables BETA Access flag to work outside DEV env.

Also, a new `betaAccessGranted` was added to Remote Configs, used to check if user has or not Beta access, useful for toggling beta access and showing settings specific section.

- [x] Completes #(CS-4347)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Improvements coming on CS-4349

- Make remote config a reactive hook to update states when values are changed (with force fetch, for exemple);
- Add Beta option on Settings.

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/187520767-5392255e-3668-484a-ba24-950f073fa004.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/187520834-ea827848-782a-42fc-8f1c-0177f36d95cb.png">
