### PR TITLE
[CS-4669] Create hook to handle selected wallet backup state

### DIFF
--- a/cardstack/src/hooks/__tests__/useSelectedWallet.test.ts
+++ b/cardstack/src/hooks/__tests__/useSelectedWallet.test.ts
@@ -1,0 +1,145 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react-native';
+
+import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
+import { useWallets } from '@rainbow-me/hooks';
+import * as WalletModel from '@rainbow-me/model/wallet';
+
+import { useSelectedWallet } from '../useSelectedWallet';
+
+const mockedSeed = 'foo bar foo';
+
+const walletMock = {
+  wallet_1664823878526: {
+    imported: true,
+    name: 'My Wallet',
+    backedUp: false,
+    damaged: false,
+    addresses: [
+      {
+        avatar: null,
+        color: 2,
+        index: 0,
+        label: '',
+        address: '0xBD88ADe042',
+      },
+    ],
+    primary: true,
+    id: 'wallet_1664823878526',
+    color: 2,
+    type: 'mnemonic',
+  },
+};
+
+jest.mock('@rainbow-me/hooks', () => ({
+  useWallets: jest.fn(),
+}));
+
+describe('useSelectedWallet', () => {
+  jest.spyOn(WalletModel, 'loadSeedPhrase').mockResolvedValue(mockedSeed);
+
+  const mockUseWallets = (
+    overwriteProps?: Partial<ReturnType<typeof useWallets>>
+  ) =>
+    (useWallets as jest.Mock).mockImplementation(() => ({
+      walletReady: true,
+      selectedWallet: walletMock,
+      ...overwriteProps,
+    }));
+
+  beforeEach(() => {
+    mockUseWallets();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`should return the account's seed phrase when wallet is ready`, async () => {
+    // FakeTimers is a solution mentioned in the Testing Library docs:
+    // https://callstack.github.io/react-native-testing-library/docs/understanding-act/
+    // to avoid the `You called act(async () => ...) without await` error on console.
+    jest.useFakeTimers();
+
+    const { result } = renderHook(() => useSelectedWallet());
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    await waitFor(() => {
+      expect(result.current.seedPhrase).toBe(mockedSeed);
+    });
+  });
+
+  it(`should return "hasCloudBackup" as true if backedUp is true and backupType is cloud`, async () => {
+    mockUseWallets({
+      selectedWallet: {
+        ...walletMock,
+        backedUp: true,
+        backupType: WalletBackupTypes.cloud,
+      },
+    });
+
+    const { result } = renderHook(() => useSelectedWallet());
+
+    await waitFor(() => {
+      expect(result.current.hasCloudBackup).toBe(true);
+    });
+  });
+
+  it(`should return "hasCloudBackup" as false if backedUp is false and backupType is cloud`, async () => {
+    mockUseWallets({
+      selectedWallet: {
+        ...walletMock,
+        backedUp: false,
+        backupType: WalletBackupTypes.cloud,
+      },
+    });
+
+    const { result } = renderHook(() => useSelectedWallet());
+
+    await waitFor(() => {
+      expect(result.current.hasCloudBackup).toBe(false);
+    });
+  });
+
+  it(`should return "hasCloudBackup" as false if backedUp is true and backupType is manual`, async () => {
+    mockUseWallets({
+      selectedWallet: {
+        ...walletMock,
+        backedUp: true,
+        backupType: WalletBackupTypes.manual,
+      },
+    });
+
+    const { result } = renderHook(() => useSelectedWallet());
+
+    await waitFor(() => {
+      expect(result.current.hasCloudBackup).toBe(false);
+    });
+  });
+
+  it(`should return "hasManualBackup" as true if manuallyBackedUp is true`, async () => {
+    mockUseWallets({
+      selectedWallet: {
+        ...walletMock,
+        manuallyBackedUp: true,
+      },
+    });
+
+    const { result } = renderHook(() => useSelectedWallet());
+
+    await waitFor(() => {
+      expect(result.current.hasManualBackup).toBe(true);
+    });
+  });
+
+  it(`should return "hasManualBackup" as false if manuallyBackedUp isn't present`, async () => {
+    const { result } = renderHook(() => useSelectedWallet());
+
+    await waitFor(() => {
+      expect(result.current.hasManualBackup).toBe(false);
+    });
+  });
+});

--- a/cardstack/src/hooks/__tests__/useSelectedWallet.test.ts
+++ b/cardstack/src/hooks/__tests__/useSelectedWallet.test.ts
@@ -78,6 +78,8 @@ describe('useSelectedWallet', () => {
         ...walletMock,
         backedUp: true,
         backupType: WalletBackupTypes.cloud,
+        backupDate: '1657732642021',
+        backupFile: 'latestBackupFile.json',
       },
     });
 
