### PR TITLE
[CS-4666] Separate manual backup flag from cloud

### DIFF
--- a/cardstack/src/hooks/backup/useWalletCloudBackup.ts
+++ b/cardstack/src/hooks/backup/useWalletCloudBackup.ts
@@ -9,10 +9,9 @@ import { useLoadingOverlay } from '@cardstack/navigation';
 import { Device } from '@cardstack/utils';
 
 import { Alert } from '@rainbow-me/components/alerts';
-import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
 import walletLoadingStates from '@rainbow-me/helpers/walletLoadingStates';
 import { useWallets } from '@rainbow-me/hooks';
-import { setWalletBackedUp } from '@rainbow-me/redux/wallets';
+import { setWalletCloudBackup } from '@rainbow-me/redux/wallets';
 import { logger } from '@rainbow-me/utils';
 
 import { getFriendlyErrorMessage } from './utils';
@@ -72,11 +71,7 @@ export const useWalletCloudBackup = () => {
         if (updatedBackupFile) {
           logger.log('[BACKUP] Backup completed!');
           await dispatch(
-            setWalletBackedUp(
-              selectedWallet.id,
-              WalletBackupTypes.cloud,
-              updatedBackupFile
-            )
+            setWalletCloudBackup(selectedWallet.id, updatedBackupFile)
           );
 
           logger.log('[BACKUP] Backup saved everywhere!');

--- a/cardstack/src/hooks/backup/useWalletManualBackup.js
+++ b/cardstack/src/hooks/backup/useWalletManualBackup.js
@@ -2,9 +2,8 @@ import { captureException } from '@sentry/react-native';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 
-import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
 import { useWallets } from '@rainbow-me/hooks';
-import { setWalletBackedUp } from '@rainbow-me/redux/wallets';
+import { setWalletManualBackup } from '@rainbow-me/redux/wallets';
 import logger from 'logger';
 
 export const useWalletManualBackup = () => {
@@ -13,9 +12,7 @@ export const useWalletManualBackup = () => {
 
   const confirmBackup = useCallback(async () => {
     try {
-      await dispatch(
-        setWalletBackedUp(selectedWallet.id, WalletBackupTypes.manual)
-      );
+      await dispatch(setWalletManualBackup(selectedWallet.id));
     } catch (e) {
       logger.sentry(
         `Error setting manual backup for wallet ID: ${selectedWallet.id}`

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
@@ -39,6 +39,10 @@ const BackupRecoveryPhraseScreen = () => {
   );
 
   const cloudBackupButtonsConfig = useMemo(() => {
+    const backupToCloudAsPrimaryConfig = {
+      onPress: handleCloudBackupOnPress,
+    };
+
     const backupToCloudConfig = {
       variant: 'linkWhite' as const,
       onPress: handleCloudBackupOnPress,
@@ -49,8 +53,21 @@ const BackupRecoveryPhraseScreen = () => {
       onPress: handleDeleteOnPress,
     };
 
-    return hasCloudBackup ? deleteCloudBackup : backupToCloudConfig;
-  }, [hasCloudBackup, handleCloudBackupOnPress, handleDeleteOnPress]);
+    if (hasCloudBackup) {
+      return deleteCloudBackup;
+    }
+
+    if (hasManualBackup) {
+      return backupToCloudAsPrimaryConfig;
+    }
+
+    return backupToCloudConfig;
+  }, [
+    hasCloudBackup,
+    hasManualBackup,
+    handleCloudBackupOnPress,
+    handleDeleteOnPress,
+  ]);
 
   return (
     <PageWithStackHeader

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen.tsx
@@ -65,11 +65,9 @@ const BackupRecoveryPhraseScreen = () => {
           <Text variant="pageHeader" paddingBottom={2}>
             {strings.title}
           </Text>
-          {!hasManualBackup && (
-            <Text color="grayText" letterSpacing={0.4}>
-              {strings.description}
-            </Text>
-          )}
+          <Text color="grayText" letterSpacing={0.4}>
+            {strings.description}
+          </Text>
         </Container>
         <SeedPhraseTable seedPhrase={seedPhrase} hideOnOpen allowCopy />
         <Text

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
@@ -33,8 +33,6 @@ export const useBackupRecoveryPhraseScreen = () => {
     hasCloudBackup:
       selectedWallet.backedUp &&
       selectedWallet.backupType === WalletBackupTypes.cloud,
-    hasManualBackup:
-      selectedWallet.backedUp &&
-      selectedWallet.backupType === WalletBackupTypes.manual,
+    hasManualBackup: selectedWallet.manuallyBackedUp,
   };
 };

--- a/src/components/settings-menu/BackupSection/AlreadyBackedUpView.js
+++ b/src/components/settings-menu/BackupSection/AlreadyBackedUpView.js
@@ -55,12 +55,17 @@ export default function AlreadyBackedUpView() {
 
   const walletStatus = useMemo(() => {
     let status = null;
-    if (wallets[walletId].backedUp) {
-      if (wallets[walletId].backupType === WalletBackupTypes.manual) {
-        status = WalletBackupStatus.MANUAL_BACKUP;
-      } else {
-        status = WalletBackupStatus.CLOUD_BACKUP;
-      }
+    if (
+      wallets[walletId].manuallyBackedUp ||
+      (wallets[walletId].backedUp &&
+        wallets[walletId].backupType === WalletBackupTypes.manual)
+    ) {
+      status = WalletBackupStatus.MANUAL_BACKUP;
+    } else if (
+      wallets[walletId].backedUp &&
+      wallets[walletId].backupType === WalletBackupTypes.cloud
+    ) {
+      status = WalletBackupStatus.CLOUD_BACKUP;
     } else {
       status = WalletBackupStatus.IMPORTED;
     }

--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -130,7 +130,7 @@ export default function SettingsSection({
           <ListItemArrowGroup showArrow={false}>
             <Icon
               iconSize="medium"
-              name={selectedWallet.backedUp ? 'success' : 'warning'}
+              name={selectedWallet.manuallyBackedUp ? 'success' : 'warning'}
             />
           </ListItemArrowGroup>
         </ListItem>

--- a/src/hooks/useWalletCloudBackup.ts
+++ b/src/hooks/useWalletCloudBackup.ts
@@ -12,7 +12,6 @@ import {
 } from '@cardstack/models/rn-cloud';
 import { useLoadingOverlay } from '@cardstack/navigation';
 import { Device } from '@cardstack/utils/device';
-import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
 import walletLoadingStates from '@rainbow-me/helpers/walletLoadingStates';
 import logger from 'logger';
 

--- a/src/hooks/useWalletCloudBackup.ts
+++ b/src/hooks/useWalletCloudBackup.ts
@@ -3,7 +3,7 @@ import { values } from 'lodash';
 import { useCallback } from 'react';
 import { Alert, Linking } from 'react-native';
 import { useDispatch } from 'react-redux';
-import { setWalletBackedUp } from '../redux/wallets';
+import { setWalletCloudBackup } from '../redux/wallets';
 import useWallets from './useWallets';
 import { backupWalletToCloud } from '@cardstack/models/backup';
 import {
@@ -110,13 +110,7 @@ export default function useWalletCloudBackup() {
 
       try {
         logger.log('backup completed!');
-        await dispatch(
-          setWalletBackedUp(
-            walletId,
-            WalletBackupTypes.cloud,
-            updatedBackupFile
-          )
-        );
+        await dispatch(setWalletCloudBackup(walletId, updatedBackupFile));
         logger.log('backup saved everywhere!');
         dismissLoadingOverlay();
 

--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -91,9 +91,6 @@ export const walletsLoadState = () => async (dispatch, getState) => {
       selectedWallet.backupType === WalletBackupTypes.manual &&
       !selectedWallet.manuallyBackedUp
     ) {
-      console.log('::: setting manuallyBackedUp', {
-        manual: selectedWallet.manuallyBackedUp,
-      });
       selectedWallet.manuallyBackedUp = true;
     }
 

--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -85,6 +85,14 @@ export const walletsLoadState = () => async (dispatch, getState) => {
       );
     }
 
+    // Migrate backup generic info if set to manual type to specific manuallyBackedUp flag.
+    if (
+      selectedWallet.backedUp &&
+      selectedWallet.backupType === WalletBackupTypes.manual
+    ) {
+      await dispatch(setWalletManualBackup(selectedWallet.id));
+    }
+
     const walletNames = await getWalletNames();
 
     dispatch({
@@ -119,7 +127,18 @@ export const walletsSetSelected = wallet => async dispatch => {
   });
 };
 
-export const setWalletBackedUp = (walletId, method, backupFile = '') => async (
+export const setWalletManualBackup = walletId => async (dispatch, getState) => {
+  const { wallets } = getState().wallets;
+  const newWallets = { ...wallets };
+  newWallets[walletId] = {
+    ...newWallets[walletId],
+    manuallyBackedUp: true,
+  };
+
+  await dispatch(walletsUpdate(newWallets));
+};
+
+export const setWalletCloudBackup = (walletId, backupFile = '') => async (
   dispatch,
   getState
 ) => {
@@ -130,7 +149,7 @@ export const setWalletBackedUp = (walletId, method, backupFile = '') => async (
     backedUp: true,
     backupDate: Date.now(),
     backupFile,
-    backupType: method,
+    backupType: WalletBackupTypes.cloud,
   };
 
   await dispatch(walletsUpdate(newWallets));
@@ -138,14 +157,12 @@ export const setWalletBackedUp = (walletId, method, backupFile = '') => async (
     await dispatch(walletsSetSelected(newWallets[walletId]));
   }
 
-  if (method === WalletBackupTypes.cloud) {
-    try {
-      await backupUserDataIntoCloud({ wallets: newWallets });
-    } catch (e) {
-      logger.sentry('SAVING WALLET USERDATA FAILED');
-      captureException(e);
-      throw e;
-    }
+  try {
+    await backupUserDataIntoCloud({ wallets: newWallets });
+  } catch (e) {
+    logger.sentry('SAVING WALLET USERDATA FAILED');
+    captureException(e);
+    throw e;
   }
 };
 

--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -88,9 +88,13 @@ export const walletsLoadState = () => async (dispatch, getState) => {
     // Migrate backup generic info if set to manual type to specific manuallyBackedUp flag.
     if (
       selectedWallet.backedUp &&
-      selectedWallet.backupType === WalletBackupTypes.manual
+      selectedWallet.backupType === WalletBackupTypes.manual &&
+      !selectedWallet.manuallyBackedUp
     ) {
-      await dispatch(setWalletManualBackup(selectedWallet.id));
+      console.log('::: setting manuallyBackedUp', {
+        manual: selectedWallet.manuallyBackedUp,
+      });
+      selectedWallet.manuallyBackedUp = true;
     }
 
     const walletNames = await getWalletNames();


### PR DESCRIPTION
### Description

This PR separates manual backups into its own flag. Manual backup is a simple boolean decision, so I limited on saving just that. The PR also refactors the actions that save backup decisions, separating cloud and manual calls and refactors the relevant code.

On loading a wallet, we check if backed-up manually to assign the new flag. The flag is only saved to secure store if something else needs to be saved, for example, if the user backups to cloud.

The PR also fixes the cloud button styling on RecoveryPhrase screen if its the only button visible.

- [x] Completes #(CS-4666)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/193588102-dd57c1bb-c014-41a2-9ba1-4efbfc38677a.png">
