### PR TITLE
[CS-4497] Add KeyboardAvoidingView to BackupCloudPasswordScreen

### DIFF
--- a/cardstack/src/screens/Backup/BackupCloudPasswordScreen/BackupCloudPasswordScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupCloudPasswordScreen/BackupCloudPasswordScreen.tsx
@@ -79,12 +79,14 @@ const BackupCloudPasswordScreen = () => {
               isValid={isValid}
               value={password}
               containerProps={styles.passwordInput}
+              returnKeyType="next"
             />
             <PasswordInput
               validationMessage={strings.confirmPasswordValidation}
               onChangeText={onChangeConfirmation}
               isValid={isValidConfirmation}
               value={confirmation}
+              returnKeyType="done"
             />
           </Container>
         </KeyboardAvoidingView>

--- a/cardstack/src/screens/Backup/BackupCloudPasswordScreen/BackupCloudPasswordScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupCloudPasswordScreen/BackupCloudPasswordScreen.tsx
@@ -1,5 +1,6 @@
 import { eq } from 'lodash';
 import React, { memo, useCallback } from 'react';
+import { KeyboardAvoidingView, StyleSheet } from 'react-native';
 
 import {
   Button,
@@ -12,6 +13,7 @@ import {
   Text,
   usePasswordInput,
 } from '@cardstack/components';
+import { Device } from '@cardstack/utils';
 import {
   hasAtLeastOneDigit,
   matchMinLength,
@@ -27,6 +29,12 @@ const layouts = {
     marginBottom: 5,
   },
 };
+
+const styles = StyleSheet.create({
+  keyboardAvoidView: {
+    flex: 1,
+  },
+});
 
 const BackupCloudPasswordScreen = () => {
   const { onChangeText, isValid, password } = usePasswordInput({
@@ -48,35 +56,41 @@ const BackupCloudPasswordScreen = () => {
 
   return (
     <PageWithStackHeader showSkip={false}>
-      <ScrollView
-        flex={1}
-        contentContainerStyle={layouts.scrollView}
-        showsVerticalScrollIndicator={false}
+      <KeyboardAvoidingView
+        style={styles.keyboardAvoidView}
+        contentContainerStyle={{ marginBottom: 200 }}
+        behavior={Device.isIOS ? 'padding' : undefined}
       >
-        <Container width="80%" marginBottom={7}>
-          <Text variant="pageHeader" paddingBottom={4}>
-            {strings.title}
-          </Text>
-          <Text color="grayText" letterSpacing={0.4}>
-            {strings.description}
-          </Text>
-        </Container>
-        <Container>
-          <PasswordInput
-            validationMessage={strings.passwordValidation}
-            onChangeText={onChangeText}
-            isValid={isValid}
-            value={password}
-            containerProps={layouts.passwordInput}
-          />
-          <PasswordInput
-            validationMessage={strings.confirmPasswordValidation}
-            onChangeText={onChangeConfirmation}
-            isValid={isValidConfirmation}
-            value={confirmation}
-          />
-        </Container>
-      </ScrollView>
+        <ScrollView
+          flex={1}
+          contentContainerStyle={layouts.scrollView}
+          showsVerticalScrollIndicator={false}
+        >
+          <Container width="80%" marginBottom={7}>
+            <Text variant="pageHeader" paddingBottom={4}>
+              {strings.title}
+            </Text>
+            <Text color="grayText" letterSpacing={0.4}>
+              {strings.description}
+            </Text>
+          </Container>
+          <Container>
+            <PasswordInput
+              validationMessage={strings.passwordValidation}
+              onChangeText={onChangeText}
+              isValid={isValid}
+              value={password}
+              containerProps={layouts.passwordInput}
+            />
+            <PasswordInput
+              validationMessage={strings.confirmPasswordValidation}
+              onChangeText={onChangeConfirmation}
+              isValid={isValidConfirmation}
+              value={confirmation}
+            />
+          </Container>
+        </ScrollView>
+      </KeyboardAvoidingView>
       <PageWithStackHeaderFooter>
         <Container
           borderTopWidth={1}

--- a/cardstack/src/screens/Backup/BackupCloudPasswordScreen/BackupCloudPasswordScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupCloudPasswordScreen/BackupCloudPasswordScreen.tsx
@@ -24,9 +24,7 @@ import { strings } from './strings';
 const styles = StyleSheet.create({
   keyboardAvoidView: {
     flex: 1,
-  },
-  contentContainerStyle: {
-    marginBottom: 200,
+    marginBottom: 50,
   },
   scrollView: {
     marginBottom: 50,
@@ -56,15 +54,15 @@ const BackupCloudPasswordScreen = () => {
 
   return (
     <PageWithStackHeader showSkip={false}>
-      <KeyboardAvoidingView
-        style={styles.keyboardAvoidView}
-        contentContainerStyle={styles.contentContainerStyle}
-        behavior={Device.isIOS ? 'padding' : undefined}
+      <ScrollView
+        flex={1}
+        contentContainerStyle={styles.scrollView}
+        showsVerticalScrollIndicator={false}
       >
-        <ScrollView
-          flex={1}
-          contentContainerStyle={styles.scrollView}
-          showsVerticalScrollIndicator={false}
+        <KeyboardAvoidingView
+          style={styles.keyboardAvoidView}
+          behavior="position"
+          keyboardVerticalOffset={Device.isIOS ? 100 : 0}
         >
           <Container width="80%" marginBottom={7}>
             <Text variant="pageHeader" paddingBottom={4}>
@@ -89,8 +87,8 @@ const BackupCloudPasswordScreen = () => {
               value={confirmation}
             />
           </Container>
-        </ScrollView>
-      </KeyboardAvoidingView>
+        </KeyboardAvoidingView>
+      </ScrollView>
       <PageWithStackHeaderFooter>
         <Container
           borderTopWidth={1}

--- a/cardstack/src/screens/Backup/BackupCloudPasswordScreen/BackupCloudPasswordScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupCloudPasswordScreen/BackupCloudPasswordScreen.tsx
@@ -21,18 +21,18 @@ import {
 
 import { strings } from './strings';
 
-const layouts = {
+const styles = StyleSheet.create({
+  keyboardAvoidView: {
+    flex: 1,
+  },
+  contentContainerStyle: {
+    marginBottom: 200,
+  },
   scrollView: {
     marginBottom: 50,
   },
   passwordInput: {
     marginBottom: 5,
-  },
-};
-
-const styles = StyleSheet.create({
-  keyboardAvoidView: {
-    flex: 1,
   },
 });
 
@@ -58,12 +58,12 @@ const BackupCloudPasswordScreen = () => {
     <PageWithStackHeader showSkip={false}>
       <KeyboardAvoidingView
         style={styles.keyboardAvoidView}
-        contentContainerStyle={{ marginBottom: 200 }}
+        contentContainerStyle={styles.contentContainerStyle}
         behavior={Device.isIOS ? 'padding' : undefined}
       >
         <ScrollView
           flex={1}
-          contentContainerStyle={layouts.scrollView}
+          contentContainerStyle={styles.scrollView}
           showsVerticalScrollIndicator={false}
         >
           <Container width="80%" marginBottom={7}>
@@ -80,7 +80,7 @@ const BackupCloudPasswordScreen = () => {
               onChangeText={onChangeText}
               isValid={isValid}
               value={password}
-              containerProps={layouts.passwordInput}
+              containerProps={styles.passwordInput}
             />
             <PasswordInput
               validationMessage={strings.confirmPasswordValidation}


### PR DESCRIPTION
### Description
This PR adds a `KeyboardAvoidingView` wrapping the password inputs to avoiding having the inputs behind the keyboard when interacting with it.  

- [x] Completes #CS-4497

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

https://user-images.githubusercontent.com/690904/191057402-1b08b90d-227f-4583-b4d2-186f8c6e465e.mov

https://user-images.githubusercontent.com/690904/191057409-66d91948-2351-468b-9e41-c33515cb50e8.mov
