### PR TITLE
[CS-4682] Connecting new backup flow into onboarding

### DIFF
--- a/cardstack/src/hooks/onboarding/__tests__/useShowOnboarding.test.ts
+++ b/cardstack/src/hooks/onboarding/__tests__/useShowOnboarding.test.ts
@@ -90,6 +90,21 @@ describe('useShowOnboarding', () => {
     expect(mockedNavigate).toBeCalledWith(Routes.PROFILE_SLUG);
   });
 
+  it('should NOT navigate to profile flow when safes are loading', () => {
+    mockPrimarySafeHelper({
+      hasProfile: false,
+      isLoadingOnInit: true,
+    });
+
+    const { result } = renderHook(useShowOnboarding);
+
+    act(() => {
+      result.current.navigateToNextOnboardingStep();
+    });
+
+    expect(mockedNavigate).not.toBeCalled();
+  });
+
   it('should NOT navigate to profile flow when profile has been fetched and it exists', () => {
     mockPrimarySafeHelper({
       hasProfile: true,

--- a/cardstack/src/hooks/onboarding/__tests__/useShowOnboarding.test.ts
+++ b/cardstack/src/hooks/onboarding/__tests__/useShowOnboarding.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 
 import { useShowOnboarding } from '@cardstack/hooks/onboarding/useShowOnboarding';
 import { Routes } from '@cardstack/navigation/routes';
@@ -66,7 +66,11 @@ describe('useShowOnboarding', () => {
   it('should NOT navigate to profile flow when profile hasnt been fetched', () => {
     mockPrimarySafeHelper({ hasProfile: false, isLoadingOnInit: true });
 
-    renderHook(useShowOnboarding);
+    const { result } = renderHook(useShowOnboarding);
+
+    act(() => {
+      result.current.navigateToNextOnboardingStep();
+    });
 
     expect(mockedNavigate).not.toBeCalled();
   });
@@ -77,7 +81,11 @@ describe('useShowOnboarding', () => {
       isLoadingOnInit: false,
     });
 
-    renderHook(useShowOnboarding);
+    const { result } = renderHook(useShowOnboarding);
+
+    act(() => {
+      result.current.navigateToNextOnboardingStep();
+    });
 
     expect(mockedNavigate).toBeCalledWith(Routes.PROFILE_SLUG);
   });
@@ -88,12 +96,16 @@ describe('useShowOnboarding', () => {
       isLoadingOnInit: false,
     });
 
-    renderHook(useShowOnboarding);
+    const { result } = renderHook(useShowOnboarding);
+
+    act(() => {
+      result.current.navigateToNextOnboardingStep();
+    });
 
     expect(mockedNavigate).not.toBeCalled();
   });
 
-  it('should NOT navigate to profile flow if user has not wallet', () => {
+  it('should NOT navigate to profile flow if no wallet', () => {
     (useAuthSelector as jest.Mock).mockReturnValueOnce({
       hasWallet: false,
     });
@@ -103,7 +115,11 @@ describe('useShowOnboarding', () => {
       isLoadingOnInit: false,
     });
 
-    renderHook(useShowOnboarding);
+    const { result } = renderHook(useShowOnboarding);
+
+    act(() => {
+      result.current.navigateToNextOnboardingStep();
+    });
 
     expect(mockedNavigate).not.toBeCalled();
   });
@@ -113,7 +129,11 @@ describe('useShowOnboarding', () => {
       hasSkippedProfileCreation: true,
     });
 
-    renderHook(useShowOnboarding);
+    const { result } = renderHook(useShowOnboarding);
+
+    act(() => {
+      result.current.navigateToNextOnboardingStep();
+    });
 
     expect(mockedNavigate).not.toBeCalled();
   });
@@ -121,7 +141,11 @@ describe('useShowOnboarding', () => {
   it('should navigate to backup flow if not backedup', () => {
     mockUseWallets({ selectedWallet: { manuallyBackedUp: false } });
 
-    renderHook(useShowOnboarding);
+    const { result } = renderHook(useShowOnboarding);
+
+    act(() => {
+      result.current.navigateToNextOnboardingStep();
+    });
 
     expect(mockedNavigate).toBeCalledWith(Routes.BACKUP_EXPLANATION);
   });
@@ -132,7 +156,11 @@ describe('useShowOnboarding', () => {
       hasSkippedBackup: true,
     });
 
-    renderHook(useShowOnboarding);
+    const { result } = renderHook(useShowOnboarding);
+
+    act(() => {
+      result.current.navigateToNextOnboardingStep();
+    });
 
     expect(mockedNavigate).not.toBeCalledWith(Routes.BACKUP_EXPLANATION);
   });

--- a/cardstack/src/hooks/onboarding/__tests__/useShowOnboarding.test.ts
+++ b/cardstack/src/hooks/onboarding/__tests__/useShowOnboarding.test.ts
@@ -36,7 +36,9 @@ jest.mock('@cardstack/redux/persistedFlagsSlice', () => ({
 }));
 
 describe('useShowOnboarding', () => {
-  const mockUseWallets = (overwriteParams: any = {}) => {
+  const mockUseWallets = (
+    overwriteParams: Partial<ReturnType<typeof useWallets>> = {}
+  ) => {
     (useWallets as jest.Mock).mockImplementation(() => ({
       selectedWallet: { manuallyBackedUp: true },
       walletReady: true,
@@ -44,7 +46,9 @@ describe('useShowOnboarding', () => {
     }));
   };
 
-  const mockPrimarySafeHelper = (overwriteParams: any = {}) =>
+  const mockPrimarySafeHelper = (
+    overwriteParams: Partial<ReturnType<typeof usePrimarySafe>> = {}
+  ) =>
     (usePrimarySafe as jest.Mock).mockImplementation(() => ({
       hasProfile: false,
       isLoadingOnInit: true,

--- a/cardstack/src/hooks/onboarding/useShowOnboarding.ts
+++ b/cardstack/src/hooks/onboarding/useShowOnboarding.ts
@@ -1,5 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
-import { useMemo, useCallback, useEffect } from 'react';
+import { useMemo, useCallback } from 'react';
 
 import { Routes } from '@cardstack/navigation/routes';
 import { useAuthSelector } from '@cardstack/redux/authSlice';
@@ -32,13 +32,6 @@ export const useShowOnboarding = () => {
 
     return hasWallet && noProfile && !hasSkippedProfileCreation;
   }, [hasProfile, hasSkippedProfileCreation, hasWallet, isLoadingSafes]);
-
-  useEffect(() => {
-    console.log('::: useShowOnboarding', {
-      shouldShowBackupFlow,
-      shouldShowProfileCreationFlow,
-    });
-  }, [shouldShowBackupFlow, shouldShowProfileCreationFlow]);
 
   const navigateToNextOnboardingStep = useCallback(
     (step?: string) => {

--- a/cardstack/src/hooks/onboarding/useShowOnboarding.ts
+++ b/cardstack/src/hooks/onboarding/useShowOnboarding.ts
@@ -6,15 +6,32 @@ import { useAuthSelector } from '@cardstack/redux/authSlice';
 import { usePrimarySafe } from '@cardstack/redux/hooks/usePrimarySafe';
 import { usePersistedFlagsSelector } from '@cardstack/redux/persistedFlagsSlice';
 
+import { useWallets } from '@rainbow-me/hooks';
+
 export const useShowOnboarding = () => {
+  const { selectedWallet, walletReady } = useWallets();
+
   const { hasProfile, isLoadingOnInit: isLoadingSafes } = usePrimarySafe();
-  const { hasSkippedProfileCreation } = usePersistedFlagsSelector();
+
+  const {
+    hasSkippedProfileCreation,
+    hasSkippedBackup,
+  } = usePersistedFlagsSelector();
 
   const { navigate } = useNavigation();
 
   const { hasWallet } = useAuthSelector();
 
   useEffect(() => {
+    // Wait until wallet and backup info has properly being loaded.
+    if (!walletReady) return;
+
+    if (!selectedWallet.manuallyBackedUp && !hasSkippedBackup) {
+      navigate(Routes.BACKUP_EXPLANATION);
+
+      return;
+    }
+
     const noProfile = !isLoadingSafes && !hasProfile;
 
     const shouldShowProfileCreationFlow =
@@ -24,6 +41,9 @@ export const useShowOnboarding = () => {
       navigate(Routes.PROFILE_SLUG);
     }
   }, [
+    walletReady,
+    selectedWallet,
+    hasSkippedBackup,
     hasProfile,
     hasSkippedProfileCreation,
     hasWallet,

--- a/cardstack/src/hooks/onboarding/useShowOnboarding.ts
+++ b/cardstack/src/hooks/onboarding/useShowOnboarding.ts
@@ -63,5 +63,6 @@ export const useShowOnboarding = () => {
     navigateToNextOnboardingStep,
     shouldShowBackupFlow,
     shouldShowProfileCreationFlow,
+    isLoadingSafes,
   };
 };

--- a/cardstack/src/hooks/onboarding/useShowOnboarding.ts
+++ b/cardstack/src/hooks/onboarding/useShowOnboarding.ts
@@ -36,6 +36,11 @@ export const useShowOnboarding = () => {
   const navigateToNextOnboardingStep = useCallback(
     (step?: string) => {
       if (step) {
+        // Avoid showing profile flow when not needed.
+        if (step === Routes.PROFILE_SLUG && !shouldShowProfileCreationFlow) {
+          return;
+        }
+
         navigate(step);
 
         return;

--- a/cardstack/src/redux/persistedFlagsSlice.ts
+++ b/cardstack/src/redux/persistedFlagsSlice.ts
@@ -24,13 +24,8 @@ const slice = createSlice({
     skipBackup(state, action: PayloadAction<boolean>) {
       state.hasSkippedBackup = action.payload;
     },
-    clearFlags(state) {
-      state = initialState;
-
-      // Hack note: Returning the state in slice reducers is not necessary generally,
-      // but this state does not update when the action is dispatched
-      // from resetWallet in wallet model for some unknown reason.
-      return state;
+    clearFlags() {
+      return initialState;
     },
   },
 });

--- a/cardstack/src/redux/persistedFlagsSlice.ts
+++ b/cardstack/src/redux/persistedFlagsSlice.ts
@@ -6,10 +6,12 @@ import { AppState } from '@rainbow-me/redux/store';
 
 type SliceType = {
   hasSkippedProfileCreation: boolean;
+  hasSkippedBackup: boolean;
 };
 
 const initialState: SliceType = {
   hasSkippedProfileCreation: false,
+  hasSkippedBackup: false,
 };
 
 const slice = createSlice({
@@ -19,12 +21,15 @@ const slice = createSlice({
     skipProfileCreation(state, action: PayloadAction<boolean>) {
       state.hasSkippedProfileCreation = action.payload;
     },
+    skipBackup(state, action: PayloadAction<boolean>) {
+      state.hasSkippedBackup = action.payload;
+    },
   },
 });
 
 export const {
   name: persistedFlagsName,
-  actions: { skipProfileCreation },
+  actions: { skipProfileCreation, skipBackup },
 } = slice;
 
 export const usePersistedFlagsSelector = () => {
@@ -40,8 +45,13 @@ export const usePersistedFlagsActions = () => {
     dispatch(skipProfileCreation(true));
   }, [dispatch]);
 
+  const triggerSkipBackup = useCallback(() => {
+    dispatch(skipBackup(true));
+  }, [dispatch]);
+
   return {
     triggerSkipProfileCreation,
+    triggerSkipBackup,
   };
 };
 

--- a/cardstack/src/redux/persistedFlagsSlice.ts
+++ b/cardstack/src/redux/persistedFlagsSlice.ts
@@ -24,12 +24,20 @@ const slice = createSlice({
     skipBackup(state, action: PayloadAction<boolean>) {
       state.hasSkippedBackup = action.payload;
     },
+    clearFlags(state) {
+      state = initialState;
+
+      // Hack note: Returning the state in slice reducers is not necessary generally,
+      // but this state does not update when the action is dispatched
+      // from resetWallet in wallet model for some unknown reason.
+      return state;
+    },
   },
 });
 
 export const {
   name: persistedFlagsName,
-  actions: { skipProfileCreation, skipBackup },
+  actions: { skipProfileCreation, skipBackup, clearFlags },
 } = slice;
 
 export const usePersistedFlagsSelector = () => {

--- a/cardstack/src/screens/Backup/BackupCloudPasswordScreen/useBackupCloudPasswordScreen.ts
+++ b/cardstack/src/screens/Backup/BackupCloudPasswordScreen/useBackupCloudPasswordScreen.ts
@@ -1,17 +1,31 @@
+import {
+  StackActions,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { TextInput } from 'react-native';
 
 import { usePasswordInput } from '@cardstack/components';
 import { useWalletCloudBackup } from '@cardstack/hooks';
+import { useShowOnboarding } from '@cardstack/hooks/onboarding/useShowOnboarding';
 import { cloudBackupPasswordMinLength } from '@cardstack/models/backup';
+import { RouteType } from '@cardstack/navigation/types';
 import {
   hasAtLeastOneDigit,
   matchMinLength,
 } from '@cardstack/utils/validators';
 
+import { BackupRouteParams } from '../types';
+
 export const useBackupCloudPasswordScreen = () => {
+  const { params } = useRoute<RouteType<BackupRouteParams>>();
+
+  const { dispatch: navDispatch } = useNavigation();
+
   const [checked, setChecked] = useState(false);
   const { backupToCloud } = useWalletCloudBackup();
+  const { navigateToNextOnboardingStep } = useShowOnboarding();
 
   const { onChangeText, isValid, password } = usePasswordInput({
     validation: (text: string) =>
@@ -42,9 +56,20 @@ export const useBackupCloudPasswordScreen = () => {
     confirmPasswordRef.current?.focus();
   }, []);
 
-  const handleBackupToCloud = useCallback(() => backupToCloud({ password }), [
+  const handleBackupToCloud = useCallback(async () => {
+    await backupToCloud({ password });
+
+    if (params?.popStackOnSuccess) {
+      navDispatch(StackActions.pop(params?.popStackOnSuccess));
+    } else {
+      navigateToNextOnboardingStep();
+    }
+  }, [
+    params,
     password,
     backupToCloud,
+    navDispatch,
+    navigateToNextOnboardingStep,
   ]);
 
   return {

--- a/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
@@ -1,8 +1,4 @@
-import {
-  StackActions,
-  useNavigation,
-  useRoute,
-} from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import React, { memo, useCallback } from 'react';
 
 import {
@@ -14,26 +10,31 @@ import {
   Text,
 } from '@cardstack/components';
 import { Routes } from '@cardstack/navigation';
-import { RouteType } from '@cardstack/navigation/types';
+import { usePersistedFlagsActions } from '@cardstack/redux/persistedFlagsSlice';
 
-import { BackupRouteParams } from '../types';
+import { useWallets } from '@rainbow-me/hooks';
 
 import { strings } from './strings';
 
 const BackupExplanationScreen = () => {
-  const { dispatch: navDispatch, navigate } = useNavigation();
-  const { params } = useRoute<RouteType<BackupRouteParams>>();
+  const { navigate } = useNavigation();
+  const { seedPhrase } = useWallets();
+
+  const { triggerSkipBackup } = usePersistedFlagsActions();
 
   const handleBackupOnPress = useCallback(() => {
-    navigate(Routes.BACKUP_MANUAL_BACKUP, params);
-  }, [navigate, params]);
+    navigate(Routes.BACKUP_MANUAL_BACKUP, { seedPhrase });
+  }, [navigate, seedPhrase]);
 
   const handleLaterOnPress = useCallback(() => {
-    navDispatch(StackActions.popToTop());
-  }, [navDispatch]);
+    triggerSkipBackup();
+  }, [triggerSkipBackup]);
 
   return (
-    <PageWithStackHeader canGoBack={false}>
+    <PageWithStackHeader
+      canGoBack={false}
+      skipPressCallback={handleLaterOnPress}
+    >
       <Container flex={1} width="90%">
         <Text variant="pageHeader" paddingBottom={4}>
           {strings.title}

--- a/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
@@ -9,6 +9,7 @@ import {
   PageWithStackHeaderFooter,
   Text,
 } from '@cardstack/components';
+import { useShowOnboarding } from '@cardstack/hooks/onboarding/useShowOnboarding';
 import { Routes } from '@cardstack/navigation';
 import { usePersistedFlagsActions } from '@cardstack/redux/persistedFlagsSlice';
 
@@ -20,6 +21,8 @@ const BackupExplanationScreen = () => {
   const { navigate } = useNavigation();
   const { seedPhrase } = useWallets();
 
+  const { navigateToNextOnboardingStep } = useShowOnboarding();
+
   const { triggerSkipBackup } = usePersistedFlagsActions();
 
   const handleBackupOnPress = useCallback(() => {
@@ -28,7 +31,8 @@ const BackupExplanationScreen = () => {
 
   const handleLaterOnPress = useCallback(() => {
     triggerSkipBackup();
-  }, [triggerSkipBackup]);
+    navigateToNextOnboardingStep(Routes.PROFILE_SLUG);
+  }, [triggerSkipBackup, navigateToNextOnboardingStep]);
 
   return (
     <PageWithStackHeader

--- a/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupExplanationScreen/BackupExplanationScreen.tsx
@@ -9,17 +9,16 @@ import {
   PageWithStackHeaderFooter,
   Text,
 } from '@cardstack/components';
+import { useSelectedWallet } from '@cardstack/hooks';
 import { useShowOnboarding } from '@cardstack/hooks/onboarding/useShowOnboarding';
 import { Routes } from '@cardstack/navigation';
 import { usePersistedFlagsActions } from '@cardstack/redux/persistedFlagsSlice';
-
-import { useWallets } from '@rainbow-me/hooks';
 
 import { strings } from './strings';
 
 const BackupExplanationScreen = () => {
   const { navigate } = useNavigation();
-  const { seedPhrase } = useWallets();
+  const { seedPhrase } = useSelectedWallet();
 
   const { navigateToNextOnboardingStep } = useShowOnboarding();
 

--- a/cardstack/src/screens/Backup/BackupManualScreen/BackupManualScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupManualScreen/BackupManualScreen.tsx
@@ -1,4 +1,4 @@
-import { useRoute, useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import React, { memo, useCallback } from 'react';
 import { StyleSheet } from 'react-native';
 
@@ -26,6 +26,7 @@ const style = StyleSheet.create({
 
 const BackupManualScreen = () => {
   const { navigate } = useNavigation();
+
   const { params } = useRoute<RouteType<BackupRouteParams>>();
 
   const handleNextOnPress = useCallback(() => {

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
@@ -10,13 +10,17 @@ export const useBackupRecoveryPhraseScreen = () => {
   const { deleteCloudBackups } = useWalletCloudBackup();
 
   const handleCloudBackupOnPress = useCallback(
-    () => navigate(Routes.BACKUP_CLOUD_PASSWORD, { seedPhrase }),
+    () =>
+      navigate(Routes.BACKUP_CLOUD_PASSWORD, {
+        seedPhrase,
+      }),
     [navigate, seedPhrase]
   );
 
   const handleManualBackupOnPress = useCallback(() => {
     navigate(Routes.BACKUP_MANUAL_BACKUP, {
       seedPhrase,
+      popStackOnSuccess: 2,
     });
   }, [navigate, seedPhrase]);
 

--- a/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
+++ b/cardstack/src/screens/Backup/BackupRecoveryPhraseScreen/useBackupRecoveryPhraseScreen.ts
@@ -12,9 +12,9 @@ export const useBackupRecoveryPhraseScreen = () => {
   const handleCloudBackupOnPress = useCallback(
     () =>
       navigate(Routes.BACKUP_CLOUD_PASSWORD, {
-        seedPhrase,
+        popStackOnSuccess: 1,
       }),
-    [navigate, seedPhrase]
+    [navigate]
   );
 
   const handleManualBackupOnPress = useCallback(() => {

--- a/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/__tests__/useBackupSeedPhraseConfirmationScreen.test.ts
+++ b/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/__tests__/useBackupSeedPhraseConfirmationScreen.test.ts
@@ -2,6 +2,7 @@ import { StackActions, useRoute } from '@react-navigation/native';
 import { renderHook } from '@testing-library/react-hooks';
 import { act } from 'react-test-renderer';
 
+import { BackupRouteParams } from '../../types';
 import { useBackupSeedPhraseConfirmationScreen } from '../useBackupSeedPhraseConfirmationScreen';
 import { seedPhraseStringToArray } from '../utils';
 
@@ -29,11 +30,11 @@ const mockSeedPhrase =
   'loan velvet fall cluster renew animal trophy clinic adjust fix soon enrich';
 
 describe('BackupSeedPhraseConfirmationScreen', () => {
-  const mockParams = (overwrite: any = {}) => {
+  const mockParams = (overwriteParams: Partial<BackupRouteParams> = {}) => {
     (useRoute as jest.Mock).mockImplementation(() => ({
       params: {
         seedPhrase: mockSeedPhrase,
-        ...overwrite,
+        ...overwriteParams,
       },
     }));
   };

--- a/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/__tests__/useBackupSeedPhraseConfirmationScreen.test.ts
+++ b/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/__tests__/useBackupSeedPhraseConfirmationScreen.test.ts
@@ -20,6 +20,14 @@ jest.mock('@cardstack/navigation', () => ({
   },
 }));
 
+const mockNavigateOnboarding = jest.fn();
+
+jest.mock('@cardstack/hooks/onboarding/useShowOnboarding', () => ({
+  useShowOnboarding: () => ({
+    navigateToNextOnboardingStep: mockNavigateOnboarding,
+  }),
+}));
+
 const mockConfirmBackup = jest.fn();
 
 jest.mock('@cardstack/hooks/backup/useWalletManualBackup', () => ({
@@ -106,7 +114,7 @@ describe('BackupSeedPhraseConfirmationScreen', () => {
     expect(result.current.isSeedPhraseCorrect).toBeFalsy();
   });
 
-  it('should confirm Backup but not pop navigation if not requested by nav params', () => {
+  it('should confirm Backup and navigate to next onboading step', () => {
     const { result } = renderHook(useBackupSeedPhraseConfirmationScreen);
 
     act(() => {
@@ -114,7 +122,8 @@ describe('BackupSeedPhraseConfirmationScreen', () => {
     });
 
     expect(mockConfirmBackup).toBeCalled();
-    expect(mockNavDispatch).toBeCalledTimes(0);
+    expect(mockNavDispatch).not.toBeCalled();
+    expect(mockNavigateOnboarding).toBeCalled();
   });
 
   it('should confirm Backup and navigate back when requested by nav params', () => {

--- a/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/useBackupSeedPhraseConfirmationScreen.ts
+++ b/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/useBackupSeedPhraseConfirmationScreen.ts
@@ -6,6 +6,7 @@ import {
 import { useCallback, useRef, useState, useMemo } from 'react';
 
 import { useWalletManualBackup } from '@cardstack/hooks/backup/useWalletManualBackup';
+import { useShowOnboarding } from '@cardstack/hooks/onboarding/useShowOnboarding';
 import { Routes } from '@cardstack/navigation';
 import { RouteType } from '@cardstack/navigation/types';
 
@@ -21,9 +22,11 @@ export const useBackupSeedPhraseConfirmationScreen = () => {
     params: { seedPhrase, popStackOnSuccess = 0 },
   } = useRoute<RouteType<BackupRouteParams>>();
 
-  const { navigate, dispatch: navDispatch } = useNavigation();
+  const { dispatch: navDispatch } = useNavigation();
 
   const { confirmBackup } = useWalletManualBackup();
+
+  const { navigateToNextOnboardingStep } = useShowOnboarding();
 
   const selectedWordsIndexes = useRef<number[]>([]).current;
   const [selectedWords, setSelectedWords] = useState<string[]>([]);
@@ -54,23 +57,30 @@ export const useBackupSeedPhraseConfirmationScreen = () => {
     [shuffledWords, selectedWords, selectedWordsIndexes, setSelectedWords]
   );
 
-  const handleConfirmPressed = useCallback(() => {
-    confirmBackup();
-
-    if (popStackOnSuccess) {
-      navDispatch(StackActions.pop(popStackOnSuccess));
-    }
-  }, [confirmBackup, popStackOnSuccess, navDispatch]);
-
   const handleClearPressed = useCallback(() => {
     selectedWordsIndexes.length = 0;
     setSelectedWords([]);
   }, [selectedWordsIndexes, setSelectedWords]);
 
+  const handleConfirmPressed = useCallback(() => {
+    confirmBackup();
+
+    if (popStackOnSuccess) {
+      navDispatch(StackActions.pop(popStackOnSuccess));
+    } else {
+      navigateToNextOnboardingStep();
+    }
+  }, [
+    confirmBackup,
+    popStackOnSuccess,
+    navDispatch,
+    navigateToNextOnboardingStep,
+  ]);
+
   const handleBackupToCloudPress = useCallback(() => {
     confirmBackup();
-    navigate(Routes.BACKUP_CLOUD_PASSWORD);
-  }, [navigate, confirmBackup]);
+    navigateToNextOnboardingStep(Routes.BACKUP_CLOUD_PASSWORD);
+  }, [navigateToNextOnboardingStep, confirmBackup]);
 
   return {
     handleWordPressed,

--- a/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/useBackupSeedPhraseConfirmationScreen.ts
+++ b/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/useBackupSeedPhraseConfirmationScreen.ts
@@ -1,25 +1,27 @@
-import { useNavigation, useRoute } from '@react-navigation/native';
+import {
+  StackActions,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native';
 import { useCallback, useRef, useState, useMemo } from 'react';
 
 import { useWalletManualBackup } from '@cardstack/hooks/backup/useWalletManualBackup';
 import { Routes } from '@cardstack/navigation';
 import { RouteType } from '@cardstack/navigation/types';
 
-import { shuffleSeedPhraseAsArray } from './utils';
+import { BackupRouteParams } from '../types';
 
-interface NavParams {
-  seedPhrase: string;
-}
+import { shuffleSeedPhraseAsArray } from './utils';
 
 // Selection UI is hard-coded for 12 words.
 const SEED_PHRASE_LENGTH = 12;
 
 export const useBackupSeedPhraseConfirmationScreen = () => {
   const {
-    params: { seedPhrase },
-  } = useRoute<RouteType<NavParams>>();
+    params: { seedPhrase, popStackOnSuccess = 0 },
+  } = useRoute<RouteType<BackupRouteParams>>();
 
-  const { navigate } = useNavigation();
+  const { navigate, dispatch: navDispatch } = useNavigation();
 
   const { confirmBackup } = useWalletManualBackup();
 
@@ -54,8 +56,13 @@ export const useBackupSeedPhraseConfirmationScreen = () => {
 
   const handleConfirmPressed = useCallback(() => {
     confirmBackup();
-    navigate(Routes.WALLET_SCREEN);
-  }, [navigate, confirmBackup]);
+
+    console.log(':::', { popStackOnSuccess });
+
+    if (popStackOnSuccess) {
+      navDispatch(StackActions.pop(popStackOnSuccess));
+    }
+  }, [confirmBackup, popStackOnSuccess, navDispatch]);
 
   const handleClearPressed = useCallback(() => {
     selectedWordsIndexes.length = 0;

--- a/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/useBackupSeedPhraseConfirmationScreen.ts
+++ b/cardstack/src/screens/Backup/BackupSeedPhraseConfirmationScreen/useBackupSeedPhraseConfirmationScreen.ts
@@ -57,8 +57,6 @@ export const useBackupSeedPhraseConfirmationScreen = () => {
   const handleConfirmPressed = useCallback(() => {
     confirmBackup();
 
-    console.log(':::', { popStackOnSuccess });
-
     if (popStackOnSuccess) {
       navDispatch(StackActions.pop(popStackOnSuccess));
     }

--- a/cardstack/src/screens/Backup/types.ts
+++ b/cardstack/src/screens/Backup/types.ts
@@ -1,3 +1,4 @@
 export interface BackupRouteParams {
   seedPhrase: string;
+  popStackOnSuccess?: number;
 }

--- a/cardstack/src/screens/WalletScreen/WalletScreen.tsx
+++ b/cardstack/src/screens/WalletScreen/WalletScreen.tsx
@@ -21,7 +21,10 @@ export const WalletScreen = () => {
 
   const initialized = useRef(!!params?.initialized);
 
-  useShowOnboarding();
+  const { navigateToNextOnboardingStep } = useShowOnboarding();
+  // This is necessary since other instances of useShowOnboading will
+  // trigger a re-render on navigateToNextOnboardingStep reference changing.
+  const calledOnboardingOnce = useRef(false);
 
   useEffect(() => {
     if (!initialized.current && !walletReady) {
@@ -29,6 +32,13 @@ export const WalletScreen = () => {
       initialized.current = true;
     }
   }, [initializeWallet, walletReady]);
+
+  useEffect(() => {
+    if (!calledOnboardingOnce.current && walletReady) {
+      navigateToNextOnboardingStep();
+      calledOnboardingOnce.current = true;
+    }
+  }, [walletReady, navigateToNextOnboardingStep]);
 
   return (
     <Container backgroundColor="backgroundDarkPurple" flex={1} height="100%">

--- a/cardstack/src/screens/WalletScreen/WalletScreen.tsx
+++ b/cardstack/src/screens/WalletScreen/WalletScreen.tsx
@@ -21,7 +21,7 @@ export const WalletScreen = () => {
 
   const initialized = useRef(!!params?.initialized);
 
-  const { navigateToNextOnboardingStep } = useShowOnboarding();
+  const { navigateToNextOnboardingStep, isLoadingSafes } = useShowOnboarding();
   // This is necessary since other instances of useShowOnboading will
   // trigger a re-render on navigateToNextOnboardingStep reference changing.
   const calledOnboardingOnce = useRef(false);
@@ -34,11 +34,11 @@ export const WalletScreen = () => {
   }, [initializeWallet, walletReady]);
 
   useEffect(() => {
-    if (!calledOnboardingOnce.current && walletReady) {
+    if (!calledOnboardingOnce.current && walletReady && !isLoadingSafes) {
       navigateToNextOnboardingStep();
       calledOnboardingOnce.current = true;
     }
-  }, [walletReady, navigateToNextOnboardingStep]);
+  }, [walletReady, navigateToNextOnboardingStep, isLoadingSafes]);
 
   return (
     <Container backgroundColor="backgroundDarkPurple" flex={1} height="100%">

--- a/src/components/settings-menu/DeveloperSettings.js
+++ b/src/components/settings-menu/DeveloperSettings.js
@@ -33,10 +33,6 @@ const DeveloperSettings = () => {
       <ListItem label="🔄 Restart app" onPress={restartApp} />
       <ListItem label="🗑️ Remove all backups" onPress={deleteAllBackups} />
       <ListItem
-        label="🤷 Restore default experimental config"
-        onPress={() => AsyncStorage.removeItem('experimentalConfig')}
-      />
-      <ListItem
         label="‍👾 Connect to ganache"
         onPress={connectToGanache}
         testID="ganache-section"

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -1,4 +1,3 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { captureException } from '@sentry/react-native';
 import { generateMnemonic } from 'bip39';
 import { signTypedData_v4, signTypedDataLegacy } from 'eth-sig-util';
@@ -49,7 +48,7 @@ import {
   updateSecureStorePin,
   wipeSecureStorage,
 } from '@cardstack/models/secure-storage';
-import { skipProfileCreation } from '@cardstack/redux/persistedFlagsSlice';
+import { clearFlags } from '@cardstack/redux/persistedFlagsSlice';
 import { restartApp } from '@cardstack/utils';
 import { Device } from '@cardstack/utils/device';
 
@@ -57,7 +56,7 @@ import {
   deleteKeychainIntegrityState,
   deletePinAuthAttemptsData,
 } from '@rainbow-me/handlers/localstorage/globalSettings';
-import store from '@rainbow-me/redux/store';
+import store, { persistor } from '@rainbow-me/redux/store';
 import logger from 'logger';
 
 const encryptor = new AesEncryptor();
@@ -906,16 +905,14 @@ export const resetWallet = async () => {
       await wipeSecureStorage(allWallets);
       await keychain.wipeKeychain();
 
-      // clear preferences on redux persist properties
-      await AsyncStorage.clear();
-
       // resets Keychain Integrity Check
       deleteKeychainIntegrityState();
 
       await deletePinAuthAttemptsData();
 
-      // clear profile creation skip
-      store.dispatch(skipProfileCreation(false));
+      // clear preferences on redux persist properties
+      store.dispatch(clearFlags());
+      await persistor.flush();
 
       logger.log('Wallet reset done!');
 

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -1,3 +1,4 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { captureException } from '@sentry/react-native';
 import { generateMnemonic } from 'bip39';
 import { signTypedData_v4, signTypedDataLegacy } from 'eth-sig-util';
@@ -904,6 +905,9 @@ export const resetWallet = async () => {
     if (allWallets) {
       await wipeSecureStorage(allWallets);
       await keychain.wipeKeychain();
+
+      // clear preferences on redux persist properties
+      await AsyncStorage.clear();
 
       // resets Keychain Integrity Check
       deleteKeychainIntegrityState();

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -622,6 +622,7 @@ export const createOrImportWallet = async ({
       color: color || 0,
       id: walletId,
       imported: isImported,
+      manuallyBackedUp: isImported,
       damaged: false,
       name: walletName,
       primary,


### PR DESCRIPTION
### Description

This PR adds the backup flow in onboarding by updating the logic in `useShowOnboarding` hook. It changes some auxiliary code but the essence is in the hook.

It also adds a new persisted preference flag in case uses skip the backup flow.

**Note:** I added a AsyncStore.clear() on resetting the wallet so preferences stored with redux-persist, like skip backup or profile, would also be cleared. Let me know if you remember something that needs to be maintained over resets.

- [x] Completes #(CS-4682)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

Several recording are available in Linear [here.](https://linear.app/cardstack/issue/CS-4682/[logic]-connect-new-backup-flow-to-the-onboarding-experience)