@@ -100,7 +102,7 @@ describe('useSelectedWallet', () => {
     const { result } = renderHook(() => useSelectedWallet());
 
     await waitFor(() => {
-      expect(result.current.hasCloudBackup).toBe(false);
+      expect(result.current.hasCloudBackup).toBeFalsy();
     });
   });
 
@@ -116,7 +118,7 @@ describe('useSelectedWallet', () => {
     const { result } = renderHook(() => useSelectedWallet());
 
     await waitFor(() => {
-      expect(result.current.hasCloudBackup).toBe(false);
+      expect(result.current.hasCloudBackup).toBeFalsy();
     });
   });
 
@@ -139,7 +141,7 @@ describe('useSelectedWallet', () => {
     const { result } = renderHook(() => useSelectedWallet());
 
     await waitFor(() => {
-      expect(result.current.hasManualBackup).toBe(false);
+      expect(result.current.hasManualBackup).toBeFalsy();
     });
   });
 });

--- a/cardstack/src/hooks/index.ts
+++ b/cardstack/src/hooks/index.ts
@@ -17,3 +17,4 @@ export * from './useAppRequirements';
 export * from './useAppState';
 export * from './useProfileJobPolling';
 export * from './profile/useProfileUpdate';
+export * from './useSelectedWallet';

--- a/cardstack/src/hooks/useSelectedWallet.ts
+++ b/cardstack/src/hooks/useSelectedWallet.ts
@@ -34,9 +34,10 @@ export const useSelectedWallet = () => {
     [selectedWallet]
   );
 
-  const hasManualBackup = useMemo(() => selectedWallet.manuallyBackedUp, [
-    selectedWallet,
-  ]);
+  const hasManualBackup = useMemo(
+    () => selectedWallet.manuallyBackedUp ?? false,
+    [selectedWallet]
+  );
 
   return {
     seedPhrase,

--- a/cardstack/src/hooks/useSelectedWallet.ts
+++ b/cardstack/src/hooks/useSelectedWallet.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
+import { isBackedUpWallet } from '@cardstack/models/backup';
+
 import { useWallets } from '@rainbow-me/hooks';
 import { loadSeedPhrase } from '@rainbow-me/model/wallet';
 import { logger } from '@rainbow-me/utils';
@@ -22,22 +23,18 @@ export const useSelectedWallet = () => {
   }, [selectedWallet]);
 
   useEffect(() => {
-    if (walletReady) {
+    if (walletReady && !seedPhrase) {
       getSeedPhrase();
     }
-  }, [walletReady, getSeedPhrase]);
+  }, [walletReady, getSeedPhrase, seedPhrase]);
 
-  const hasCloudBackup = useMemo(
-    () =>
-      selectedWallet.backedUp &&
-      selectedWallet.backupType === WalletBackupTypes.cloud,
-    [selectedWallet]
-  );
+  const hasCloudBackup = useMemo(() => isBackedUpWallet(selectedWallet), [
+    selectedWallet,
+  ]);
 
