### PR TITLE
[CS-4555]: use https sokol instead of wss while ws is down

### DIFF
--- a/cardstack/src/models/web3-provider.ts
+++ b/cardstack/src/models/web3-provider.ts
@@ -3,6 +3,7 @@ import { getConstantByNetwork, HubConfig } from '@cardstack/cardpay-sdk';
 import Web3 from 'web3';
 import { WebsocketProvider } from 'web3-core';
 
+import { remoteFlags } from '@cardstack/services/remote-config';
 import { isLayer1 } from '@cardstack/utils';
 
 import { getNetwork } from '@rainbow-me/handlers/localstorage/globalSettings';
@@ -20,11 +21,18 @@ const Web3WsProvider = {
         getConstantByNetwork('hubUrl', currentNetwork)
       );
 
+      const shouldUseSokolHttpNode =
+        currentNetwork === Network.sokol && remoteFlags().useHttpSokolNode;
+
       const hubConfigResponse = await hubConfig.getConfig();
 
-      const node = isLayer1(currentNetwork)
+      const wssPath = isLayer1(currentNetwork)
         ? hubConfigResponse.web3.layer1RpcNodeWssUrl
         : hubConfigResponse.web3.layer2RpcNodeWssUrl;
+
+      const node = shouldUseSokolHttpNode
+        ? hubConfigResponse.web3.layer2RpcNodeHttpsUrl
+        : wssPath;
 
       provider = new Web3.providers.WebsocketProvider(node, {
         timeout: 30000,

--- a/cardstack/src/services/remote-config/remote-config-service.ts
+++ b/cardstack/src/services/remote-config/remote-config-service.ts
@@ -37,4 +37,5 @@ export const remoteFlags = (): { [K in ConfigKey]: RemoteConfigValues[K] } => ({
     'featureProfilePurchaseOnboarding'
   ),
   betaAccessGranted: getRemoteConfigAsBoolean('betaAccessGranted'),
+  useHttpSokolNode: getRemoteConfigAsBoolean('useHttpSokolNode'),
 });

--- a/cardstack/src/services/remote-config/remoteConfigDefaults.ts
+++ b/cardstack/src/services/remote-config/remoteConfigDefaults.ts
@@ -7,4 +7,5 @@ export const remoteConfigDefaults = {
   featurePrepaidCardDrop: false,
   featureProfilePurchaseOnboarding: false,
   betaAccessGranted: false,
+  useHttpSokolNode: true,
 };


### PR DESCRIPTION
### Description

This PR adds a feature flag and sokol only condition to use the https url instead of the websocket one which is down and without forecast.

### Checklist

- [x] Tested on iOS
- [x] Tested on Android

