### PR TITLE
[CS-4759] Remove asterisk from copy on ProfileSlugScreen

### DIFF
--- a/cardstack/src/screens/Profile/ProfileSlugScreen/strings.ts
+++ b/cardstack/src/screens/Profile/ProfileSlugScreen/strings.ts
@@ -5,11 +5,11 @@ export const MIN_SLUG_LENGTH = 4;
 export const strings = {
   header: 'Choose a unique ID that others can use to send you money',
   purchaseDisclaimer: (price: string) =>
-    `* Creating a payment profile will require a one-time ${price} fee.`,
+    `Creating a payment profile will require a one-time ${price} fee.`,
   input: {
     domainSuffix: cardSpaceDomain,
     description:
-      'This unique ID will be used to identify your payment profile.* Please note this ID cannot be changed once the profile is created and may be used as a contact address.',
+      'This unique ID will be used to identify your payment profile. Please note this ID cannot be changed once the profile is created and may be used as a contact address.',
   },
   errors: {
     minLength: `ID must be at least ${MIN_SLUG_LENGTH} characters long`,


### PR DESCRIPTION
### Description
This PR handles the issue with the asterisk in the copy for the ProfileSlugScreen. After some back and forth, we decided to remove the asterisk.

- [x] Completes #CS-4759

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/198111631-71c0b5f5-3966-45f0-a882-ed050780843d.png">

