### PR TITLE
[CS-4717] Add view mode to SuffixedInput

### DIFF
--- a/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
+++ b/cardstack/src/components/Input/SuffixedInput/SuffixedInput.tsx
@@ -23,6 +23,7 @@ const styles = StyleSheet.create({
 interface SuffixedInputProps extends TextInputProps {
   suffixText?: string;
   suffixTextProps?: TextProps;
+  readOnly?: boolean;
 }
 
 const DEFAULT_MAX_LENGTH = 25;
@@ -34,6 +35,7 @@ const SuffixedInput = ({
   placeholder = strings.defaultPlaceholder,
   onChangeText,
   value,
+  readOnly,
 }: SuffixedInputProps) => (
   <Container
     width="100%"
@@ -58,6 +60,7 @@ const SuffixedInput = ({
       onChangeText={onChangeText}
       value={value}
       returnKeyType="done"
+      editable={!readOnly}
     />
     <Text
       style={styles.textStyle}

--- a/cardstack/src/screens/Dev/DesignSystemScreen.tsx
+++ b/cardstack/src/screens/Dev/DesignSystemScreen.tsx
@@ -8,8 +8,8 @@ import {
   Container,
   Text,
   SeedPhraseTable,
+  SuffixedInput,
 } from '@cardstack/components';
-import SuffixedInput from '@cardstack/components/Input/SuffixedInput/SuffixedInput';
 import { cardSpaceDomain } from '@cardstack/constants';
 import { buttonVariants } from '@cardstack/theme';
 
@@ -22,7 +22,7 @@ const DesignSystemScreen = () => {
   const sections = [
     {
       title: 'Input',
-      data: ['slug'],
+      data: ['slug', 'viewOnly'],
     },
     {
       title: 'Seed Phrase',
@@ -96,6 +96,21 @@ const DesignSystemScreen = () => {
     }
   }, []);
 
+  const renderInputVariants = useCallback(item => {
+    switch (item) {
+      case 'viewOnly':
+        return (
+          <SuffixedInput
+            value="Mandello123"
+            suffixText={cardSpaceDomain}
+            readOnly
+          />
+        );
+      default:
+        return <SuffixedInput suffixText={cardSpaceDomain} />;
+    }
+  }, []);
+
   const renderItem = useCallback(
     ({ item, section: { title } }) => {
       switch (title) {
@@ -104,11 +119,7 @@ const DesignSystemScreen = () => {
             <Container padding={2}>{renderSeedPhraseStates(item)}</Container>
           );
         case 'Input':
-          return (
-            <Container padding={2}>
-              <SuffixedInput suffixText={cardSpaceDomain} />
-            </Container>
-          );
+          return <Container padding={2}>{renderInputVariants(item)}</Container>;
         case 'Buttons':
           return (
             <CenteredContainer padding={2}>
@@ -130,7 +141,7 @@ const DesignSystemScreen = () => {
           );
       }
     },
-    [renderButtonStates, renderSeedPhraseStates]
+    [renderButtonStates, renderSeedPhraseStates, renderInputVariants]
   );
 
   return (


### PR DESCRIPTION
### Description
This PR adds a new prop to the `SuffixedInput` component API that enables or disables the `editable` prop from RN `TextInput`, allowing us to use the component in "view mode".

- [x] Completes #CS-4717

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/195391533-95325c13-09f5-45ca-ba5d-f0fead4f0266.png">

