### PR TITLE
[CS-4720] UI seed phrase input box

### DIFF
--- a/cardstack/src/components/Input/PasswordInput/PasswordInput.tsx
+++ b/cardstack/src/components/Input/PasswordInput/PasswordInput.tsx
@@ -10,7 +10,7 @@ import {
   Touchable,
   BaseInputProps,
 } from '@cardstack/components';
-import { palette } from '@cardstack/theme';
+import { colors } from '@cardstack/theme';
 import { hitSlop } from '@cardstack/utils';
 
 interface PasswordInputProps extends BaseInputProps {
@@ -61,7 +61,7 @@ const PasswordInput = forwardRef((props: PasswordInputProps, ref) => {
             selectTextOnFocus={true}
             textContentType="password"
             {...inputProps}
-            placeholderTextColor={palette.blueText}
+            placeholderTextColor={colors.blueText}
             secureTextEntry={!isPasswordVisible}
             autoCapitalize="none"
             onChangeText={onChangeText}

--- a/cardstack/src/components/Input/PhraseInput/PhraseInput.tsx
+++ b/cardstack/src/components/Input/PhraseInput/PhraseInput.tsx
@@ -9,19 +9,19 @@ import { Device } from '@cardstack/utils/device';
 const InputHeight = Device.isIOS ? 139 : 110;
 
 interface PasswordInputProps extends BaseInputProps {
-  isValid: boolean;
+  showAsError?: boolean;
 }
 
 const PhraseInput = forwardRef((props: PasswordInputProps, ref) => {
-  const { onChangeText, value, isValid = true, ...inputProps } = props;
+  const { onChangeText, value, showAsError, ...inputProps } = props;
 
   const inputStyle = useMemo(
     () => ({
       ...textVariants.semibold,
       fontSize: 18,
-      color: isValid ? colors.teal : colors.invalid,
+      color: showAsError ? colors.invalid : colors.teal,
     }),
-    [isValid]
+    [showAsError]
   );
 
   return (

--- a/cardstack/src/components/Input/PhraseInput/PhraseInput.tsx
+++ b/cardstack/src/components/Input/PhraseInput/PhraseInput.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, forwardRef, memo } from 'react';
 
 import { Container, Input, BaseInputProps } from '@cardstack/components';
 import { colors, textVariants } from '@cardstack/theme';
-import { Device } from '@cardstack/utils';
+import { Device } from '@cardstack/utils/device';
 
 // Note: This is necessary to account for lack of support for
 // lineHeight in Android;

--- a/cardstack/src/components/Input/PhraseInput/PhraseInput.tsx
+++ b/cardstack/src/components/Input/PhraseInput/PhraseInput.tsx
@@ -43,6 +43,7 @@ const PhraseInput = forwardRef((props: PasswordInputProps, ref) => {
         selectionColor="teal"
         allowFontScaling={false}
         autoCompleteType="off"
+        autoCorrect={false}
         autoCapitalize="none"
         blurOnSubmit={false}
         placeholderTextColor={colors.blueText}

--- a/cardstack/src/components/Input/PhraseInput/PhraseInput.tsx
+++ b/cardstack/src/components/Input/PhraseInput/PhraseInput.tsx
@@ -18,7 +18,7 @@ const PhraseInput = forwardRef((props: PasswordInputProps, ref) => {
   const inputStyle = useMemo(
     () => ({
       ...textVariants.semibold,
-      fontSize: 16,
+      fontSize: 18,
       color: isValid ? colors.teal : colors.invalid,
     }),
     [isValid]

--- a/cardstack/src/components/Input/PhraseInput/PhraseInput.tsx
+++ b/cardstack/src/components/Input/PhraseInput/PhraseInput.tsx
@@ -1,0 +1,59 @@
+import React, { useMemo, forwardRef, memo } from 'react';
+
+import { Container, Input, BaseInputProps } from '@cardstack/components';
+import { colors, textVariants } from '@cardstack/theme';
+import { Device } from '@cardstack/utils';
+
+// Note: This is necessary to account for lack of support for
+// lineHeight in Android;
+const InputHeight = Device.isIOS ? 139 : 110;
+
+interface PasswordInputProps extends BaseInputProps {
+  isValid: boolean;
+}
+
+const PhraseInput = forwardRef((props: PasswordInputProps, ref) => {
+  const { onChangeText, value, isValid = true, ...inputProps } = props;
+
+  const inputStyle = useMemo(
+    () => ({
+      ...textVariants.semibold,
+      fontSize: 16,
+      color: isValid ? colors.teal : colors.invalid,
+    }),
+    [isValid]
+  );
+
+  return (
+    <Container
+      backgroundColor="blueDarkest"
+      borderColor="blueDarkest"
+      borderWidth={1}
+      borderRadius={20}
+    >
+      <Input
+        ref={ref}
+        value={value}
+        onChangeText={onChangeText}
+        textContentType="none"
+        multiline
+        numberOfLines={4}
+        height={InputHeight}
+        lineHeight={30} // Only works on iOS
+        selectionColor="teal"
+        allowFontScaling={false}
+        autoCompleteType="off"
+        autoCapitalize="none"
+        blurOnSubmit={false}
+        placeholderTextColor={colors.blueText}
+        textAlignVertical="top"
+        paddingHorizontal={5}
+        paddingBottom={3}
+        style={inputStyle}
+        {...inputProps}
+      />
+    </Container>
+  );
+});
+
+export default memo(PhraseInput);

--- a/cardstack/src/components/Input/PhraseInput/index.ts
+++ b/cardstack/src/components/Input/PhraseInput/index.ts
@@ -1,0 +1,1 @@
+export { default as PhraseInput } from './PhraseInput';

--- a/cardstack/src/components/Input/index.ts
+++ b/cardstack/src/components/Input/index.ts
@@ -4,3 +4,4 @@ export * from './InputAmount/useInputAmountHelper';
 export { default as FormInput } from './FormInput';
 export { default as PinInput } from './PinInput/PinInput';
 export * from './PasswordInput';
+export * from './PhraseInput';

--- a/cardstack/src/screens/Dev/DesignSystemScreen.tsx
+++ b/cardstack/src/screens/Dev/DesignSystemScreen.tsx
@@ -108,7 +108,7 @@ const DesignSystemScreen = () => {
           />
         );
       case 'phrase':
-        return <PhraseInput isValid />;
+        return <PhraseInput isValid placeholder="Enter your seed phrase" />;
       default:
         return <SuffixedInput suffixText={cardSpaceDomain} />;
     }

--- a/cardstack/src/screens/Dev/DesignSystemScreen.tsx
+++ b/cardstack/src/screens/Dev/DesignSystemScreen.tsx
@@ -9,6 +9,7 @@ import {
   Text,
   SeedPhraseTable,
   SuffixedInput,
+  PhraseInput,
 } from '@cardstack/components';
 import { cardSpaceDomain } from '@cardstack/constants';
 import { buttonVariants } from '@cardstack/theme';
@@ -22,7 +23,7 @@ const DesignSystemScreen = () => {
   const sections = [
     {
       title: 'Input',
-      data: ['slug', 'viewOnly'],
+      data: ['slug', 'viewOnly', 'phrase'],
     },
     {
       title: 'Seed Phrase',
@@ -106,6 +107,8 @@ const DesignSystemScreen = () => {
             readOnly
           />
         );
+      case 'phrase':
+        return <PhraseInput isValid />;
       default:
         return <SuffixedInput suffixText={cardSpaceDomain} />;
     }

--- a/cardstack/src/screens/Dev/DesignSystemScreen.tsx
+++ b/cardstack/src/screens/Dev/DesignSystemScreen.tsx
@@ -23,7 +23,7 @@ const DesignSystemScreen = () => {
   const sections = [
     {
       title: 'Input',
-      data: ['slug', 'viewOnly', 'phrase'],
+      data: ['slug', 'viewOnly', 'phrase', 'phraseError'],
     },
     {
       title: 'Seed Phrase',
@@ -108,7 +108,9 @@ const DesignSystemScreen = () => {
           />
         );
       case 'phrase':
-        return <PhraseInput isValid placeholder="Enter your seed phrase" />;
+        return <PhraseInput placeholder="Enter your seed phrase" />;
+      case 'phraseError':
+        return <PhraseInput showAsError placeholder="Enter your seed phrase" />;
       default:
         return <SuffixedInput suffixText={cardSpaceDomain} />;
     }


### PR DESCRIPTION
### Description

Adds a new component `PhraseInput` for seed phrase recovery.

Notes:
- The implementation does not follow exactly the design, adding the number is tough!
- On android, lineHeight is not respected, so the appearances vary.
- Since numbers are not showing and spacing between words is smaller, the number of lines to show a whole seed phrase is at least 1 line less, so it is looking a bit empty. I accept suggestions on how to make this better :)

Thanks!

- [x] Completes #(CS-4720)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/195947092-8f3762fe-c3cc-4202-a9d6-5298e0dd1e4a.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/195947141-08f882d9-1cfd-44c7-8731-8684260b194e.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/195947229-d68d2ce4-d11e-40d9-9fc1-746ecb60fa1b.png">

