### PR TITLE
[CS-4495] Backup wallet explanation screen

### DIFF
--- a/cardstack/src/navigation/index.ts
+++ b/cardstack/src/navigation/index.ts
@@ -2,6 +2,5 @@ export * from './hooks';
 export * from './routes';
 export * from './screens';
 export * from './presetOptions';
-export * from './screenGroups';
 export { default as AppContainer } from './navigator';
 export { default as Navigation } from './Navigation';

--- a/cardstack/src/navigation/index.ts
+++ b/cardstack/src/navigation/index.ts
@@ -2,6 +2,6 @@ export * from './hooks';
 export * from './routes';
 export * from './screens';
 export * from './presetOptions';
-export * from './profileScreenGroup';
+export * from './screenGroups';
 export { default as AppContainer } from './navigator';
 export { default as Navigation } from './Navigation';

--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -71,6 +71,10 @@ const ProfileRoutes = {
   PROFILE_CHARGE_EXPLANATION: 'ProfileChargeExplanation',
 };
 
+const BackupRoutes = {
+  BACKUP_EXPLANATION: 'BackupExplanation',
+};
+
 export const Routes = {
   UNLOCK_SCREEN: 'UnlockScreen',
   ...SharedRoutes,
@@ -78,4 +82,5 @@ export const Routes = {
   ...TabRoutes,
   ...MainRoutes,
   ...ProfileRoutes,
+  ...BackupRoutes,
 } as const;

--- a/cardstack/src/navigation/screenGroups/backup.tsx
+++ b/cardstack/src/navigation/screenGroups/backup.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import {
+  horizontalNonStackingInterpolator,
+  Routes,
+} from '@cardstack/navigation';
+import { BackupExplanationScreen } from '@cardstack/screens';
+
+import { StackType } from '../types';
+
+export const BackupScreenGroup = ({ Stack }: { Stack: StackType }) => (
+  <Stack.Group
+    screenOptions={{
+      ...horizontalNonStackingInterpolator,
+      presentation: 'card',
+      detachPreviousScreen: false,
+    }}
+  >
+    <Stack.Screen
+      component={BackupExplanationScreen}
+      name={Routes.BACKUP_EXPLANATION}
+    />
+  </Stack.Group>
+);

--- a/cardstack/src/navigation/screenGroups/index.ts
+++ b/cardstack/src/navigation/screenGroups/index.ts
@@ -1,0 +1,1 @@
+export * from './profile';

--- a/cardstack/src/navigation/screenGroups/index.ts
+++ b/cardstack/src/navigation/screenGroups/index.ts
@@ -1,1 +1,2 @@
 export * from './profile';
+export * from './backup';

--- a/cardstack/src/navigation/screenGroups/profile.tsx
+++ b/cardstack/src/navigation/screenGroups/profile.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 
 import {
+  horizontalNonStackingInterpolator,
+  Routes,
+} from '@cardstack/navigation';
+import {
   ProfileNameScreen,
   ProfileSlugScreen,
   ProfilePurchaseCTA,
   ProfileChargeExplanationScreen,
 } from '@cardstack/screens';
 
-import { StackType } from './types';
-
-import { horizontalNonStackingInterpolator, Routes } from '.';
+import { StackType } from '../types';
 
 export const ProfileScreenGroup = ({ Stack }: { Stack: StackType }) => (
   <Stack.Group

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -32,13 +32,13 @@ import RestoreSheet from '@rainbow-me/screens/RestoreSheet';
 
 import { createCustomStackNavigator } from './customNavigator';
 import { useCardstackMainScreens } from './hooks';
+import { ProfileScreenGroup, BackupScreenGroup } from './screenGroups';
 
 import {
   dismissAndroidKeyboardOnClose,
   horizontalInterpolator,
   NonAuthRoutes,
   overlayPreset,
-  ProfileScreenGroup,
   Routes,
   sheetPreset,
 } from '.';
@@ -237,6 +237,7 @@ export const StackNavigator = () => {
       )}
       {SharedScreens({ navigationKey: !hasWallet ? 'non-auth' : 'auth' })}
       {ProfileScreenGroup({ Stack })}
+      {BackupScreenGroup({ Stack })}
     </Stack.Navigator>
   );
 };

