### PR TITLE
[CS-4667] Handle cloud backup deletion

### DIFF
--- a/cardstack/src/hooks/backup/__tests__/useWalletCloudBackup.test.ts
+++ b/cardstack/src/hooks/backup/__tests__/useWalletCloudBackup.test.ts
@@ -1,16 +1,173 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { Alert } from 'react-native';
+import * as reactRedux from 'react-redux';
+
+import { useWalletCloudBackup } from '@cardstack/hooks';
+import * as backupModel from '@cardstack/models/backup';
+import * as rnCloud from '@cardstack/models/rn-cloud';
+import { Device } from '@cardstack/utils';
+
+import walletLoadingStates from '@rainbow-me/helpers/walletLoadingStates';
+import * as walletsActions from '@rainbow-me/redux/wallets';
+import logger from 'logger';
+
+const mockedPassword = 'passw0rd';
+const mockedShowOverlay = jest.fn();
+const mockedDismissOverlay = jest.fn();
+const mockNavDispatch = jest.fn();
+
+const walletMock = {
+  wallet_1664823878526: {
+    imported: true,
+    name: 'My Wallet',
+    backedUp: false,
+    damaged: false,
+    addresses: [
+      {
+        avatar: null,
+        color: 2,
+        index: 0,
+        label: '',
+        address: '0xBD88ADe042',
+      },
+    ],
+    primary: true,
+    id: 'wallet_1664823878526',
+    color: 2,
+    type: 'mnemonic',
+  },
+};
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    dispatch: mockNavDispatch,
+  }),
+  StackActions: { popToTop: jest.fn() },
+}));
+
+jest.mock('@cardstack/navigation', () => ({
+  useLoadingOverlay: () => ({
+    showLoadingOverlay: mockedShowOverlay,
+    dismissLoadingOverlay: mockedDismissOverlay,
+  }),
+}));
+
+jest.mock('@rainbow-me/hooks', () => ({
+  useWallets: () => ({
+    wallets: walletMock,
+    selectedWallet: walletMock.wallet_1664823878526,
+  }),
+}));
+
 describe('useWalletCloudBackup', () => {
+  Device.isIOS = true;
+  Device.cloudPlatform = 'iCloud';
+  const spyAlert = jest.spyOn(Alert, 'alert');
+  const spyIsCloudAvailable = jest.spyOn(rnCloud, 'isIOSCloudBackupAvailable');
+
+  const useDispatchSpy = jest.spyOn(reactRedux, 'useDispatch');
+  const mockDispatchFn = jest.fn();
+  useDispatchSpy.mockReturnValue(mockDispatchFn);
+
+  beforeAll(() => {
+    logger.sentry = jest.fn();
+    logger.log = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('Backup to Cloud', () => {
-    it.todo(`should show an Alert if iCloud isn't configure on iOS`);
-    it.todo(`should call backupWalletToCloud with the correct params`);
-    it.todo(
-      `should update Redux with the wallet ID and filename if backupWalletToCloud was successful`
+    const backupWalletToCloudSpy = jest.spyOn(
+      backupModel,
+      'backupWalletToCloud'
     );
+
+    const setWalletCloudBackupSpy = jest.spyOn(
+      walletsActions,
+      'setWalletCloudBackup'
+    );
+
+    it(`should show an Alert if iCloud isn't configured on iOS`, async () => {
+      spyIsCloudAvailable.mockReturnValue(Promise.resolve(false));
+
+      const { result } = renderHook(useWalletCloudBackup);
+
+      await act(async () => {
+        await result.current.backupToCloud({ password: mockedPassword });
+      });
+
+      expect(spyAlert).toBeCalledWith(
+        'iCloud Not Enabled',
+        `Looks like iCloud drive is not enabled on your device. Do you want to see how to enable it?`,
+        [
+          {
+            text: 'Yes, Show me',
+            onPress: expect.any(Function),
+          },
+          {
+            text: 'No thanks',
+            style: 'cancel',
+          },
+        ],
+        undefined
+      );
+    });
+
+    it(`should call backupWalletToCloud with the correct params`, async () => {
+      spyIsCloudAvailable.mockReturnValue(Promise.resolve(true));
+
+      backupWalletToCloudSpy.mockResolvedValue('filename');
+
+      const { result } = renderHook(useWalletCloudBackup);
+
+      await act(async () => {
+        await result.current.backupToCloud({ password: mockedPassword });
+      });
+
+      expect(mockedShowOverlay).toBeCalledWith({
+        title: walletLoadingStates.BACKING_UP_WALLET,
+      });
+
+      expect(mockDispatchFn).toBeCalled();
+      expect(setWalletCloudBackupSpy).toBeCalledWith(
+        walletMock.wallet_1664823878526.id,
+        'filename'
+      );
+
+      expect(mockedDismissOverlay).toBeCalled();
+    });
 
     it.todo(`should show an Alert if backupWalletToCloud wasn't successful`);
   });
 
   describe('Delete Backup from Cloud', () => {
-    it.todo(`should show an Alert with two options: confirm and cancel`);
+    it(`should show an Alert with two options: confirm and cancel`, () => {
+      const { result } = renderHook(useWalletCloudBackup);
+
+      act(() => {
+        result.current.deleteCloudBackups();
+      });
+
+      expect(spyAlert).toBeCalledWith(
+        `Are you sure you want to delete your ${Device.cloudPlatform} wallet backups?`,
+        undefined,
+        [
+          {
+            style: 'destructive',
+            text: 'Confirm and Delete Backups',
+            onPress: expect.any(Function),
+          },
+          {
+            style: 'cancel',
+            text: 'Cancel',
+          },
+        ],
+        undefined
+      );
+    });
+
     it.todo(`should delete all files in the remote directory on confirm press`);
     it.todo(
       `should update Redux resetting the cloud backup flags to false/undefined`

--- a/cardstack/src/hooks/backup/__tests__/useWalletCloudBackup.test.ts
+++ b/cardstack/src/hooks/backup/__tests__/useWalletCloudBackup.test.ts
@@ -1,0 +1,22 @@
+describe('useWalletCloudBackup', () => {
+  describe('Backup to Cloud', () => {
+    it.todo(`should show an Alert if iCloud isn't configure on iOS`);
+    it.todo(`should call backupWalletToCloud with the correct params`);
+    it.todo(
+      `should update Redux with the wallet ID and filename if backupWalletToCloud was successful`
+    );
+
+    it.todo(`should show an Alert if backupWalletToCloud wasn't successful`);
+  });
+
+  describe('Delete Backup from Cloud', () => {
+    it.todo(`should show an Alert with two options: confirm and cancel`);
+    it.todo(`should delete all files in the remote directory on confirm press`);
+    it.todo(
+      `should update Redux resetting the cloud backup flags to false/undefined`
+    );
+
+    it.todo(`should show an Alert confirming that the deletion was successful`);
+    it.todo(`should show an Alert if the deletion failed`);
+  });
+});

--- a/cardstack/src/hooks/backup/useWalletCloudBackup.ts
+++ b/cardstack/src/hooks/backup/useWalletCloudBackup.ts
@@ -129,6 +129,9 @@ export const useWalletCloudBackup = () => {
         message:
           'Try again in a few minutes. Make sure you have a stable internet connection.',
       });
+
+      logger.sentry(`[BACKUP] ${error}`);
+      captureException(error);
     }
   }, [dispatch, showLoadingOverlay, dismissLoadingOverlay]);
 

--- a/cardstack/src/hooks/backup/useWalletCloudBackup.ts
+++ b/cardstack/src/hooks/backup/useWalletCloudBackup.ts
@@ -7,7 +7,7 @@ import { useDispatch } from 'react-redux';
 import { backupWalletToCloud } from '@cardstack/models/backup';
 import {
   CLOUD_BACKUP_ERRORS,
-  deleteAllBackups,
+  deleteAllCloudBackups,
   isIOSCloudBackupAvailable,
 } from '@cardstack/models/rn-cloud';
 import { useLoadingOverlay } from '@cardstack/navigation';
@@ -113,7 +113,7 @@ export const useWalletCloudBackup = () => {
     showLoadingOverlay({ title: 'Deleting backup...' });
 
     try {
-      await deleteAllBackups();
+      await deleteAllCloudBackups();
 
       const updatedWallets = { ...wallets };
       Object.keys(updatedWallets).forEach(key => {

--- a/cardstack/src/hooks/backup/useWalletCloudBackup.ts
+++ b/cardstack/src/hooks/backup/useWalletCloudBackup.ts
@@ -98,7 +98,26 @@ export const useWalletCloudBackup = () => {
     [showLoadingOverlay, selectedWallet, dismissLoadingOverlay, dispatch]
   );
 
+  const deleteCloudBackups = useCallback(() => {
+    Alert({
+      title: `Are you sure you want to delete your ${Device.cloudPlatform} wallet backups?`,
+      buttons: [
+        {
+          onPress: () => console.log('delete'),
+          style: 'destructive',
+          text: 'Confirm and Delete Backups',
+        },
+        {
+          onPress: () => console.log('cancel'),
+          style: 'cancel',
+          text: 'Cancel',
+        },
+      ],
+    });
+  }, []);
+
   return {
     backupToCloud,
+    deleteCloudBackups,
   };
 };

--- a/cardstack/src/hooks/backup/useWalletCloudBackup.ts
+++ b/cardstack/src/hooks/backup/useWalletCloudBackup.ts
@@ -1,3 +1,4 @@
+import { StackActions, useNavigation } from '@react-navigation/native';
 import { captureException } from '@sentry/react-native';
 import { useCallback } from 'react';
 import { Linking } from 'react-native';
@@ -43,6 +44,7 @@ export const useWalletCloudBackup = () => {
   const { showLoadingOverlay, dismissLoadingOverlay } = useLoadingOverlay();
   const { selectedWallet } = useWallets();
   const dispatch = useDispatch();
+  const { dispatch: navDispatch } = useNavigation();
 
   const backupToCloud = useCallback(
     async ({ password }: BackupToCloud) => {
@@ -76,9 +78,9 @@ export const useWalletCloudBackup = () => {
           );
 
           logger.log('[BACKUP] Backup saved everywhere!');
+          dismissLoadingOverlay();
+          navDispatch(StackActions.popToTop());
         }
-
-        dismissLoadingOverlay();
       } catch (error) {
         const title = `Error while trying to backup wallet to ${Device.cloudPlatform}`;
 

--- a/cardstack/src/hooks/backup/useWalletCloudBackup.ts
+++ b/cardstack/src/hooks/backup/useWalletCloudBackup.ts
@@ -27,8 +27,8 @@ interface BackupToCloud {
 
 const iCloudAlertConfig = {
   title: 'iCloud Not Enabled',
-  message: `Looks like iCloud drive is not enabled on your device.
-Do you want to see how to enable it?`,
+  message:
+    'Looks like iCloud drive is not enabled on your device. Do you want to see how to enable it?',
   buttons: [
     {
       onPress: () => {

--- a/cardstack/src/hooks/backup/useWalletCloudBackup.ts
+++ b/cardstack/src/hooks/backup/useWalletCloudBackup.ts
@@ -16,9 +16,11 @@ import { Device } from '@cardstack/utils';
 import { Alert } from '@rainbow-me/components/alerts';
 import walletLoadingStates from '@rainbow-me/helpers/walletLoadingStates';
 import { useWallets } from '@rainbow-me/hooks';
-import { setWalletCloudBackup, walletsUpdate } from '@rainbow-me/redux/wallets';
-import { logger } from '@rainbow-me/utils';
-
+import {
+  deleteWalletCloudBackup,
+  setWalletCloudBackup,
+} from '@rainbow-me/redux/wallets';
+import logger from 'logger';
 interface BackupToCloud {
   password: string;
 }
@@ -43,7 +45,7 @@ Do you want to see how to enable it?`,
 
 export const useWalletCloudBackup = () => {
   const { showLoadingOverlay, dismissLoadingOverlay } = useLoadingOverlay();
-  const { selectedWallet, wallets } = useWallets();
+  const { selectedWallet } = useWallets();
   const dispatch = useDispatch();
   const { dispatch: navDispatch } = useNavigation();
 
@@ -79,9 +81,10 @@ export const useWalletCloudBackup = () => {
           );
 
           logger.log('[BACKUP] Backup saved everywhere!');
-          dismissLoadingOverlay();
           navDispatch(StackActions.popToTop());
         }
+
+        dismissLoadingOverlay();
       } catch (error) {
         dismissLoadingOverlay();
 
@@ -115,15 +118,7 @@ export const useWalletCloudBackup = () => {
     try {
       await deleteAllCloudBackups();
 
-      const updatedWallets = { ...wallets };
-      Object.keys(updatedWallets).forEach(key => {
-        updatedWallets[key].backedUp = false;
-        updatedWallets[key].backupDate = undefined;
-        updatedWallets[key].backupFile = undefined;
-        updatedWallets[key].backupType = undefined;
-      });
-
-      await dispatch(walletsUpdate(updatedWallets));
+      await dispatch(deleteWalletCloudBackup());
 
       dismissLoadingOverlay();
 
@@ -137,7 +132,7 @@ export const useWalletCloudBackup = () => {
           'Try again in a few minutes. Make sure you have a stable internet connection.',
       });
     }
-  }, [dispatch, wallets, showLoadingOverlay, dismissLoadingOverlay]);
+  }, [dispatch, showLoadingOverlay, dismissLoadingOverlay]);
 
   const deleteCloudBackups = useCallback(() => {
     Alert({

--- a/cardstack/src/hooks/backup/useWalletCloudBackup.ts
+++ b/cardstack/src/hooks/backup/useWalletCloudBackup.ts
@@ -86,8 +86,6 @@ export const useWalletCloudBackup = () => {
 
         dismissLoadingOverlay();
       } catch (error) {
-        dismissLoadingOverlay();
-
         const title = `Error while trying to backup wallet to ${Device.cloudPlatform}`;
 
         const message =

--- a/cardstack/src/hooks/index.ts
+++ b/cardstack/src/hooks/index.ts
@@ -18,3 +18,5 @@ export * from './useAppState';
 export * from './useProfileJobPolling';
 export * from './profile/useProfileUpdate';
 export * from './useSelectedWallet';
+export * from './backup/useWalletCloudBackup';
+export * from './backup/useWalletManualBackup';

--- a/cardstack/src/hooks/useSelectedWallet.ts
+++ b/cardstack/src/hooks/useSelectedWallet.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { isBackedUpWallet } from '@cardstack/models/backup';
 
@@ -28,17 +28,9 @@ export const useSelectedWallet = () => {
     }
   }, [walletReady, getSeedPhrase, seedPhrase]);
 
-  const hasCloudBackup = useMemo(() => isBackedUpWallet(selectedWallet), [
-    selectedWallet,
-  ]);
-
-  const hasManualBackup = useMemo(() => selectedWallet?.manuallyBackedUp, [
-    selectedWallet,
-  ]);
-
   return {
     seedPhrase,
-    hasCloudBackup,
-    hasManualBackup,
+    hasCloudBackup: isBackedUpWallet(selectedWallet),
+    hasManualBackup: selectedWallet?.manuallyBackedUp,
   };
 };

--- a/cardstack/src/models/rn-cloud.ts
+++ b/cardstack/src/models/rn-cloud.ts
@@ -28,7 +28,7 @@ export const CLOUD_BACKUP_ERRORS = {
 /**
  * Goes through the cloud backup directory and deletes all files.
  */
-export const deleteAllBackups = async () => {
+export const deleteAllCloudBackups = async () => {
   try {
     if (Device.isAndroid) {
       await RNCloudFs.loginIfNeeded();

--- a/cardstack/src/screens/Backup/BackupCloudPasswordScreen/useBackupCloudPasswordScreen.ts
+++ b/cardstack/src/screens/Backup/BackupCloudPasswordScreen/useBackupCloudPasswordScreen.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { TextInput } from 'react-native';
 
 import { usePasswordInput } from '@cardstack/components';
-import { useWalletCloudBackup } from '@cardstack/hooks/backup/useWalletCloudBackup';
+import { useWalletCloudBackup } from '@cardstack/hooks';
 import { cloudBackupPasswordMinLength } from '@cardstack/models/backup';
 import {
   hasAtLeastOneDigit,

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
@@ -1,12 +1,13 @@
 import { useNavigation } from '@react-navigation/native';
 import { useCallback } from 'react';
 
-import { useSelectedWallet } from '@cardstack/hooks';
+import { useSelectedWallet, useWalletCloudBackup } from '@cardstack/hooks';
 import { Routes } from '@cardstack/navigation';
 
 export const useBackupRecoveryPhraseScreen = () => {
   const { navigate } = useNavigation();
   const { seedPhrase, hasManualBackup, hasCloudBackup } = useSelectedWallet();
+  const { deleteCloudBackups } = useWalletCloudBackup();
 
   const handleCloudBackupOnPress = useCallback(
     () => navigate(Routes.BACKUP_CLOUD_PASSWORD, { seedPhrase }),
@@ -20,8 +21,8 @@ export const useBackupRecoveryPhraseScreen = () => {
   }, [navigate, seedPhrase]);
 
   const handleDeleteOnPress = useCallback(() => {
-    // TBD.
-  }, []);
+    deleteCloudBackups();
+  }, [deleteCloudBackups]);
 
   return {
     handleCloudBackupOnPress,

--- a/cardstack/src/test-utils/jest-setup.js
+++ b/cardstack/src/test-utils/jest-setup.js
@@ -111,7 +111,6 @@ jest.mock('@react-native-firebase/messaging', () => ({
 
 jest.mock('react-native-cloud-fs', () => ({
   RNCloudFs: jest.fn(),
-  RNFS: jest.fn(),
 }));
 
 jest.mock('react-native-fs', () => ({

--- a/src/components/settings-menu/DeveloperSettings.js
+++ b/src/components/settings-menu/DeveloperSettings.js
@@ -3,7 +3,7 @@ import { useNavigation } from '@react-navigation/native';
 import React, { useCallback } from 'react';
 import { ScrollView } from 'react-native';
 import { ListFooter, ListItem } from '../list';
-import { deleteCloudBackups } from '@cardstack/hooks';
+import { deleteAllBackups } from '@cardstack/models/rn-cloud';
 import { Routes } from '@cardstack/navigation';
 import GanacheUtils, { restartApp } from '@cardstack/utils';
 import { resetWallet } from '@rainbow-me/model/wallet';
@@ -31,7 +31,7 @@ const DeveloperSettings = () => {
         testID="reset-keychain-section"
       />
       <ListItem label="🔄 Restart app" onPress={restartApp} />
-      <ListItem label="🗑️ Remove all backups" onPress={deleteCloudBackups} />
+      <ListItem label="🗑️ Remove all backups" onPress={deleteAllBackups} />
       <ListItem
         label="🤷 Restore default experimental config"
         onPress={() => AsyncStorage.removeItem('experimentalConfig')}

--- a/src/components/settings-menu/DeveloperSettings.js
+++ b/src/components/settings-menu/DeveloperSettings.js
@@ -1,45 +1,22 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback } from 'react';
-import { Alert, ScrollView } from 'react-native';
-import GanacheUtils from '../../../cardstack/src/utils/ganache-utils';
+import { ScrollView } from 'react-native';
 import { ListFooter, ListItem } from '../list';
-import { deleteAllBackups } from '@cardstack/models/rn-cloud';
+import { deleteCloudBackups } from '@cardstack/hooks';
 import { Routes } from '@cardstack/navigation';
-import { restartApp } from '@cardstack/utils';
-import { useWallets } from '@rainbow-me/hooks';
+import GanacheUtils, { restartApp } from '@cardstack/utils';
 import { resetWallet } from '@rainbow-me/model/wallet';
 import { clearImageMetadataCache } from '@rainbow-me/redux/imageMetadata';
-import store from '@rainbow-me/redux/store';
-import { walletsUpdate } from '@rainbow-me/redux/wallets';
 
 const DeveloperSettings = () => {
   const { navigate } = useNavigation();
-  const { wallets } = useWallets();
 
   const connectToGanache = useCallback(async () => {
     GanacheUtils.connect(() => {
       navigate(Routes.HOME_SCREEN);
     });
   }, [navigate]);
-
-  const removeBackups = async () => {
-    const newWallets = { ...wallets };
-    Object.keys(newWallets).forEach(key => {
-      delete newWallets[key].backedUp;
-      delete newWallets[key].backupDate;
-      delete newWallets[key].backupFile;
-      delete newWallets[key].backupType;
-    });
-
-    await store.dispatch(walletsUpdate(newWallets));
-
-    // Delete all backups (debugging)
-    await deleteAllBackups();
-
-    Alert.alert('Backups deleted succesfully');
-    restartApp();
-  };
 
   return (
     <ScrollView testID="developer-settings-modal">
@@ -54,7 +31,7 @@ const DeveloperSettings = () => {
         testID="reset-keychain-section"
       />
       <ListItem label="🔄 Restart app" onPress={restartApp} />
-      <ListItem label="🗑️ Remove all backups" onPress={removeBackups} />
+      <ListItem label="🗑️ Remove all backups" onPress={deleteCloudBackups} />
       <ListItem
         label="🤷 Restore default experimental config"
         onPress={() => AsyncStorage.removeItem('experimentalConfig')}

--- a/src/handlers/imgix.ts
+++ b/src/handlers/imgix.ts
@@ -21,9 +21,6 @@ const shouldCreateImgixClient = (): ImgixClient | null => {
       secureURLToken,
     });
   }
-  console.log(
-    '[Imgix] Image signing disabled. Please ensure you have specified both IMGIX_DOMAIN and IMGIX_TOKEN inside your .env.'
-  );
   return null;
 };
 

--- a/src/hooks/useManageCloudBackups.ts
+++ b/src/hooks/useManageCloudBackups.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { Alert } from 'react-native';
 import { useDispatch } from 'react-redux';
 import useWallets from './useWallets';
-import { deleteAllBackups } from '@cardstack/models/rn-cloud';
+import { deleteAllCloudBackups } from '@cardstack/models/rn-cloud';
 import { Device } from '@cardstack/utils/device';
 import { AppDispatch } from '@rainbow-me/redux/store';
 import { walletsUpdate } from '@rainbow-me/redux/wallets';
@@ -55,7 +55,7 @@ function deleteWalletWithConfirmation(wallets: any, dispatch: AppDispatch) {
         await dispatch(walletsUpdate(newWallets));
 
         // Delete all backups (debugging)
-        await deleteAllBackups();
+        await deleteAllCloudBackups();
 
         Alert.alert('Backups Deleted Succesfully');
       }

--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -145,6 +145,20 @@ export const setWalletManualBackup = walletId => async (dispatch, getState) => {
   }
 };
 
+export const deleteWalletCloudBackup = () => async (dispatch, getState) => {
+  const { wallets } = getState().wallets;
+
+  const updatedWallets = { ...wallets };
+  Object.keys(updatedWallets).forEach(key => {
+    updatedWallets[key].backedUp = false;
+    updatedWallets[key].backupDate = undefined;
+    updatedWallets[key].backupFile = undefined;
+    updatedWallets[key].backupType = undefined;
+  });
+
+  await dispatch(walletsUpdate(updatedWallets));
+};
+
 export const setWalletCloudBackup = (walletId, backupFile = '') => async (
   dispatch,
   getState

--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -112,8 +112,11 @@ export const walletsLoadState = () => async (dispatch, getState) => {
   }
 };
 
-export const walletsUpdate = wallets => async dispatch => {
+export const walletsUpdate = wallets => async (dispatch, getState) => {
+  const { selected } = getState().wallets;
+
   await saveAllWallets(wallets);
+  await dispatch(walletsSetSelected(wallets[selected.id]));
   dispatch({
     payload: wallets,
     type: WALLETS_UPDATE,
@@ -146,7 +149,7 @@ export const setWalletCloudBackup = (walletId, backupFile = '') => async (
   dispatch,
   getState
 ) => {
-  const { wallets, selected } = getState().wallets;
+  const { wallets } = getState().wallets;
   const newWallets = { ...wallets };
   newWallets[walletId] = {
     ...newWallets[walletId],
@@ -157,9 +160,6 @@ export const setWalletCloudBackup = (walletId, backupFile = '') => async (
   };
 
   await dispatch(walletsUpdate(newWallets));
-  if (selected.id === walletId) {
-    await dispatch(walletsSetSelected(newWallets[walletId]));
-  }
 
   try {
     await backupUserDataIntoCloud({ wallets: newWallets });
@@ -284,13 +284,9 @@ export const checkKeychainIntegrity = () => async (dispatch, getState) => {
         wallet.damaged = true;
         await dispatch(walletsUpdate(wallets));
 
-        // Update selected wallet if needed
-        if (wallet.id === selected.id) {
-          logger.sentry(
-            '[KeychainIntegrityCheck]: declaring selected wallet unhealthy...'
-          );
-          await dispatch(walletsSetSelected(wallets[wallet.id]));
-        }
+        logger.sentry(
+          '[KeychainIntegrityCheck]: declaring selected wallet unhealthy...'
+        );
         logger.sentry('[KeychainIntegrityCheck]: done updating wallets');
       }
     }

--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -116,11 +116,11 @@ export const walletsUpdate = wallets => async (dispatch, getState) => {
   const { selected } = getState().wallets;
 
   await saveAllWallets(wallets);
-  await dispatch(walletsSetSelected(wallets[selected.id]));
   dispatch({
     payload: wallets,
     type: WALLETS_UPDATE,
   });
+  await dispatch(walletsSetSelected(wallets[selected.id]));
 };
 
 export const walletsSetSelected = wallet => async dispatch => {

--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -116,7 +116,7 @@ export const walletsUpdate = wallets => async (dispatch, getState) => {
   const { selected } = getState().wallets;
 
   await saveAllWallets(wallets);
-  dispatch({
+  await dispatch({
     payload: wallets,
     type: WALLETS_UPDATE,
   });

--- a/src/redux/wallets.js
+++ b/src/redux/wallets.js
@@ -132,7 +132,7 @@ export const walletsSetSelected = wallet => async dispatch => {
 };
 
 export const setWalletManualBackup = walletId => async (dispatch, getState) => {
-  const { wallets, selected } = getState().wallets;
+  const { wallets } = getState().wallets;
   const newWallets = { ...wallets };
   newWallets[walletId] = {
     ...newWallets[walletId],
@@ -140,9 +140,6 @@ export const setWalletManualBackup = walletId => async (dispatch, getState) => {
   };
 
   await dispatch(walletsUpdate(newWallets));
-  if (selected.id === walletId) {
-    await dispatch(walletsSetSelected(newWallets[walletId]));
-  }
 };
 
 export const deleteWalletCloudBackup = () => async (dispatch, getState) => {


### PR DESCRIPTION
### Description
This PR adds the cloud backup deletion to the `useWalletCloudBackup` hook.
It also adds a redirect when the cloud backup is successful. We were missing that.

~I'm still working on the tests, but I don't wanna that to block this PR from being reviewed.~
Tests done!

# Update
Video reference updated on Linear.

- [x] Completes #CS-4667

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
