### PR TITLE
[CS-4715] Restore wallet screen

### DIFF
--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -76,6 +76,7 @@ const BackupRoutes = {
   BACKUP_RECOVERY_PHRASE: 'BackupRecoveryPhrase',
   BACKUP_SEEDPHRASE_CONFIRMATION: 'BackupSeedPhraseConfirmationScreen',
   BACKUP_MANUAL_BACKUP: 'BackupManualBackup',
+  BACKUP_RESTORE_EXPLANATION: 'BackupRestoreExplanation',
 };
 
 export const Routes = {

--- a/cardstack/src/navigation/screenGroups/backup.tsx
+++ b/cardstack/src/navigation/screenGroups/backup.tsx
@@ -20,7 +20,7 @@ export const BackupScreenGroup = ({ Stack }: { Stack: StackType }) => (
     screenOptions={{
       ...horizontalNonStackingInterpolator,
       detachPreviousScreen: false,
-      gestureEnabled: false, // presentation as 'card' brings conflicts with iCloud password autofill.
+      gestureDirection: 'horizontal',
     }}
   >
     <Stack.Screen

--- a/cardstack/src/navigation/screenGroups/backup.tsx
+++ b/cardstack/src/navigation/screenGroups/backup.tsx
@@ -10,6 +10,7 @@ import {
   BackupRecoveryPhraseScreen,
   BackupSeedPhraseConfirmationScreen,
   BackupManualScreen,
+  BackupRestoreExplanationScreen,
 } from '@cardstack/screens';
 
 import { StackType } from '../types';
@@ -41,6 +42,10 @@ export const BackupScreenGroup = ({ Stack }: { Stack: StackType }) => (
     <Stack.Screen
       component={BackupManualScreen}
       name={Routes.BACKUP_MANUAL_BACKUP}
+    />
+    <Stack.Screen
+      component={BackupRestoreExplanationScreen}
+      name={Routes.BACKUP_RESTORE_EXPLANATION}
     />
   </Stack.Group>
 );

--- a/cardstack/src/screens/Backup/BackupRestoreExplanationScreen/BackupRestoreExplanationScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupRestoreExplanationScreen/BackupRestoreExplanationScreen.tsx
@@ -1,0 +1,48 @@
+import React, { memo, useCallback } from 'react';
+
+import {
+  Button,
+  CenteredContainer,
+  Container,
+  PageWithStackHeader,
+  PageWithStackHeaderFooter,
+  Text,
+} from '@cardstack/components';
+import { Device } from '@cardstack/utils';
+
+import { strings } from './strings';
+
+const BackupRestoreExplanationScreen = () => {
+  const handleRestoreCloudOnPress = useCallback(() => {
+    // TBD
+  }, []);
+
+  const handleRecoveryPhraseOnPress = useCallback(() => {
+    // TBD
+  }, []);
+
+  return (
+    <PageWithStackHeader showSkip={false}>
+      <Container flex={1} width="90%">
+        <Text variant="pageHeader" paddingBottom={4}>
+          {strings.title}
+        </Text>
+        <Text color="grayText" letterSpacing={0.4}>
+          {strings.description}
+        </Text>
+      </Container>
+      <PageWithStackHeaderFooter>
+        <CenteredContainer>
+          <Button onPress={handleRestoreCloudOnPress} marginBottom={4}>
+            {strings.primaryBtn}
+          </Button>
+          <Button variant="linkWhite" onPress={handleRecoveryPhraseOnPress}>
+            {strings.secondaryBtn(Device.cloudPlatform)}
+          </Button>
+        </CenteredContainer>
+      </PageWithStackHeaderFooter>
+    </PageWithStackHeader>
+  );
+};
+
+export default memo(BackupRestoreExplanationScreen);

--- a/cardstack/src/screens/Backup/BackupRestoreExplanationScreen/BackupRestoreExplanationScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupRestoreExplanationScreen/BackupRestoreExplanationScreen.tsx
@@ -8,7 +8,6 @@ import {
   PageWithStackHeaderFooter,
   Text,
 } from '@cardstack/components';
-import { Device } from '@cardstack/utils';
 
 import { strings } from './strings';
 
@@ -37,7 +36,7 @@ const BackupRestoreExplanationScreen = () => {
             {strings.primaryBtn}
           </Button>
           <Button variant="linkWhite" onPress={handleRecoveryPhraseOnPress}>
-            {strings.secondaryBtn(Device.cloudPlatform)}
+            {strings.secondaryBtn}
           </Button>
         </CenteredContainer>
       </PageWithStackHeaderFooter>

--- a/cardstack/src/screens/Backup/BackupRestoreExplanationScreen/strings.ts
+++ b/cardstack/src/screens/Backup/BackupRestoreExplanationScreen/strings.ts
@@ -1,0 +1,7 @@
+export const strings = {
+  title: 'Restore wallet',
+  description:
+    'Restore your wallet with the 12 word recovery phrase that you have written down.',
+  primaryBtn: 'Restore with recovery phrase',
+  secondaryBtn: (cloud: string) => `Restore with ${cloud}`,
+};

--- a/cardstack/src/screens/Backup/BackupRestoreExplanationScreen/strings.ts
+++ b/cardstack/src/screens/Backup/BackupRestoreExplanationScreen/strings.ts
@@ -1,7 +1,9 @@
+import { Device } from '@cardstack/utils';
+
 export const strings = {
   title: 'Restore wallet',
   description:
     'Restore your wallet with the 12 word recovery phrase that you have written down.',
   primaryBtn: 'Restore with recovery phrase',
-  secondaryBtn: (cloud: string) => `Restore with ${cloud}`,
+  secondaryBtn: `Restore with ${Device.cloudPlatform}`,
 };

--- a/cardstack/src/screens/Backup/index.ts
+++ b/cardstack/src/screens/Backup/index.ts
@@ -3,3 +3,4 @@ export { default as BackupCloudPasswordScreen } from './BackupCloudPasswordScree
 export { default as BackupRecoveryPhraseScreen } from './BackupRecoveryPhraseScreen/BackupRecoveryPhraseScreen';
 export { default as BackupSeedPhraseConfirmationScreen } from './BackupSeedPhraseConfirmationScreen/BackupSeedPhraseConfirmationScreen';
 export { default as BackupManualScreen } from './BackupManualScreen/BackupManualScreen';
+export { default as BackupRestoreExplanationScreen } from './BackupRestoreExplanationScreen/BackupRestoreExplanationScreen';


### PR DESCRIPTION
### Description
This PR adds the first screen of Restore/Import wallet flow. 
I choose to use the same `screenGroup` as the rest of the backup flow to group by feature, if you will.

One thing to notice is that I've changed the screenGroup configuration. For some weird reason, enabling gestures doesn't conflict with the iCloud password generation anymore (on the `BackupCloudPasswordScreen`). 

- [x] Completes #CS-4715


### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

## iOS (iPhone 11)
<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/195898109-2b677e6d-8375-4326-a5ef-e9fef34ab513.jpeg">

## Android (Moto G8 Plus)
<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/195898345-5fcb9d51-5cb8-4d3b-b14c-c624e27a22b0.png">