--- a/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
@@ -1,16 +1,55 @@
-import React, { memo } from 'react';
+import { StackActions, useNavigation } from '@react-navigation/native';
+import React, { memo, useCallback, useMemo } from 'react';
 
-import { Container, PageWithStackHeader, Text } from '@cardstack/components';
+import {
+  Button,
+  Container,
+  PageWithStackHeader,
+  Text,
+  Touchable,
+} from '@cardstack/components';
+import { hitSlop } from '@cardstack/utils';
 
 import { strings } from './strings';
 
 const BackupExplanationScreen = () => {
+  const { dispatch: navDispatch } = useNavigation();
+
+  const handleBackupOnPress = useCallback(() => {
+    // TODO
+  }, []);
+
+  const handleLaterOnPress = useCallback(() => {
+    navDispatch(StackActions.popToTop());
+  }, [navDispatch]);
+
+  const FooterComponent = useMemo(
+    () => (
+      <Container flex={1} alignItems="center">
+        <Button onPress={handleBackupOnPress}>{strings.primaryBtn}</Button>
+        <Touchable
+          onPress={handleLaterOnPress}
+          paddingVertical={5}
+          hitSlop={hitSlop.medium}
+        >
+          <Text color="white" fontSize={16} weight="semibold">
+            {strings.secondaryBtn}
+          </Text>
+        </Touchable>
+      </Container>
+    ),
+    [handleBackupOnPress, handleLaterOnPress]
+  );
+
   return (
-    <PageWithStackHeader>
-      <Container>
-        <Container width="90%" paddingBottom={4}>
-          <Text variant="pageHeader">{strings.title}</Text>
-        </Container>
+    <PageWithStackHeader canGoBack={false} footer={FooterComponent}>
+      <Container width="90%">
+        <Text variant="pageHeader" paddingBottom={4}>
+          {strings.title}
+        </Text>
+        <Text color="grayText" letterSpacing={0.4}>
+          {strings.description}
+        </Text>
       </Container>
     </PageWithStackHeader>
   );

--- a/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
@@ -1,0 +1,19 @@
+import React, { memo } from 'react';
+
+import { Container, PageWithStackHeader, Text } from '@cardstack/components';
+
+import { strings } from './strings';
+
+const BackupExplanationScreen = () => {
+  return (
+    <PageWithStackHeader>
+      <Container>
+        <Container width="90%" paddingBottom={4}>
+          <Text variant="pageHeader">{strings.title}</Text>
+        </Container>
+      </Container>
+    </PageWithStackHeader>
+  );
+};
+
+export default memo(BackupExplanationScreen);

--- a/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
@@ -6,9 +6,9 @@ import {
   Container,
   PageWithStackHeader,
   Text,
-  Touchable,
 } from '@cardstack/components';
-import { hitSlop } from '@cardstack/utils';
+
+import { ButtonLink } from '../components/ButtonLink';
 
 import { strings } from './strings';
 
@@ -27,15 +27,9 @@ const BackupExplanationScreen = () => {
     () => (
       <Container flex={1} alignItems="center">
         <Button onPress={handleBackupOnPress}>{strings.primaryBtn}</Button>
-        <Touchable
-          onPress={handleLaterOnPress}
-          paddingVertical={5}
-          hitSlop={hitSlop.medium}
-        >
-          <Text color="white" fontSize={16} weight="semibold">
-            {strings.secondaryBtn}
-          </Text>
-        </Touchable>
+        <ButtonLink onPress={handleLaterOnPress}>
+          {strings.secondaryBtn}
+        </ButtonLink>
       </Container>
     ),
     [handleBackupOnPress, handleLaterOnPress]

--- a/cardstack/src/screens/Backup/BackupExplanationScreen/strings.ts
+++ b/cardstack/src/screens/Backup/BackupExplanationScreen/strings.ts
@@ -1,0 +1,7 @@
+export const strings = {
+  title: 'Backup your wallet',
+  description:
+    'You will be presented a secret phrase. Anyone with these words will have access to your funds. Protect these in a secure spot.',
+  primaryBtn: 'Back up now',
+  secondaryBtn: `I'll do this later`,
+};

--- a/cardstack/src/screens/Backup/components/ButtonLink.tsx
+++ b/cardstack/src/screens/Backup/components/ButtonLink.tsx
@@ -1,0 +1,19 @@
+import React, { PropsWithChildren } from 'react';
+
+import { Touchable, Text } from '@cardstack/components';
+import { hitSlop } from '@cardstack/utils';
+
+interface ButtonLinkProps {
+  onPress: () => void;
+}
+
+export const ButtonLink = ({
+  onPress,
+  children,
+}: PropsWithChildren<ButtonLinkProps>) => (
+  <Touchable onPress={onPress} paddingVertical={5} hitSlop={hitSlop.medium}>
+    <Text color="white" variant="semibold">
+      {children}
+    </Text>
+  </Touchable>
+);

--- a/cardstack/src/screens/Backup/index.ts
+++ b/cardstack/src/screens/Backup/index.ts
@@ -1,0 +1,1 @@
+export { default as BackupExplanationScreen } from './BackupExplanationScreen/BackupExplanationScreen';

--- a/cardstack/src/screens/index.ts
+++ b/cardstack/src/screens/index.ts
@@ -41,3 +41,4 @@ export { default as SeedPhraseBackup } from './SeedPhraseBackup/SeedPhraseBackup
 export { default as SecurityScreen } from './SecurityScreen/SecurityScreen';
 export * from './Profile';
 export { default as WyreAuthenticationWidget } from './WyreAuthenticationWidget';
+export * from './Backup';

--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -92,6 +92,10 @@ export default function SettingsSection({
     navigate(Routes.PROFILE_SLUG);
   }, [navigate]);
 
+  const onPressNewBackup = useCallback(() => {
+    navigate(Routes.BACKUP_EXPLANATION);
+  }, [navigate]);
+
   return (
     <ScrollView backgroundColor="white">
       <ColumnWithDividers dividerRenderer={ListItemDivider} marginTop={7}>
@@ -209,6 +213,11 @@ export default function SettingsSection({
             icon={<Icon color="black" name="shopping-cart" />}
             label="Profile Purchase Test-Drive"
             onPress={onPressIAP}
+          />
+          <ListItem
+            icon={<Icon color="black" name="upload-cloud" />}
+            label="New Backup Flow"
+            onPress={onPressNewBackup}
           />
         </>
       )}


### PR DESCRIPTION
### Description
This PR adds the first screen of the new backup flow. There's a new folder to group the `screenGroup` files inside the `/navigation` folder in order to help organize the files. 

As it was with the IAP screens, the navigation from this screen to the next will be handled when doing the next screen.

- [x] Completes #CS-4495

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

### Android 12 - Small
<img width="300" alt="Android 12 - Small" src="https://user-images.githubusercontent.com/690904/189993032-e0675cea-cede-45c8-b903-84728e1f1f5f.png">


### Android 11 - Tall
<img width="300" alt="Android 11 - Tall" src="https://user-images.githubusercontent.com/690904/189993031-29082a84-1d0f-4406-8679-e56c985646fe.png">


### iPhone SE
<img width="300" alt="iPhone SE" src="https://user-images.githubusercontent.com/690904/189993035-119cde62-b4a5-4fb8-8d8f-ffc0d330bc4d.png">


### iPhone 11
<img width="300" alt="iPhone 11" src="https://user-images.githubusercontent.com/690904/189993026-881c588e-d399-48da-a603-f96dfd109a7a.jpeg">

