### PR TITLE
[CS-4651] Adjustments to manual backup flow

### DIFF
--- a/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
@@ -1,4 +1,8 @@
-import { StackActions, useNavigation } from '@react-navigation/native';
+import {
+  StackActions,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native';
 import React, { memo, useCallback } from 'react';
 
 import {
@@ -10,15 +14,19 @@ import {
   Text,
 } from '@cardstack/components';
 import { Routes } from '@cardstack/navigation';
+import { RouteType } from '@cardstack/navigation/types';
+
+import { BackupRouteParams } from '../types';
 
 import { strings } from './strings';
 
 const BackupExplanationScreen = () => {
   const { dispatch: navDispatch, navigate } = useNavigation();
+  const { params } = useRoute<RouteType<BackupRouteParams>>();
 
   const handleBackupOnPress = useCallback(() => {
-    navigate(Routes.BACKUP_RECOVERY_PHRASE);
-  }, [navigate]);
+    navigate(Routes.BACKUP_MANUAL_BACKUP, params);
+  }, [navigate, params]);
 
   const handleLaterOnPress = useCallback(() => {
     navDispatch(StackActions.popToTop());

--- a/cardstack/src/screens/Backup/BackupManualScreen/BackupManualScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupManualScreen/BackupManualScreen.tsx
@@ -14,6 +14,8 @@ import {
 import { Routes } from '@cardstack/navigation';
 import { RouteType } from '@cardstack/navigation/types';
 
+import { BackupRouteParams } from '../types';
+
 import { strings } from './strings';
 
 const style = StyleSheet.create({
@@ -22,13 +24,9 @@ const style = StyleSheet.create({
   },
 });
 
-interface RouteParams {
-  seedPhrase: string;
-}
-
 const BackupManualScreen = () => {
   const { navigate } = useNavigation();
-  const { params } = useRoute<RouteType<RouteParams>>();
+  const { params } = useRoute<RouteType<BackupRouteParams>>();
 
   const handleNextOnPress = useCallback(() => {
     navigate(Routes.BACKUP_SEEDPHRASE_CONFIRMATION, params);
@@ -48,7 +46,7 @@ const BackupManualScreen = () => {
             {strings.description}
           </Text>
         </Container>
-        <SeedPhraseTable seedPhrase={params.seedPhrase} allowCopy />
+        <SeedPhraseTable seedPhrase={params.seedPhrase} allowCopy hideOnOpen />
       </ScrollView>
       <PageWithStackHeaderFooter>
         <Button onPress={handleNextOnPress}>{strings.primaryBtn}</Button>

--- a/cardstack/src/screens/Backup/BackupManualScreen/strings.ts
+++ b/cardstack/src/screens/Backup/BackupManualScreen/strings.ts
@@ -1,5 +1,6 @@
 export const strings = {
-  title: 'Manual Backup',
-  description: 'Write these 12 words down, or copy them to a password manager.',
+  title: 'Recovery Phrase',
+  description:
+    'These 12 words are the keys to your wallet. Write them down or copy them to a password manager. Do not share this with anyone.',
   primaryBtn: 'Next',
 };

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
@@ -1,31 +1,14 @@
 import { useNavigation } from '@react-navigation/native';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 
-import { getSeedPhrase } from '@cardstack/models/secure-storage';
 import { Routes } from '@cardstack/navigation';
 
 import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
 import { useWallets } from '@rainbow-me/hooks';
-import { logger } from '@rainbow-me/utils';
 
 export const useBackupRecoveryPhraseScreen = () => {
   const { navigate } = useNavigation();
-  const { selectedWallet } = useWallets();
-  const [seedPhrase, setSeedPhrase] = useState('');
-
-  const loadSeedPhrase = useCallback(async () => {
-    try {
-      const seedphrase = await getSeedPhrase(selectedWallet.id);
-
-      setSeedPhrase(seedphrase);
-    } catch (error) {
-      logger.log('Error getting seed phrase', error);
-    }
-  }, [selectedWallet]);
-
-  useEffect(() => {
-    loadSeedPhrase();
-  }, [loadSeedPhrase]);
+  const { selectedWallet, seedPhrase } = useWallets();
 
   const handleCloudBackupOnPress = useCallback(
     () => navigate(Routes.BACKUP_CLOUD_PASSWORD, { seedPhrase }),

--- a/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/BackupSeedPhraseConfirmationScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/BackupSeedPhraseConfirmationScreen.tsx
@@ -10,6 +10,7 @@ import {
   ScrollView,
   SeedPhraseTable,
 } from '@cardstack/components';
+import { Device } from '@cardstack/utils';
 
 import { WordPressableGroup } from './components/WordPressableGroup';
 import { strings } from './strings';
@@ -25,6 +26,7 @@ const BackupSeedPhraseConfirmationScreen = () => {
     shuffledWords,
     selectedWordsIndexes,
     selectedSeedPhraseAsString,
+    handleBackupToCloudPress,
   } = useBackupSeedPhraseConfirmationScreen();
 
   return (
@@ -55,7 +57,14 @@ const BackupSeedPhraseConfirmationScreen = () => {
         <PageWithStackHeaderFooter>
           <CenteredContainer>
             {isSeedPhraseCorrect ? (
-              <Button onPress={handleConfirmPressed}>{strings.doneBtn}</Button>
+              <>
+                <Button onPress={handleConfirmPressed}>
+                  {strings.doneBtn}
+                </Button>
+                <Button variant="linkWhite" onPress={handleBackupToCloudPress}>
+                  {strings.backupToCloudBtn(Device.cloudPlatform)}
+                </Button>
+              </>
             ) : (
               <Button variant="red" onPress={handleClearPressed}>
                 {strings.retryBtn}

--- a/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/strings.ts
+++ b/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/strings.ts
@@ -3,5 +3,6 @@ export const strings = {
   description:
     'Enter the words in the order as they appeared in the previous screen.',
   doneBtn: 'Done',
+  backupToCloudBtn: (cloud: string) => `Back up to ${cloud}`,
   retryBtn: 'Incorrect, reset & try again',
 };

--- a/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/useBackupSeedPhraseConfirmationScreen.ts
+++ b/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/useBackupSeedPhraseConfirmationScreen.ts
@@ -62,6 +62,11 @@ export const useBackupSeedPhraseConfirmationScreen = () => {
     setSelectedWords([]);
   }, [selectedWordsIndexes, setSelectedWords]);
 
+  const handleBackupToCloudPress = useCallback(() => {
+    confirmBackup();
+    navigate(Routes.BACKUP_CLOUD_PASSWORD);
+  }, [navigate, confirmBackup]);
+
   return {
     handleWordPressed,
     handleConfirmPressed,
@@ -71,5 +76,6 @@ export const useBackupSeedPhraseConfirmationScreen = () => {
     shuffledWords,
     selectedWordsIndexes,
     selectedSeedPhraseAsString,
+    handleBackupToCloudPress,
   };
 };

--- a/cardstack/src/screens/Backup/types.ts
+++ b/cardstack/src/screens/Backup/types.ts
@@ -1,0 +1,3 @@
+export interface BackupRouteParams {
+  seedPhrase: string;
+}

--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -13,6 +13,7 @@ import {
 } from '../list';
 import { CenteredContainer, Icon, ScrollView } from '@cardstack/components';
 import { SettingsExternalURLs } from '@cardstack/constants';
+import { getSeedPhrase } from '@cardstack/models/secure-storage';
 import { Routes } from '@cardstack/navigation';
 import networkInfo from '@rainbow-me/helpers/networkInfo';
 import {
@@ -20,6 +21,7 @@ import {
   useSendFeedback,
   useWallets,
 } from '@rainbow-me/hooks';
+import { logger } from '@rainbow-me/utils';
 
 export default function SettingsSection({
   onPressDev,
@@ -33,6 +35,21 @@ export default function SettingsSection({
 }) {
   const { selectedWallet } = useWallets();
   const { nativeCurrency, network, accountAddress } = useAccountSettings();
+  const [seedPhrase, setSeedPhrase] = useState('');
+
+  const loadSeedPhrase = useCallback(async () => {
+    try {
+      const seedphrase = await getSeedPhrase(selectedWallet.id);
+
+      setSeedPhrase(seedphrase);
+    } catch (error) {
+      logger.log('Error getting seed phrase', error);
+    }
+  }, [selectedWallet]);
+
+  useEffect(() => {
+    loadSeedPhrase();
+  }, [loadSeedPhrase]);
 
   const onSendFeedback = useSendFeedback();
 
@@ -64,8 +81,8 @@ export default function SettingsSection({
   }, [navigate]);
 
   const onPressNewBackup = useCallback(() => {
-    navigate(Routes.BACKUP_EXPLANATION);
-  }, [navigate]);
+    navigate(Routes.BACKUP_EXPLANATION, { seedPhrase });
+  }, [navigate, seedPhrase]);
 
   return (
     <ScrollView backgroundColor="white">

--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -13,7 +13,6 @@ import {
 } from '../list';
 import { CenteredContainer, Icon, ScrollView } from '@cardstack/components';
 import { SettingsExternalURLs } from '@cardstack/constants';
-import { getSeedPhrase } from '@cardstack/models/secure-storage';
 import { Routes } from '@cardstack/navigation';
 import networkInfo from '@rainbow-me/helpers/networkInfo';
 import {
@@ -21,7 +20,6 @@ import {
   useSendFeedback,
   useWallets,
 } from '@rainbow-me/hooks';
-import { logger } from '@rainbow-me/utils';
 
 export default function SettingsSection({
   onPressDev,
@@ -33,23 +31,8 @@ export default function SettingsSection({
   onPressDS,
   onPressSecurity,
 }) {
-  const { selectedWallet } = useWallets();
+  const { selectedWallet, seedPhrase } = useWallets();
   const { nativeCurrency, network, accountAddress } = useAccountSettings();
-  const [seedPhrase, setSeedPhrase] = useState('');
-
-  const loadSeedPhrase = useCallback(async () => {
-    try {
-      const seedphrase = await getSeedPhrase(selectedWallet.id);
-
-      setSeedPhrase(seedphrase);
-    } catch (error) {
-      logger.log('Error getting seed phrase', error);
-    }
-  }, [selectedWallet]);
-
-  useEffect(() => {
-    loadSeedPhrase();
-  }, [loadSeedPhrase]);
 
   const onSendFeedback = useSendFeedback();
 


### PR DESCRIPTION
### Description
- [x] Completes #CS-4651

This PR has the refactoring of the manual backup flow to be the priority when on the onboarding flow. Screenshot on Linear.

Meaningful changes:
- ~Seed phrase loading inside the `Settings` component since we need that to render the SeedPhraseTable on the `ManualBackupScreen`.~
- Seed phrase is accessible without promises via `useWallets` hook.
- Added new button at the Confirmation screen to redirect the user to the cloud backup in case they want while keeping the "Done" button if they want to skip this process.


### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

