### PR TITLE
[CS-4619] Fix for seedphrase visible while blur loads

### DIFF
--- a/cardstack/src/components/SeedPhraseTable/SeedPhraseTable.tsx
+++ b/cardstack/src/components/SeedPhraseTable/SeedPhraseTable.tsx
@@ -148,9 +148,10 @@ const styles = StyleSheet.create({
     position: 'absolute',
     width: '100%',
     height: '100%',
+    backgroundColor: colors.blueDarkest,
+    borderRadius: 20,
   },
   imageBlurView: {
-    borderRadius: 20,
     borderColor: colors.whiteTinyLightOpacity,
     borderWidth: StyleSheet.hairlineWidth,
   },


### PR DESCRIPTION
### Description

PR fills blur image view background with color so phrase isn't visible while blurred image loads. This issue affects particularly slow devices.

- [x] Completes #(CS-4619)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

Frame-by-frame check on android:

https://user-images.githubusercontent.com/129619/191260270-ca5e7560-4284-436f-938f-b344ea77bc22.mov

