### PR TITLE
[CS-4585] Refactors footers

### DIFF
--- a/cardstack/src/components/PageWithStackHeader/PageWithStackHeader.tsx
+++ b/cardstack/src/components/PageWithStackHeader/PageWithStackHeader.tsx
@@ -75,7 +75,11 @@ const PageWithStackHeader = ({
         {...headerContainerProps}
       />
       <Container flex={1}>{children}</Container>
-      {!!footer && <Container flex={0.3}>{footer}</Container>}
+      {!!footer && (
+        <Container justifyContent="flex-end" paddingTop={2} paddingBottom={5}>
+          {footer}
+        </Container>
+      )}
     </Container>
   );
 };

--- a/cardstack/src/components/PageWithStackHeader/PageWithStackHeader.tsx
+++ b/cardstack/src/components/PageWithStackHeader/PageWithStackHeader.tsx
@@ -33,7 +33,6 @@ const PageWithStackHeader = ({
   showSkip = true,
   skipPressCallback,
   children,
-  footer,
   leftIconProps,
   headerContainerProps,
 }: PropsWithChildren<PageWithStackHeaderProps>) => {
@@ -74,12 +73,7 @@ const PageWithStackHeader = ({
         paddingHorizontal={0} // reset MainHeaderWrapper's default padding
         {...headerContainerProps}
       />
-      <Container flex={1}>{children}</Container>
-      {!!footer && (
-        <Container justifyContent="flex-end" paddingTop={2} paddingBottom={5}>
-          {footer}
-        </Container>
-      )}
+      {children}
     </Container>
   );
 };

--- a/cardstack/src/components/PageWithStackHeader/PageWithStackHeaderFooter.tsx
+++ b/cardstack/src/components/PageWithStackHeader/PageWithStackHeaderFooter.tsx
@@ -1,0 +1,15 @@
+import React, { memo, ReactNode } from 'react';
+
+import { Container } from '@cardstack/components';
+
+interface Props {
+  children: ReactNode;
+}
+
+const PageWithStackHeaderFooter = ({ children }: Props) => (
+  <Container justifyContent="flex-end" paddingTop={2} paddingBottom={5}>
+    {children}
+  </Container>
+);
+
+export default memo(PageWithStackHeaderFooter);

--- a/cardstack/src/components/PageWithStackHeader/index.ts
+++ b/cardstack/src/components/PageWithStackHeader/index.ts
@@ -1,1 +1,2 @@
 export { default as PageWithStackHeader } from './PageWithStackHeader';
+export { default as PageWithStackHeaderFooter } from './PageWithStackHeaderFooter';

--- a/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
@@ -1,5 +1,5 @@
 import { StackActions, useNavigation } from '@react-navigation/native';
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, useCallback } from 'react';
 
 import {
   Button,
@@ -25,18 +25,6 @@ const BackupExplanationScreen = () => {
     navDispatch(StackActions.popToTop());
   }, [navDispatch]);
 
-  const FooterContent = useMemo(
-    () => (
-      <CenteredContainer>
-        <Button onPress={handleBackupOnPress}>{strings.primaryBtn}</Button>
-        <ButtonLink onPress={handleLaterOnPress}>
-          {strings.secondaryBtn}
-        </ButtonLink>
-      </CenteredContainer>
-    ),
-    [handleBackupOnPress, handleLaterOnPress]
-  );
-
   return (
     <PageWithStackHeader canGoBack={false}>
       <Container flex={1} width="90%">
@@ -47,7 +35,14 @@ const BackupExplanationScreen = () => {
           {strings.description}
         </Text>
       </Container>
-      <PageWithStackHeaderFooter>{FooterContent}</PageWithStackHeaderFooter>
+      <PageWithStackHeaderFooter>
+        <CenteredContainer>
+          <Button onPress={handleBackupOnPress}>{strings.primaryBtn}</Button>
+          <ButtonLink onPress={handleLaterOnPress}>
+            {strings.secondaryBtn}
+          </ButtonLink>
+        </CenteredContainer>
+      </PageWithStackHeaderFooter>
     </PageWithStackHeader>
   );
 };

--- a/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
@@ -6,6 +6,7 @@ import {
   CenteredContainer,
   Container,
   PageWithStackHeader,
+  PageWithStackHeaderFooter,
   Text,
 } from '@cardstack/components';
 
@@ -24,21 +25,21 @@ const BackupExplanationScreen = () => {
     navDispatch(StackActions.popToTop());
   }, [navDispatch]);
 
