### PR TITLE
[CS-4622] Restores container with flex 1 to children of PageWithStackHeader

### DIFF
--- a/cardstack/src/components/PageWithStackHeader/PageWithStackHeader.tsx
+++ b/cardstack/src/components/PageWithStackHeader/PageWithStackHeader.tsx
@@ -66,7 +66,7 @@ const PageWithStackHeader = ({
         paddingHorizontal={0} // reset MainHeaderWrapper's default padding
         {...headerContainerProps}
       />
-      {children}
+      <Container flex={1}>{children}</Container>
     </Container>
   );
 };


### PR DESCRIPTION
### Description

As title says, Container with flex 1 was removed by mistake to add the Footer component, which breaks some uses like on ProfileNameScreen. Re-adding the container fixes it.

- [x] Completes #(CS-4622)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/191327059-eee6ed63-8f98-4357-b82c-859faa1af5fd.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/191327063-8bda0a7b-3cfd-49ba-b7e0-abd6e027001b.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/191327193-37b1a6bf-30b5-4e18-9c16-bbcd5e754a8e.jpg">
