### PR TITLE
[CS-4496] Backup recovery phrase screen

### DIFF
--- a/cardstack/src/components/PageWithStackHeader/PageWithStackHeader.tsx
+++ b/cardstack/src/components/PageWithStackHeader/PageWithStackHeader.tsx
@@ -1,5 +1,11 @@
 import { useNavigation, StackActions } from '@react-navigation/native';
-import React, { memo, PropsWithChildren, useCallback, useMemo } from 'react';
+import React, {
+  memo,
+  PropsWithChildren,
+  ReactNode,
+  useCallback,
+  useMemo,
+} from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
@@ -19,6 +25,7 @@ interface PageWithStackHeaderProps {
     name?: IconName;
   };
   headerContainerProps?: ContainerProps;
+  headerChildren?: ReactNode;
 }
 
 const PageWithStackHeader = ({
@@ -28,6 +35,7 @@ const PageWithStackHeader = ({
   children,
   leftIconProps,
   headerContainerProps,
+  headerChildren,
 }: PropsWithChildren<PageWithStackHeaderProps>) => {
   const { dispatch: navDispatch } = useNavigation();
 
@@ -65,8 +73,10 @@ const PageWithStackHeader = ({
         leftIconProps={leftIconProps}
         paddingHorizontal={0} // reset MainHeaderWrapper's default padding
         {...headerContainerProps}
-      />
-      <Container flex={1}>{children}</Container>
+      >
+        {headerChildren}
+      </NavigationStackHeader>
+      {children}
     </Container>
   );
 };

--- a/cardstack/src/components/PageWithStackHeader/PageWithStackHeader.tsx
+++ b/cardstack/src/components/PageWithStackHeader/PageWithStackHeader.tsx
@@ -76,7 +76,7 @@ const PageWithStackHeader = ({
       >
         {headerChildren}
       </NavigationStackHeader>
-      {children}
+      <Container flex={1}>{children}</Container>
     </Container>
   );
 };

--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -74,6 +74,7 @@ const ProfileRoutes = {
 const BackupRoutes = {
   BACKUP_EXPLANATION: 'BackupExplanation',
   BACKUP_CLOUD_PASSWORD: 'BackupCloudPassword',
+  BACKUP_RECOVERY_PHRASE: 'BackupRecoveryPhrase',
 };
 
 export const Routes = {

--- a/cardstack/src/navigation/screenGroups/backup.tsx
+++ b/cardstack/src/navigation/screenGroups/backup.tsx
@@ -7,6 +7,7 @@ import {
 import {
   BackupCloudPasswordScreen,
   BackupExplanationScreen,
+  BackupRecoveryPhraseScreen,
 } from '@cardstack/screens';
 
 import { StackType } from '../types';
@@ -26,6 +27,10 @@ export const BackupScreenGroup = ({ Stack }: { Stack: StackType }) => (
     <Stack.Screen
       component={BackupCloudPasswordScreen}
       name={Routes.BACKUP_CLOUD_PASSWORD}
+    />
+    <Stack.Screen
+      component={BackupRecoveryPhraseScreen}
+      name={Routes.BACKUP_RECOVERY_PHRASE}
     />
   </Stack.Group>
 );

--- a/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
@@ -9,17 +9,18 @@ import {
   PageWithStackHeaderFooter,
   Text,
 } from '@cardstack/components';
+import { Routes } from '@cardstack/navigation';
 
 import { ButtonLink } from '../components/ButtonLink';
 
 import { strings } from './strings';
 
 const BackupExplanationScreen = () => {
-  const { dispatch: navDispatch } = useNavigation();
+  const { dispatch: navDispatch, navigate } = useNavigation();
 
   const handleBackupOnPress = useCallback(() => {
-    // TODO
-  }, []);
+    navigate(Routes.BACKUP_RECOVERY_PHRASE);
+  }, [navigate]);
 
   const handleLaterOnPress = useCallback(() => {
     navDispatch(StackActions.popToTop());

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
@@ -1,7 +1,8 @@
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { StyleSheet } from 'react-native';
 
 import {
+  BackupStatus,
   Button,
   CenteredContainer,
   Container,
@@ -27,10 +28,16 @@ const BackupRecoveryPhraseScreen = () => {
   const {
     handleCloudBackupOnPress,
     handleManualBackupOnPress,
+    latestBackup,
   } = useBackupRecoveryPhraseScreen();
 
+  const backupStatus = useMemo(
+    () => <BackupStatus status={latestBackup ? 'success' : 'missing'} />,
+    [latestBackup]
+  );
+
   return (
-    <PageWithStackHeader>
+    <PageWithStackHeader headerChildren={backupStatus}>
       <ScrollView
         showsVerticalScrollIndicator={false}
         contentContainerStyle={style.scrollview}

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
@@ -12,6 +12,7 @@ import {
   SeedPhraseTable,
   Text,
 } from '@cardstack/components';
+import { Device } from '@cardstack/utils';
 
 import { ButtonLink } from '../components/ButtonLink';
 
@@ -63,7 +64,7 @@ const BackupRecoveryPhraseScreen = () => {
       <PageWithStackHeaderFooter>
         <CenteredContainer>
           <Button onPress={handleCloudBackupOnPress}>
-            {strings.primaryBtn('iCloud')}
+            {strings.primaryBtn(Device.cloudPlatform)}
           </Button>
           <ButtonLink onPress={handleManualBackupOnPress}>
             {strings.secondaryBtn}

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
@@ -29,13 +29,13 @@ const BackupRecoveryPhraseScreen = () => {
   const {
     handleCloudBackupOnPress,
     handleManualBackupOnPress,
-    latestBackup,
+    backedUp,
     seedPhrase,
   } = useBackupRecoveryPhraseScreen();
 
   const backupStatus = useMemo(
-    () => <BackupStatus status={latestBackup ? 'success' : 'missing'} />,
-    [latestBackup]
+    () => <BackupStatus status={backedUp ? 'success' : 'missing'} />,
+    [backedUp]
   );
 
   return (

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
@@ -1,0 +1,22 @@
+import React, { memo } from 'react';
+
+import { Container, PageWithStackHeader, Text } from '@cardstack/components';
+
+import { strings } from './strings';
+
+const BackupRecoveryPhraseScreen = () => {
+  return (
+    <PageWithStackHeader>
+      <Container flex={1} width="90%">
+        <Text variant="pageHeader" paddingBottom={4}>
+          {strings.title}
+        </Text>
+        <Text color="grayText" letterSpacing={0.4}>
+          {strings.description}
+        </Text>
+      </Container>
+    </PageWithStackHeader>
+  );
+};
+
+export default memo(BackupRecoveryPhraseScreen);

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
@@ -1,20 +1,68 @@
 import React, { memo } from 'react';
+import { StyleSheet } from 'react-native';
 
-import { Container, PageWithStackHeader, Text } from '@cardstack/components';
+import {
+  Button,
+  CenteredContainer,
+  Container,
+  PageWithStackHeader,
+  PageWithStackHeaderFooter,
+  ScrollView,
+  SeedPhraseTable,
+  Text,
+} from '@cardstack/components';
+
+import { ButtonLink } from '../components/ButtonLink';
 
 import { strings } from './strings';
+import { useBackupRecoveryPhraseScreen } from './useBackupRecoveryPhraseScreen';
+
+const style = StyleSheet.create({
+  scrollview: {
+    paddingBottom: 30,
+  },
+});
 
 const BackupRecoveryPhraseScreen = () => {
+  const {
+    handleCloudBackupOnPress,
+    handleManualBackupOnPress,
+  } = useBackupRecoveryPhraseScreen();
+
   return (
     <PageWithStackHeader>
-      <Container flex={1} width="90%">
-        <Text variant="pageHeader" paddingBottom={4}>
-          {strings.title}
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={style.scrollview}
+      >
+        <Container flex={1} width="90%" marginBottom={10}>
+          <Text variant="pageHeader" paddingBottom={4}>
+            {strings.title}
+          </Text>
+          <Text color="grayText" letterSpacing={0.4}>
+            {strings.description}
+          </Text>
+        </Container>
+        <SeedPhraseTable />
+        <Text
+          color="grayText"
+          letterSpacing={0.28}
+          fontSize={11}
+          paddingVertical={2}
+        >
+          {strings.disclaimer}
         </Text>
-        <Text color="grayText" letterSpacing={0.4}>
-          {strings.description}
-        </Text>
-      </Container>
+      </ScrollView>
+      <PageWithStackHeaderFooter>
+        <CenteredContainer>
+          <Button onPress={handleCloudBackupOnPress}>
+            {strings.primaryBtn('iCloud')}
+          </Button>
+          <ButtonLink onPress={handleManualBackupOnPress}>
+            {strings.secondaryBtn}
+          </ButtonLink>
+        </CenteredContainer>
+      </PageWithStackHeaderFooter>
     </PageWithStackHeader>
   );
 };

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
@@ -30,6 +30,7 @@ const BackupRecoveryPhraseScreen = () => {
     handleCloudBackupOnPress,
     handleManualBackupOnPress,
     latestBackup,
+    seedPhrase,
   } = useBackupRecoveryPhraseScreen();
 
   const backupStatus = useMemo(
@@ -51,7 +52,7 @@ const BackupRecoveryPhraseScreen = () => {
             {strings.description}
           </Text>
         </Container>
-        <SeedPhraseTable />
+        <SeedPhraseTable seedPhrase={seedPhrase} hideOnOpen />
         <Text
           color="grayText"
           letterSpacing={0.28}

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/strings.ts
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/strings.ts
@@ -1,0 +1,9 @@
+export const strings = {
+  title: 'Recovery Phrase',
+  description:
+    'These 12 words are the keys to your wallet. Back them up on the cloud or back them up manually. Do not share this with anyone.',
+  disclaimer:
+    '* Always be mindful of your surroundings when viewing your recovery phrase',
+  primaryBtn: (cloud: string) => `Back up to ${cloud}`,
+  secondaryBtn: 'Back up manually',
+};

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
@@ -1,0 +1,27 @@
+import { useNavigation } from '@react-navigation/native';
+import { useCallback } from 'react';
+
+import { Routes } from '@cardstack/navigation';
+
+import { useWallets } from '@rainbow-me/hooks';
+
+export const useBackupRecoveryPhraseScreen = () => {
+  const { navigate } = useNavigation();
+  const { wallets } = useWallets();
+
+  const handleCloudBackupOnPress = useCallback(
+    () => navigate(Routes.BACKUP_CLOUD_PASSWORD),
+    [navigate]
+  );
+
+  const handleManualBackupOnPress = useCallback(() => {
+    // TBD
+  }, []);
+
+  console.log('[LOG] wallets', wallets);
+
+  return {
+    handleCloudBackupOnPress,
+    handleManualBackupOnPress,
+  };
+};

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
@@ -7,7 +7,7 @@ import { useWallets } from '@rainbow-me/hooks';
 
 export const useBackupRecoveryPhraseScreen = () => {
   const { navigate } = useNavigation();
-  const { wallets } = useWallets();
+  const { latestBackup } = useWallets();
 
   const handleCloudBackupOnPress = useCallback(
     () => navigate(Routes.BACKUP_CLOUD_PASSWORD),
@@ -18,10 +18,9 @@ export const useBackupRecoveryPhraseScreen = () => {
     // TBD
   }, []);
 
-  console.log('[LOG] wallets', wallets);
-
   return {
     handleCloudBackupOnPress,
     handleManualBackupOnPress,
+    latestBackup,
   };
 };

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
@@ -9,7 +9,7 @@ import { logger } from '@rainbow-me/utils';
 
 export const useBackupRecoveryPhraseScreen = () => {
   const { navigate } = useNavigation();
-  const { latestBackup, selectedWallet } = useWallets();
+  const { selectedWallet } = useWallets();
   const [seedPhrase, setSeedPhrase] = useState('');
 
   const loadSeedPhrase = useCallback(async () => {
@@ -38,7 +38,7 @@ export const useBackupRecoveryPhraseScreen = () => {
   return {
     handleCloudBackupOnPress,
     handleManualBackupOnPress,
-    latestBackup,
+    backedUp: selectedWallet.backedUp,
     seedPhrase,
   };
 };

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
@@ -1,17 +1,29 @@
 import { useNavigation } from '@react-navigation/native';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
+import { getSeedPhrase } from '@cardstack/models/secure-storage';
 import { Routes } from '@cardstack/navigation';
 
 import { useWallets } from '@rainbow-me/hooks';
 
 export const useBackupRecoveryPhraseScreen = () => {
   const { navigate } = useNavigation();
-  const { latestBackup } = useWallets();
+  const { latestBackup, selectedWallet } = useWallets();
+  const [seedPhrase, setSeedPhrase] = useState('');
+
+  const loadSeedPhrase = useCallback(async () => {
+    const seedphrase = await getSeedPhrase(selectedWallet.id);
+
+    setSeedPhrase(seedphrase);
+  }, [selectedWallet]);
+
+  useEffect(() => {
+    loadSeedPhrase();
+  }, [loadSeedPhrase]);
 
   const handleCloudBackupOnPress = useCallback(
-    () => navigate(Routes.BACKUP_CLOUD_PASSWORD),
-    [navigate]
+    () => navigate(Routes.BACKUP_CLOUD_PASSWORD, { seedPhrase }),
+    [navigate, seedPhrase]
   );
 
   const handleManualBackupOnPress = useCallback(() => {
@@ -22,5 +34,6 @@ export const useBackupRecoveryPhraseScreen = () => {
     handleCloudBackupOnPress,
     handleManualBackupOnPress,
     latestBackup,
+    seedPhrase,
   };
 };

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
@@ -5,6 +5,7 @@ import { getSeedPhrase } from '@cardstack/models/secure-storage';
 import { Routes } from '@cardstack/navigation';
 
 import { useWallets } from '@rainbow-me/hooks';
+import { logger } from '@rainbow-me/utils';
 
 export const useBackupRecoveryPhraseScreen = () => {
   const { navigate } = useNavigation();
@@ -12,9 +13,13 @@ export const useBackupRecoveryPhraseScreen = () => {
   const [seedPhrase, setSeedPhrase] = useState('');
 
   const loadSeedPhrase = useCallback(async () => {
-    const seedphrase = await getSeedPhrase(selectedWallet.id);
+    try {
+      const seedphrase = await getSeedPhrase(selectedWallet.id);
 
-    setSeedPhrase(seedphrase);
+      setSeedPhrase(seedphrase);
+    } catch (error) {
+      logger.log('Error getting seed phrase', error);
+    }
   }, [selectedWallet]);
 
   useEffect(() => {

--- a/cardstack/src/screens/Backup/index.ts
+++ b/cardstack/src/screens/Backup/index.ts
@@ -1,2 +1,3 @@
 export { default as BackupExplanationScreen } from './BackupExplanationScreen/BackupExplanationScreen';
 export { default as BackupCloudPasswordScreen } from './BackupCloudPasswordScreen/BackupCloudPasswordScreen';
+export { default as BackupRecoveryPhraseScreen } from './BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen';


### PR DESCRIPTION
### Description
This PR adds the recovery phrase screen. There's one thing worth mentioning here that's the change on the `PageWithStackHeader`. We need to be able to pass the `BackupStatus` component to the `NavigationStackHeader` via children.

- [x] Completes #CS-4496

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

**iOS - Tall**
<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/191344606-60670161-d470-4039-ac05-b686ea91dc41.jpeg">

**iOS - Small**

https://user-images.githubusercontent.com/690904/191345523-e890a954-b2de-4ff6-a665-d6e843e090ed.mov


**Android - Tall**
<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/191344997-a5221c02-5772-4d92-afb2-d73f6852ff0e.png">

**Android - Small**

https://user-images.githubusercontent.com/690904/191345427-0416999c-1f27-4bbc-8f41-3e316e598406.mov





