### PR TITLE
Update GH actions Checkout and Cache to v3

### DIFF
--- a/.github/workflows/discord-test.yml
+++ b/.github/workflows/discord-test.yml
@@ -17,8 +17,8 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Checkout tag  
-        uses: actions/checkout@v2
+      - name: Checkout tag
+        uses: actions/checkout@v3
       # Runs a single command to fail
       - name: Force failure
         run: exit 1
@@ -27,7 +27,7 @@ jobs:
         if: ${{ failure() }}
         with:
           nodetails: true
-          webhook: ${{ secrets.DISCORD_WEBHOOK }} 
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
           title: Release iOS to TestFlight
-          description: "Click [here](https://github.com/cardstack/cardwallet/actions/runs/`${{github.run_id}}`) to review the issue"
+          description: 'Click [here](https://github.com/cardstack/cardwallet/actions/runs/`${{github.run_id}}`) to review the issue'
           color: 0xff91a4

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - run: |
           git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
 
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: volta-cli/action@v4
       - name: Set up yarn cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -29,7 +29,7 @@ jobs:
           title: Android release started
           color: 0xFFFFFF
       - name: Checkout tag
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.CHECKOUT_REF }}
       - uses: volta-cli/action@v4
@@ -39,11 +39,11 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Decrypt fastlane vars
         run: yarn fastlane run decrypt_fastlane_vars
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           title: TestFlight release started
           color: 0xFFFFFF
       - name: Checkout tag
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.CHECKOUT_REF }}
       - uses: volta-cli/action@v4
@@ -45,11 +45,11 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Decrypt fastlane vars
         run: bundle exec fastlane run decrypt_fastlane_vars
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: '**/Pods'
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,7 +20,7 @@ jobs:
       BASE_BRANCH: 'develop'
     steps:
       - name: Set environment variables
-        env: 
+        env:
           DEFAULT_VERSION_CHANGE_TYPE: none
           VERSION_CHANGE_BRANCH_TO_TAG: 'release/${{ github.event.inputs.versionChangeType }}-version-${{ github.run_id }}'
         run: |
@@ -34,7 +34,7 @@ jobs:
             echo "BRANCH_TO_TAG=develop" >> $GITHUB_ENV
             echo "VERSION_BUMP=false"
           fi
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ env.BASE_BRANCH }}
       - name: Bump iOS version


### PR DESCRIPTION
### Description
Following the update made on https://github.com/cardstack/cardwallet/pull/1073, this PR also updates both `checkout` and `cache` to v3 in order to start using Node 16 instead of Node 12.