-  const FooterComponent = useMemo(
+  const FooterContent = useMemo(
     () => (
       <CenteredContainer>
         <Button onPress={handleBackupOnPress}>{strings.primaryBtn}</Button>
         <ButtonLink onPress={handleLaterOnPress}>
           {strings.secondaryBtn}
         </ButtonLink>
-      </Container>
+      </CenteredContainer>
     ),
     [handleBackupOnPress, handleLaterOnPress]
   );
 
   return (
-    <PageWithStackHeader canGoBack={false} footer={FooterComponent}>
-      <Container width="90%">
+    <PageWithStackHeader canGoBack={false}>
+      <Container flex={1} width="90%">
         <Text variant="pageHeader" paddingBottom={4}>
           {strings.title}
         </Text>
@@ -46,6 +47,7 @@ const BackupExplanationScreen = () => {
           {strings.description}
         </Text>
       </Container>
+      <PageWithStackHeaderFooter>{FooterContent}</PageWithStackHeaderFooter>
     </PageWithStackHeader>
   );
 };

--- a/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
@@ -3,6 +3,7 @@ import React, { memo, useCallback, useMemo } from 'react';
 
 import {
   Button,
+  CenteredContainer,
   Container,
   PageWithStackHeader,
   Text,
@@ -25,7 +26,7 @@ const BackupExplanationScreen = () => {
 
   const FooterComponent = useMemo(
     () => (
-      <Container flex={1} alignItems="center">
+      <CenteredContainer>
         <Button onPress={handleBackupOnPress}>{strings.primaryBtn}</Button>
         <ButtonLink onPress={handleLaterOnPress}>
           {strings.secondaryBtn}

--- a/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
+++ b/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
@@ -221,6 +221,11 @@ export const ProfileNameScreen = () => {
       showSkip={!isUpdating}
       skipPressCallback={triggerSkipProfileCreation}
       headerContainerProps={androidOpenKeyboardStyles?.header}
+      footer={
+        <Button blocked={isBlocked} onPress={onContinuePress}>
+          {strings.btns[flow]}
+        </Button>
+      }
     >
       <Animated.View style={animatedHeaderStyles}>
         <Text variant="pageHeader">{strings.header[flow]}</Text>
@@ -303,11 +308,6 @@ export const ProfileNameScreen = () => {
           </Container>
         </Container>
       </KeyboardAvoidingView>
-      <CenteredContainer flex={0.2} paddingBottom={2}>
-        <Button blocked={isBlocked} onPress={onContinuePress}>
-          {strings.btns[flow]}
-        </Button>
-      </CenteredContainer>
     </PageWithStackHeader>
   );
 };

--- a/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
+++ b/cardstack/src/screens/Profile/ProfileNameScreen/ProfileNameScreen.tsx
@@ -26,6 +26,7 @@ import {
   Text,
   Touchable,
   PageWithStackHeader,
+  PageWithStackHeaderFooter,
 } from '@cardstack/components';
 import { cardSpaceDomain } from '@cardstack/constants';
 import { colors, SPACING_MULTIPLIER } from '@cardstack/theme';
@@ -221,11 +222,6 @@ export const ProfileNameScreen = () => {
       showSkip={!isUpdating}
       skipPressCallback={triggerSkipProfileCreation}
       headerContainerProps={androidOpenKeyboardStyles?.header}
-      footer={
-        <Button blocked={isBlocked} onPress={onContinuePress}>
-          {strings.btns[flow]}
-        </Button>
-      }
     >
       <Animated.View style={animatedHeaderStyles}>
         <Text variant="pageHeader">{strings.header[flow]}</Text>
@@ -308,6 +304,11 @@ export const ProfileNameScreen = () => {
           </Container>
         </Container>
       </KeyboardAvoidingView>
+      <PageWithStackHeaderFooter>
+        <Button blocked={isBlocked} onPress={onContinuePress}>
+          {strings.btns[flow]}
+        </Button>
+      </PageWithStackHeaderFooter>
     </PageWithStackHeader>
   );
 };

--- a/cardstack/src/screens/Profile/ProfileSlugScreen/ProfileSlugScreen.tsx
+++ b/cardstack/src/screens/Profile/ProfileSlugScreen/ProfileSlugScreen.tsx
@@ -26,6 +26,11 @@ const ProfileSlugScreen = () => {
     <PageWithStackHeader
       canGoBack={false}
       skipPressCallback={triggerSkipProfileCreation}
+      footer={
+        <Button onPress={onContinuePress} blocked={!canContinue}>
+          {strings.buttons.continue}
+        </Button>
+      }
     >
       <Container flex={1} justifyContent="space-between">
         <Container flex={0.8}>
@@ -50,11 +55,6 @@ const ProfileSlugScreen = () => {
               {strings.input.description}
             </Text>
           </Container>
-        </Container>
-        <Container flex={0.2} justifyContent="flex-end" paddingBottom={5}>
-          <Button onPress={onContinuePress} blocked={!canContinue}>
-            {strings.buttons.continue}
-          </Button>
         </Container>
       </Container>
     </PageWithStackHeader>

--- a/cardstack/src/screens/Profile/ProfileSlugScreen/ProfileSlugScreen.tsx
+++ b/cardstack/src/screens/Profile/ProfileSlugScreen/ProfileSlugScreen.tsx
@@ -7,6 +7,7 @@ import {
   ValidationMessage,
   SuffixedInput,
   PageWithStackHeader,
+  PageWithStackHeaderFooter,
 } from '@cardstack/components';
 
 import { strings } from './strings';
@@ -26,11 +27,6 @@ const ProfileSlugScreen = () => {
     <PageWithStackHeader
       canGoBack={false}
       skipPressCallback={triggerSkipProfileCreation}
-      footer={
-        <Button onPress={onContinuePress} blocked={!canContinue}>
-          {strings.buttons.continue}
-        </Button>
-      }
     >
       <Container flex={1} justifyContent="space-between">
         <Container flex={0.8}>
@@ -57,6 +53,11 @@ const ProfileSlugScreen = () => {
           </Container>
         </Container>
       </Container>
+      <PageWithStackHeaderFooter>
+        <Button onPress={onContinuePress} blocked={!canContinue}>
+          {strings.buttons.continue}
+        </Button>
+      </PageWithStackHeaderFooter>
     </PageWithStackHeader>
   );
 };

--- a/cardstack/src/screens/Profile/PurchaseCTAScreen/PurchaseCTAScreen.tsx
+++ b/cardstack/src/screens/Profile/PurchaseCTAScreen/PurchaseCTAScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { StyleSheet } from 'react-native';
 
 import {
@@ -33,6 +33,47 @@ const PurchaseCTAScreen = () => {
     triggerSkipProfileCreation,
   } = usePurchaseCTAScreen();
 
+  const purchaseBtnLabel = `${strings.button.purchase} ${localizedValue}`;
+
+  const FooterComponent = useMemo(
+    () => (
+      <>
+        <Button onPress={onPressBuy} blocked={inPurchaseOngoing}>
+          {purchaseBtnLabel}
+        </Button>
+        {showPrepaidCardOption && (
+          <Button
+            onPress={onPressPrepaidCards}
+            variant="primaryWhite"
+            borderColor="teal"
+            blocked={inPurchaseOngoing}
+            marginTop={5}
+          >
+            {strings.button.prepaidCard}
+          </Button>
+        )}
+        <Touchable
+          onPress={onPressChargeExplanation}
+          alignSelf="center"
+          disabled={inPurchaseOngoing}
+          paddingVertical={5}
+        >
+          <Text color="white" fontSize={16} weight="semibold">
+            {strings.whyCharge}
+          </Text>
+        </Touchable>
+      </>
+    ),
+    [
+      inPurchaseOngoing,
+      purchaseBtnLabel,
+      showPrepaidCardOption,
+      onPressChargeExplanation,
+      onPressBuy,
+      onPressPrepaidCards,
+    ]
+  );
+
   const BenefitsItem = useCallback(
     ({ iconName, copy }: BenefitsItem) => (
       <Container alignItems="center" flexDirection="row">
@@ -51,10 +92,11 @@ const PurchaseCTAScreen = () => {
     []
   );
 
-  const purchaseBtnLabel = `${strings.button.purchase} ${localizedValue}`;
-
   return (
-    <PageWithStackHeader skipPressCallback={triggerSkipProfileCreation}>
+    <PageWithStackHeader
+      skipPressCallback={triggerSkipProfileCreation}
+      footer={FooterComponent}
+    >
       <Container
         flex={1}
         flexDirection="column"
@@ -78,28 +120,6 @@ const PurchaseCTAScreen = () => {
           style={styles.iapPreview}
           resizeMode="contain"
         />
-        <Button onPress={onPressBuy} blocked={inPurchaseOngoing}>
-          {purchaseBtnLabel}
-        </Button>
-        {showPrepaidCardOption && (
-          <Button
-            onPress={onPressPrepaidCards}
-            variant="primaryWhite"
-            borderColor="teal"
-            blocked={inPurchaseOngoing}
-          >
-            {strings.button.prepaidCard}
-          </Button>
-        )}
-        <Touchable
-          onPress={onPressChargeExplanation}
-          alignSelf="center"
-          disabled={inPurchaseOngoing}
-        >
-          <Text color="white" fontSize={16} weight="semibold">
-            {strings.whyCharge}
-          </Text>
-        </Touchable>
       </Container>
     </PageWithStackHeader>
   );

--- a/cardstack/src/screens/Profile/PurchaseCTAScreen/PurchaseCTAScreen.tsx
+++ b/cardstack/src/screens/Profile/PurchaseCTAScreen/PurchaseCTAScreen.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   Touchable,
   PageWithStackHeader,
+  PageWithStackHeaderFooter,
 } from '@cardstack/components';
 
 import profilePreview from '../../../assets/profile-preview.png';
@@ -93,10 +94,7 @@ const PurchaseCTAScreen = () => {
   );
 
   return (
-    <PageWithStackHeader
-      skipPressCallback={triggerSkipProfileCreation}
-      footer={FooterComponent}
-    >
+    <PageWithStackHeader skipPressCallback={triggerSkipProfileCreation}>
       <Container
         flex={1}
         flexDirection="column"
@@ -121,6 +119,7 @@ const PurchaseCTAScreen = () => {
           resizeMode="contain"
         />
       </Container>
+      <PageWithStackHeaderFooter>{FooterComponent}</PageWithStackHeaderFooter>
     </PageWithStackHeader>
   );
 };

--- a/cardstack/src/screens/Profile/PurchaseCTAScreen/PurchaseCTAScreen.tsx
+++ b/cardstack/src/screens/Profile/PurchaseCTAScreen/PurchaseCTAScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import { StyleSheet } from 'react-native';
 
 import {
@@ -35,45 +35,6 @@ const PurchaseCTAScreen = () => {
   } = usePurchaseCTAScreen();
 
   const purchaseBtnLabel = `${strings.button.purchase} ${localizedValue}`;
-
-  const FooterComponent = useMemo(
-    () => (
-      <>
-        <Button onPress={onPressBuy} blocked={inPurchaseOngoing}>
-          {purchaseBtnLabel}
-        </Button>
-        {showPrepaidCardOption && (
-          <Button
-            onPress={onPressPrepaidCards}
-            variant="primaryWhite"
-            borderColor="teal"
-            blocked={inPurchaseOngoing}
-            marginTop={5}
-          >
-            {strings.button.prepaidCard}
-          </Button>
-        )}
-        <Touchable
-          onPress={onPressChargeExplanation}
-          alignSelf="center"
-          disabled={inPurchaseOngoing}
-          paddingVertical={5}
-        >
-          <Text color="white" fontSize={16} weight="semibold">
-            {strings.whyCharge}
-          </Text>
-        </Touchable>
-      </>
-    ),
-    [
-      inPurchaseOngoing,
-      purchaseBtnLabel,
-      showPrepaidCardOption,
-      onPressChargeExplanation,
-      onPressBuy,
-      onPressPrepaidCards,
-    ]
-  );
 
   const BenefitsItem = useCallback(
     ({ iconName, copy }: BenefitsItem) => (
@@ -119,7 +80,33 @@ const PurchaseCTAScreen = () => {
           resizeMode="contain"
         />
       </Container>
-      <PageWithStackHeaderFooter>{FooterComponent}</PageWithStackHeaderFooter>
+
+      <PageWithStackHeaderFooter>
+        <Button onPress={onPressBuy} blocked={inPurchaseOngoing}>
+          {purchaseBtnLabel}
+        </Button>
+        {showPrepaidCardOption && (
+          <Button
+            onPress={onPressPrepaidCards}
+            variant="primaryWhite"
+            borderColor="teal"
+            blocked={inPurchaseOngoing}
+            marginTop={5}
+          >
+            {strings.button.prepaidCard}
+          </Button>
+        )}
+        <Touchable
+          onPress={onPressChargeExplanation}
+          alignSelf="center"
+          disabled={inPurchaseOngoing}
+          paddingVertical={5}
+        >
+          <Text color="white" fontSize={16} weight="semibold">
+            {strings.whyCharge}
+          </Text>
+        </Touchable>
+      </PageWithStackHeaderFooter>
     </PageWithStackHeader>
   );
 };


### PR DESCRIPTION
### Description

Refactors onboarding screens to use `PageWithStackHeader` footer prop, also standardizing paddings and alignment.

I went ahead with this change because I noticed different padding in the footer in PR #1039 from other screens and didn't want to throw away some of the tests for padding I was doing. 

PR Dependant on PR #1039. I'll rebase with dev once that's merged.

- [x] Completes #(CS-4585)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

https://user-images.githubusercontent.com/129619/190165693-8ee73a50-864c-4bfa-b47a-105ef81809ce.mov

<img width="200" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/190166289-ef54fac9-7953-421a-8f39-ca3af5d90924.jpg">
<img width="200" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/190166299-a62a1b2d-8aa4-463a-bf79-c6ee00931692.jpg">
<img width="200" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/190166304-a9a88e6c-ed6d-4fbe-8e63-d71bf23f9599.jpg">
<img width="200" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/190166306-196685a0-863e-4e9d-ade2-8653d69e8676.jpg">


