### PR TITLE
[CS-4544] Hide scrollbar on Rewards screen

### DIFF
--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -63,7 +63,7 @@ export const ClaimContent = ({ claimList }: ClaimContentProps) => {
   );
 
   return (
-    <ScrollView>
+    <ScrollView showsVerticalScrollIndicator={false}>
       <Container padding={5}>
         <RewardsTitle title={title} width="100%" paddingBottom={5} />
         <InfoBanner


### PR DESCRIPTION
### Description
Although I wasn't able to reproduce the issue mentioned at the ticket, I've tried a lot. I've added up to a 100 entries as my fake history and didn't get the same result as the ticket. So, to avoid having an issue with the scrollbar rendering in the wrong place, we're not showing the scrollbar.

- [x] Completes #CS-4544

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