-  const hasManualBackup = useMemo(
-    () => selectedWallet?.manuallyBackedUp ?? false,
-    [selectedWallet]
-  );
+  const hasManualBackup = useMemo(() => selectedWallet?.manuallyBackedUp, [
+    selectedWallet,
+  ]);
 
   return {
     seedPhrase,

--- a/cardstack/src/hooks/useSelectedWallet.ts
+++ b/cardstack/src/hooks/useSelectedWallet.ts
@@ -35,7 +35,7 @@ export const useSelectedWallet = () => {
   );
 
   const hasManualBackup = useMemo(
-    () => selectedWallet.manuallyBackedUp ?? false,
+    () => selectedWallet?.manuallyBackedUp ?? false,
     [selectedWallet]
   );
 

--- a/cardstack/src/hooks/useSelectedWallet.ts
+++ b/cardstack/src/hooks/useSelectedWallet.ts
@@ -34,12 +34,9 @@ export const useSelectedWallet = () => {
     [selectedWallet]
   );
 
-  const hasManualBackup = useMemo(
-    () =>
-      selectedWallet.backedUp &&
-      selectedWallet.backupType === WalletBackupTypes.manual,
-    [selectedWallet]
-  );
+  const hasManualBackup = useMemo(() => selectedWallet.manuallyBackedUp, [
+    selectedWallet,
+  ]);
 
   return {
     seedPhrase,

--- a/cardstack/src/hooks/useSelectedWallet.ts
+++ b/cardstack/src/hooks/useSelectedWallet.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
+import { useWallets } from '@rainbow-me/hooks';
+import { loadSeedPhrase } from '@rainbow-me/model/wallet';
+import { logger } from '@rainbow-me/utils';
+
+export const useSelectedWallet = () => {
+  const { walletReady, selectedWallet } = useWallets();
+  const [seedPhrase, setSeedPhrase] = useState<string>('');
+
+  const getSeedPhrase = useCallback(async () => {
+    try {
+      const seedphrase = await loadSeedPhrase(selectedWallet.id);
+
+      if (seedphrase) {
+        setSeedPhrase(seedphrase);
+      }
+    } catch (error) {
+      logger.log('Error getting seed phrase', error);
+    }
+  }, [selectedWallet]);
+
+  useEffect(() => {
+    if (walletReady) {
+      getSeedPhrase();
+    }
+  }, [walletReady, getSeedPhrase]);
+
+  const hasCloudBackup = useMemo(
+    () =>
+      selectedWallet.backedUp &&
+      selectedWallet.backupType === WalletBackupTypes.cloud,
+    [selectedWallet]
+  );
+
+  const hasManualBackup = useMemo(
+    () =>
+      selectedWallet.backedUp &&
+      selectedWallet.backupType === WalletBackupTypes.manual,
+    [selectedWallet]
+  );
+
+  return {
+    seedPhrase,
+    hasCloudBackup,
+    hasManualBackup,
+  };
+};

--- a/cardstack/src/models/backup.ts
+++ b/cardstack/src/models/backup.ts
@@ -15,7 +15,7 @@ import { encryptAndSaveDataToCloud, getDataFromCloud } from './rn-cloud';
 export const cloudBackupPasswordMinLength = 8;
 export const iCloudPasswordRules = `minlength: ${cloudBackupPasswordMinLength}; required: digit;`;
 
-const isBackedUpWallet = (wallet: RainbowWallet) =>
+const hasCloudBackup = (wallet: RainbowWallet) =>
   wallet.backedUp &&
   wallet.backupDate &&
   wallet.backupFile &&
@@ -46,7 +46,7 @@ export function findLatestBackUp(wallets: AllRainbowWallets) {
 
   forEach(wallets, wallet => {
     // Check if there's a wallet backed up
-    if (isBackedUpWallet(wallet)) {
+    if (hasCloudBackup(wallet)) {
       // If there is one, let's grab the latest backup
       // @ts-expect-error isBackupWallet checks undefined values
       if (!latestBackup || wallet?.backupDate > latestBackup) {

--- a/cardstack/src/models/backup.ts
+++ b/cardstack/src/models/backup.ts
@@ -15,7 +15,7 @@ import { encryptAndSaveDataToCloud, getDataFromCloud } from './rn-cloud';
 export const cloudBackupPasswordMinLength = 8;
 export const iCloudPasswordRules = `minlength: ${cloudBackupPasswordMinLength}; required: digit;`;
 
-const hasCloudBackup = (wallet: RainbowWallet) =>
+export const isBackedUpWallet = (wallet: RainbowWallet) =>
   wallet.backedUp &&
   wallet.backupDate &&
   wallet.backupFile &&
@@ -46,7 +46,7 @@ export function findLatestBackUp(wallets: AllRainbowWallets) {
 
   forEach(wallets, wallet => {
     // Check if there's a wallet backed up
-    if (hasCloudBackup(wallet)) {
+    if (isBackedUpWallet(wallet)) {
       // If there is one, let's grab the latest backup
       // @ts-expect-error isBackupWallet checks undefined values
       if (!latestBackup || wallet?.backupDate > latestBackup) {

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
@@ -1,14 +1,12 @@
 import { useNavigation } from '@react-navigation/native';
 import { useCallback } from 'react';
 
+import { useSelectedWallet } from '@cardstack/hooks';
 import { Routes } from '@cardstack/navigation';
-
-import WalletBackupTypes from '@rainbow-me/helpers/walletBackupTypes';
-import { useWallets } from '@rainbow-me/hooks';
 
 export const useBackupRecoveryPhraseScreen = () => {
   const { navigate } = useNavigation();
-  const { selectedWallet, seedPhrase } = useWallets();
+  const { seedPhrase, hasManualBackup, hasCloudBackup } = useSelectedWallet();
 
   const handleCloudBackupOnPress = useCallback(
     () => navigate(Routes.BACKUP_CLOUD_PASSWORD, { seedPhrase }),
@@ -30,9 +28,7 @@ export const useBackupRecoveryPhraseScreen = () => {
     handleManualBackupOnPress,
     handleDeleteOnPress,
     seedPhrase,
-    hasCloudBackup:
-      selectedWallet.backedUp &&
-      selectedWallet.backupType === WalletBackupTypes.cloud,
-    hasManualBackup: selectedWallet.manuallyBackedUp,
+    hasManualBackup,
+    hasCloudBackup,
   };
 };

--- a/src/components/settings-menu/SettingsSection.js
+++ b/src/components/settings-menu/SettingsSection.js
@@ -13,13 +13,10 @@ import {
 } from '../list';
 import { CenteredContainer, Icon, ScrollView } from '@cardstack/components';
 import { SettingsExternalURLs } from '@cardstack/constants';
+import { useSelectedWallet } from '@cardstack/hooks';
 import { Routes } from '@cardstack/navigation';
 import networkInfo from '@rainbow-me/helpers/networkInfo';
-import {
-  useAccountSettings,
-  useSendFeedback,
-  useWallets,
-} from '@rainbow-me/hooks';
+import { useAccountSettings, useSendFeedback } from '@rainbow-me/hooks';
 
 export default function SettingsSection({
   onPressDev,
@@ -31,7 +28,7 @@ export default function SettingsSection({
   onPressDS,
   onPressSecurity,
 }) {
-  const { selectedWallet, seedPhrase } = useWallets();
+  const { seedPhrase, hasManualBackup } = useSelectedWallet();
   const { nativeCurrency, network, accountAddress } = useAccountSettings();
 
   const onSendFeedback = useSendFeedback();
@@ -130,7 +127,7 @@ export default function SettingsSection({
           <ListItemArrowGroup showArrow={false}>
             <Icon
               iconSize="medium"
-              name={selectedWallet.manuallyBackedUp ? 'success' : 'warning'}
+              name={hasManualBackup ? 'success' : 'warning'}
             />
           </ListItemArrowGroup>
         </ListItem>

--- a/src/hooks/useWallets.ts
+++ b/src/hooks/useWallets.ts
@@ -1,10 +1,9 @@
 import { isEmpty } from 'lodash';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import { useAccountSettings } from '.';
 import { findLatestBackUp } from '@cardstack/models/backup';
-import { getSeedPhrase } from '@cardstack/models/secure-storage';
 import WalletTypes from '@rainbow-me/helpers/walletTypes';
 import { Account } from '@rainbow-me/model/wallet';
 import { useRainbowSelector } from '@rainbow-me/redux/hooks';
@@ -26,7 +25,6 @@ const walletSelector = createSelector(
 );
 
 export default function useWallets() {
-  const [seedPhrase, setSeedPhrase] = useState('');
   const { latestBackup, selectedWallet, walletNames, wallets } = useSelector(
     walletSelector
   );
@@ -59,20 +57,6 @@ export default function useWallets() {
     [accountAddress, selectedWallet.addresses]
   );
 
-  const loadSeedPhrase = useCallback(async () => {
-    try {
-      const seedphrase = await getSeedPhrase(selectedWallet.id);
-
-      setSeedPhrase(seedphrase);
-    } catch (error) {
-      logger.log('Error getting seed phrase', error);
-    }
-  }, [selectedWallet]);
-
-  useEffect(() => {
-    loadSeedPhrase();
-  }, [loadSeedPhrase]);
-
   return {
     isDamaged,
     isReadOnlyWallet: selectedWallet.type === WalletTypes.readOnly,
@@ -83,6 +67,5 @@ export default function useWallets() {
     selectedWallet,
     accountAddress,
     walletReady,
-    seedPhrase,
   };
 }

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -130,6 +130,7 @@ export interface RainbowWallet {
   backupDate?: string;
   backupType?: string;
   damaged?: boolean;
+  manuallyBackedUp?: boolean;
 }
 
 export interface AllRainbowWallets {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9063,15 +9063,10 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
-caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001135, caniuse-lite@^1.0.30001219:
-  version "1.0.30001327"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001327.tgz#c1546d7d7bb66506f0ccdad6a7d07fc6d668c858"
-  integrity sha512-1/Cg4jlD9qjZzhbzkzEaAC2JHsP0WrOc8Rd/3a3LuajGzGWR/hD7TVyvq99VqmTy99eVh8Zkmdq213OgvgXx7w==
-
-caniuse-lite@^1.0.30001332:
-  version "1.0.30001342"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001342.tgz#87152b1e3b950d1fbf0093e23f00b6c8e8f1da96"
-  integrity sha512-bn6sOCu7L7jcbBbyNhLg0qzXdJ/PMbybZTH/BA6Roet9wxYRm6Tr9D0s0uhLkOZ6MSG+QU6txUgdpr3MXIVqjA==
+caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001135, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001332:
+  version "1.0.30001414"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz"
+  integrity sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
### Description
This PR creates the `useSelectedWallet` hook. it exposes the seed phrase and the wallet status regarding its backup state (cloud, manual or none).

Other adjustments made on this PR worth explaining:
1. `browserlist` was triggering annoying warnings whenever you ran `yarn start`. It doesn't affect our project, so I updated it to get rid of the warnings.
2. Added `manuallyBackedUp` to the `RainbowWallet` interface.
3. Renamed `isBackedUpWallet` function inside `models/backup.ts` as `hasCloudBackup` to better reflect what is does.
4. `jest.FakeTimers` was added to one of the test assertions to get rid of the `You called act(async () => ...) without await` warnings. 

- [x] Completes #CS-4649

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots
You shouldn't see any visual changes ;)
