### PR TITLE
[CS-4613] Handle default exclamation point color in warning icon

### DIFF
--- a/cardstack/src/components/Icon/custom-icons/warning.tsx
+++ b/cardstack/src/components/Icon/custom-icons/warning.tsx
@@ -20,7 +20,7 @@ function SvgComponent({ fill = '#ffa700', stroke = '#fff' }: SvgProps) {
       <Path
         data-name="Path 382"
         d="M13.139 13.342h-2.343l-.49-6.924h3.327zm-2.871 3.288a1.61 1.61 0 01.432-1.22 1.752 1.752 0 011.258-.413 1.7 1.7 0 011.234.423 1.606 1.606 0 01.441 1.21 1.606 1.606 0 01-.442 1.2 1.672 1.672 0 01-1.229.437 1.722 1.722 0 01-1.252-.437 1.6 1.6 0 01-.442-1.2z"
-        fill={stroke} // using stroke as fill-color to enable two-color component
+        fill={stroke ?? '#fff'} // using stroke as fill-color to enable two-color component
       />
       <Circle
         data-name="Ellipse 43"


### PR DESCRIPTION
### Description
In https://github.com/cardstack/cardwallet/pull/1031, we introduced a change on the `warning` component. This change didn't take into consideration other instances of where this component was being used. To fix the issue, we added a default color to the exclamation point `fill` property. 

- [x] Completes #CS-4613

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/190231632-caa7e001-22fa-4a3d-aad6-c5eaeed72fb6.png">