### PR TITLE
Update volta.sh Github Action

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Set up yarn cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ env.CHECKOUT_REF }}
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Setup Ruby & bundle
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ env.CHECKOUT_REF }}
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
       - name: Setup Ruby & bundle
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
### Description
As of today, out Github Actions are breaking because of `volta.sh`. This PR updates its action to the latest version.
