### PR TITLE
[CS-4797] Enhance test coverage in backup

### DIFF
--- a/cardstack/src/components/Input/PinInput/PinInput.tsx
+++ b/cardstack/src/components/Input/PinInput/PinInput.tsx
@@ -102,6 +102,7 @@ const PinInput = ({
         blurOnSubmit={false}
         underlineColorAndroid="transparent"
         keyboardType="number-pad"
+        returnKeyType="default"
         {...inputProps}
       />
     </Container>

--- a/cardstack/src/models/__tests__/rn-cloud.test.ts
+++ b/cardstack/src/models/__tests__/rn-cloud.test.ts
@@ -1,13 +1,27 @@
+import * as sentry from '@sentry/react-native';
 import RNCloudFs from 'react-native-cloud-fs';
+import RNFS from 'react-native-fs';
 
+import { BackupUserData } from '@cardstack/types';
 import { Device } from '@cardstack/utils';
 
 import AesEncryptor from '@rainbow-me/handlers/aesEncryption';
+import { EthereumWalletType } from '@rainbow-me/helpers/walletTypes';
 import logger from 'logger';
 
-import { deleteAllCloudBackups, getDataFromCloud } from '../rn-cloud';
+import {
+  deleteAllCloudBackups,
+  encryptAndSaveDataToCloud,
+  getDataFromCloud,
+  REMOTE_BACKUP_WALLET_DIR,
+  USERDATA_FILE,
+} from '../rn-cloud';
 
-const mockedBackupData = {
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+const mockedBackupData: BackupUserData = {
   wallets: {
     wallet_1666814362880: {
       addresses: [
@@ -27,10 +41,7 @@ const mockedBackupData = {
       damaged: false,
       name: 'My Wallet',
       primary: true,
-      type: 'mnemonic',
-      backupDate: 1666966010273,
-      backupFile: 'backup_1666966010171.json',
-      backupType: 'cloud',
+      type: EthereumWalletType.mnemonic,
     },
   },
 };
@@ -44,12 +55,17 @@ const mockedListFiles = {
       lastModified: '1657732642021',
     },
     {
-      name: 'UserData.json',
+      name: USERDATA_FILE,
       id: '98765',
       path: 'path/to/file', // iOS only
       lastModified: '1657732642021',
     },
   ],
+};
+
+const mockUserData = {
+  createdAt: 1657732642021,
+  seedPhrase: 'foo bar',
 };
 
 jest.mock('@rainbow-me/handlers/aesEncryption');
@@ -70,6 +86,10 @@ describe('rn-cloud', () => {
   describe('deleteAllCloudBackups', () => {
     RNCloudFs.listFiles = jest.fn().mockReturnValue(mockedListFiles);
     RNCloudFs.deleteFromCloud = jest.fn().mockResolvedValue(true);
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
 
     it(`should get backup files from cloud drive and delete them`, async () => {
       await deleteAllCloudBackups();
@@ -153,6 +173,140 @@ describe('rn-cloud', () => {
       const response = await getDataFromCloud(password, filename);
 
       expect(response).toMatchObject(mockedBackupData);
+    });
+  });
+
+  describe('encryptAndSaveDataToCloud', () => {
+    const captureExceptionSpy = jest.spyOn(sentry, 'captureException');
+    RNFS.writeFile = jest.fn();
+    const password = 'password';
+    const filename = 'backup';
+    const path = `${RNFS.DocumentDirectoryPath}/${filename}`;
+    const sourceUri = { path };
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it(`should return undefined if there's an error encrypting the file`, async () => {
+      AesEncryptor.prototype.encrypt = jest.fn().mockResolvedValue(undefined);
+
+      const response = await encryptAndSaveDataToCloud(
+        mockUserData,
+        password,
+        filename
+      );
+
+      expect(AesEncryptor.prototype.encrypt).toBeCalledWith(
+        password,
+        JSON.stringify(mockUserData)
+      );
+
+      expect(logger.sentry).toBeCalledWith(
+        `[BACKUP] We couldn't encrypt the data`
+      );
+
+      expect(response).toBe(undefined);
+    });
+
+    it(`should call RNFS to save file locally first`, async () => {
+      AesEncryptor.prototype.encrypt = jest
+        .fn()
+        .mockResolvedValue('encryptedBackup');
+
+      await encryptAndSaveDataToCloud(mockUserData, password, filename);
+
+      expect(RNFS.writeFile).toBeCalledWith(path, 'encryptedBackup', 'utf8');
+    });
+
+    it(`should call copyToCloud with the correct params`, async () => {
+      AesEncryptor.prototype.encrypt = jest
+        .fn()
+        .mockResolvedValue('encryptedBackup');
+
+      RNCloudFs.copyToCloud = jest.fn();
+
+      await encryptAndSaveDataToCloud(mockUserData, password, filename);
+
+      expect(RNCloudFs.copyToCloud).toBeCalledWith({
+        mimeType: 'application/json',
+        scope: 'hidden',
+        sourcePath: sourceUri,
+        targetPath: `${REMOTE_BACKUP_WALLET_DIR}/${filename}`,
+      });
+    });
+
+    it(`should call RNCloudFs.fileExists with the correct params for iOS`, async () => {
+      AesEncryptor.prototype.encrypt = jest
+        .fn()
+        .mockResolvedValue('encryptedBackup');
+
+      RNCloudFs.fileExists = jest.fn();
+      RNCloudFs.copyToCloud = jest.fn();
+
+      await encryptAndSaveDataToCloud(mockUserData, password, filename);
+
+      expect(RNCloudFs.fileExists).toBeCalledWith({
+        scope: 'hidden',
+        targetPath: `${REMOTE_BACKUP_WALLET_DIR}/${filename}`,
+      });
+    });
+
+    it(`should call RNCloudFs.fileExists with the correct params for Android`, async () => {
+      Device.isAndroid = true;
+      Device.isIOS = false;
+
+      AesEncryptor.prototype.encrypt = jest
+        .fn()
+        .mockResolvedValue('encryptedBackup');
+
+      RNCloudFs.copyToCloud = jest.fn().mockReturnValue('fileId');
+      RNCloudFs.loginIfNeeded = jest.fn();
+      RNCloudFs.fileExists = jest.fn();
+
+      await encryptAndSaveDataToCloud(mockUserData, password, filename);
+
+      expect(RNCloudFs.fileExists).toBeCalledWith({
+        scope: 'hidden',
+        fileId: 'fileId',
+      });
+    });
+
+    it(`should return undefined if file doesn't exist in the cloud`, async () => {
+      AesEncryptor.prototype.encrypt = jest
+        .fn()
+        .mockResolvedValue('encryptedBackup');
+
+      RNCloudFs.copyToCloud = jest.fn().mockReturnValue('');
+      RNCloudFs.fileExists = jest.fn().mockResolvedValue(false);
+
+      const response = await encryptAndSaveDataToCloud(
+        mockUserData,
+        password,
+        filename
+      );
+
+      expect(captureExceptionSpy).toBeCalled();
+      expect(response).toBe(undefined);
+    });
+
+    it(`should return the filename if saving to the cloud was successful`, async () => {
+      AesEncryptor.prototype.encrypt = jest
+        .fn()
+        .mockResolvedValue('encryptedBackup');
+
+      RNCloudFs.copyToCloud = jest.fn().mockReturnValue('');
+      RNCloudFs.fileExists = jest.fn().mockResolvedValue(true);
+      RNFS.unlink = jest.fn().mockResolvedValue(true);
+
+      const response = await encryptAndSaveDataToCloud(
+        mockUserData,
+        password,
+        filename
+      );
+
+      expect(RNFS.unlink).toBeCalledWith(path);
+      expect(response).toBe(filename);
     });
   });
 });

--- a/cardstack/src/models/__tests__/rn-cloud.test.ts
+++ b/cardstack/src/models/__tests__/rn-cloud.test.ts
@@ -1,0 +1,158 @@
+import RNCloudFs from 'react-native-cloud-fs';
+
+import { Device } from '@cardstack/utils';
+
+import AesEncryptor from '@rainbow-me/handlers/aesEncryption';
+import logger from 'logger';
+
+import { deleteAllCloudBackups, getDataFromCloud } from '../rn-cloud';
+
+const mockedBackupData = {
+  wallets: {
+    wallet_1666814362880: {
+      addresses: [
+        {
+          address: '0xa47052b',
+          avatar: null,
+          color: 6,
+          index: 0,
+          label: '',
+        },
+      ],
+      backedUp: true,
+      color: 0,
+      id: 'wallet_1666814362880',
+      imported: true,
+      manuallyBackedUp: true,
+      damaged: false,
+      name: 'My Wallet',
+      primary: true,
+      type: 'mnemonic',
+      backupDate: 1666966010273,
+      backupFile: 'backup_1666966010171.json',
+      backupType: 'cloud',
+    },
+  },
+};
+
+const mockedListFiles = {
+  files: [
+    {
+      name: 'backup',
+      id: '123456',
+      path: 'path/to/file', // iOS only
+      lastModified: '1657732642021',
+    },
+    {
+      name: 'UserData.json',
+      id: '98765',
+      path: 'path/to/file', // iOS only
+      lastModified: '1657732642021',
+    },
+  ],
+};
+
+jest.mock('@rainbow-me/handlers/aesEncryption');
+
+describe('rn-cloud', () => {
+  Device.isIOS = true;
+  Device.cloudPlatform = 'iCloud';
+
+  beforeAll(() => {
+    logger.sentry = jest.fn();
+    logger.log = jest.fn();
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('deleteAllCloudBackups', () => {
+    RNCloudFs.listFiles = jest.fn().mockReturnValue(mockedListFiles);
+    RNCloudFs.deleteFromCloud = jest.fn().mockResolvedValue(true);
+
+    it(`should get backup files from cloud drive and delete them`, async () => {
+      await deleteAllCloudBackups();
+
+      expect(RNCloudFs.listFiles).toBeCalledTimes(1);
+      expect(RNCloudFs.deleteFromCloud).toBeCalledTimes(2);
+    });
+  });
+
+  describe('getDataFromCloud', () => {
+    const password = 'password';
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it(`should return undefined if there's no backup file on the remote directory`, async () => {
+      RNCloudFs.listFiles = jest.fn().mockReturnValue({ files: [] });
+      const filename = 'UserData.json';
+
+      const response = await getDataFromCloud(password, filename);
+
+      expect(logger.sentry).toBeCalledWith('[BACKUP] No backups found');
+      expect(response).toBe(undefined);
+    });
+
+    it(`should return undefined if there's no file in the remote dir that matches the filename passed`, async () => {
+      RNCloudFs.listFiles = jest.fn().mockReturnValue(mockedListFiles);
+
+      const response = await getDataFromCloud(password, 'foo');
+
+      expect(logger.sentry).toBeCalledWith(
+        '[BACKUP] No backup found with that name: ',
+        'foo'
+      );
+
+      expect(response).toBe(undefined);
+    });
+
+    it(`should return undefined if encrypted backup document wasn't found`, async () => {
+      RNCloudFs.listFiles = jest.fn().mockReturnValue(mockedListFiles);
+      RNCloudFs.getIcloudDocument = jest.fn().mockResolvedValue(false);
+
+      const filename = 'UserData.json';
+      const response = await getDataFromCloud(password, filename);
+
+      expect(logger.sentry).toBeCalledWith(
+        `[BACKUP] We couldn't get the encrypted data for: `,
+        mockedListFiles.files[1]
+      );
+
+      expect(response).toBe(undefined);
+    });
+
+    it(`should return undefined if the document couldn't be decrypted`, async () => {
+      RNCloudFs.listFiles = jest.fn().mockReturnValue(mockedListFiles);
+      RNCloudFs.getIcloudDocument = jest.fn().mockResolvedValue('backup');
+      AesEncryptor.prototype.decrypt = jest.fn().mockResolvedValue(undefined);
+
+      const filename = 'UserData.json';
+      const response = await getDataFromCloud(password, filename);
+
+      expect(logger.sentry).toBeCalledWith(
+        `[BACKUP] We couldn't decrypt the data `,
+        filename
+      );
+
+      expect(response).toBe(undefined);
+    });
+
+    it(`should return a parsed backup data JSON file`, async () => {
+      RNCloudFs.listFiles = jest.fn().mockReturnValue(mockedListFiles);
+      RNCloudFs.getIcloudDocument = jest.fn().mockResolvedValue('backup');
+      const stringifyMockedBackupData = JSON.stringify(mockedBackupData);
+
+      AesEncryptor.prototype.decrypt = jest
+        .fn()
+        .mockResolvedValue(stringifyMockedBackupData);
+
+      const filename = 'UserData.json';
+      const response = await getDataFromCloud(password, filename);
+
+      expect(response).toMatchObject(mockedBackupData);
+    });
+  });
+});

--- a/cardstack/src/models/__tests__/rn-cloud.test.ts
+++ b/cardstack/src/models/__tests__/rn-cloud.test.ts
@@ -113,7 +113,7 @@ describe('rn-cloud', () => {
       const response = await getDataFromCloud(password, filename);
 
       expect(logger.sentry).toBeCalledWith('[BACKUP] No backups found');
-      expect(response).toBe(undefined);
+      expect(response).toBeUndefined();
     });
 
     it(`should return undefined if there's no file in the remote dir that matches the filename passed`, async () => {
@@ -126,7 +126,7 @@ describe('rn-cloud', () => {
         'foo'
       );
 
-      expect(response).toBe(undefined);
+      expect(response).toBeUndefined();
     });
 
     it(`should return undefined if encrypted backup document wasn't found`, async () => {
@@ -141,7 +141,7 @@ describe('rn-cloud', () => {
         mockedListFiles.files[1]
       );
 
-      expect(response).toBe(undefined);
+      expect(response).toBeUndefined();
     });
 
     it(`should return undefined if the document couldn't be decrypted`, async () => {
@@ -157,7 +157,7 @@ describe('rn-cloud', () => {
         filename
       );
 
-      expect(response).toBe(undefined);
+      expect(response).toBeUndefined();
     });
 
     it(`should return a parsed backup data JSON file`, async () => {
@@ -206,7 +206,7 @@ describe('rn-cloud', () => {
         `[BACKUP] We couldn't encrypt the data`
       );
 
-      expect(response).toBe(undefined);
+      expect(response).toBeUndefined();
     });
 
     it(`should call RNFS to save file locally first`, async () => {
@@ -287,7 +287,7 @@ describe('rn-cloud', () => {
       );
 
       expect(captureExceptionSpy).toBeCalled();
-      expect(response).toBe(undefined);
+      expect(response).toBeUndefined();
     });
 
     it(`should return the filename if saving to the cloud was successful`, async () => {

--- a/cardstack/src/models/rn-cloud.ts
+++ b/cardstack/src/models/rn-cloud.ts
@@ -1,4 +1,5 @@
 import { captureException } from '@sentry/react-native';
+import { OptionalUnion } from 'globals';
 import RNCloudFs, { ListFilesResult } from 'react-native-cloud-fs';
 import { CARDWALLET_MASTER_KEY } from 'react-native-dotenv';
 import RNFS from 'react-native-fs';
@@ -90,7 +91,7 @@ const getBackupDocumentByFilename = (
 export const getDataFromCloud = async (
   backupPassword: string,
   filename: string
-): Promise<BackupSecretsData | BackupUserData | undefined> => {
+): Promise<OptionalUnion<BackupSecretsData, BackupUserData> | undefined> => {
   if (Device.isAndroid) {
     await RNCloudFs.loginIfNeeded();
   }

--- a/cardstack/src/models/rn-cloud.ts
+++ b/cardstack/src/models/rn-cloud.ts
@@ -12,8 +12,8 @@ import { Alert } from '@rainbow-me/components/alerts';
 import AesEncryptor from '@rainbow-me/handlers/aesEncryption';
 import logger from 'logger';
 
-const REMOTE_BACKUP_WALLET_DIR = 'cardstack.com/wallet-backups';
-const USERDATA_FILE = 'UserData.json';
+export const REMOTE_BACKUP_WALLET_DIR = 'cardstack.com/wallet-backups';
+export const USERDATA_FILE = 'UserData.json';
 const encryptor = new AesEncryptor();
 
 export const CLOUD_BACKUP_ERRORS = {
@@ -162,6 +162,8 @@ export const encryptAndSaveDataToCloud = async (
     );
 
     if (!encryptedData) {
+      logger.sentry(`[BACKUP] We couldn't encrypt the data`);
+
       return;
     }
 

--- a/cardstack/src/screens/Backup/BackupCloudPasswordScreen/__tests__/useBackupCloudPasswordScreen.test.ts
+++ b/cardstack/src/screens/Backup/BackupCloudPasswordScreen/__tests__/useBackupCloudPasswordScreen.test.ts
@@ -54,7 +54,7 @@ describe('useBackupCloudPasswordScreen', () => {
     jest.clearAllMocks();
   });
 
-  it(`isSubmitDisabled should be true if checkbox isn't checked`, () => {
+  it(`should have isSubmitDisabled as true if checkbox isn't checked`, () => {
     mockUsePasswordInput({ isValid: true });
 
     const { result } = renderHook(useBackupCloudPasswordScreen);
@@ -62,7 +62,7 @@ describe('useBackupCloudPasswordScreen', () => {
     expect(result.current.isSubmitDisabled).toBe(true);
   });
 
-  it(`isSubmitDisabled should be true if both password fields are not valid`, () => {
+  it(`should have isSubmitDisabled as true if both password fields are not valid`, () => {
     mockUsePasswordInput({ isValid: false });
 
     const { result } = renderHook(useBackupCloudPasswordScreen);
@@ -74,7 +74,7 @@ describe('useBackupCloudPasswordScreen', () => {
     expect(result.current.isSubmitDisabled).toBe(true);
   });
 
-  it(`isSubmitDisabled should be false if both password fields are valid and checkbox is checked`, () => {
+  it(`should have isSubmitDisabled as false if both password fields are valid and checkbox is checked`, () => {
     mockUsePasswordInput({ isValid: true });
 
     const { result } = renderHook(useBackupCloudPasswordScreen);

--- a/cardstack/src/screens/Backup/BackupCloudPasswordScreen/__tests__/useBackupCloudPasswordScreen.test.ts
+++ b/cardstack/src/screens/Backup/BackupCloudPasswordScreen/__tests__/useBackupCloudPasswordScreen.test.ts
@@ -1,0 +1,127 @@
+import { StackActions, useRoute } from '@react-navigation/native';
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import { usePasswordInput } from '@cardstack/components';
+
+import { BackupRouteParams } from '../../types';
+import { useBackupCloudPasswordScreen } from '../useBackupCloudPasswordScreen';
+
+const mockNavDispatch = jest.fn();
+const mockNavigateOnboarding = jest.fn();
+const mockBackupToCloud = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ dispatch: mockNavDispatch }),
+  useRoute: jest.fn(),
+  StackActions: { pop: jest.fn() },
+}));
+
+jest.mock('@cardstack/hooks/onboarding/useShowOnboarding', () => ({
+  useShowOnboarding: () => ({
+    navigateToNextOnboardingStep: mockNavigateOnboarding,
+  }),
+}));
+
+jest.mock('@cardstack/hooks/backup/useWalletCloudBackup', () => ({
+  useWalletCloudBackup: () => ({ backupToCloud: mockBackupToCloud }),
+}));
+
+jest.mock('@cardstack/components/Input/PasswordInput/usePasswordInput', () => ({
+  usePasswordInput: jest.fn(),
+}));
+
+describe('useBackupCloudPasswordScreen', () => {
+  const mockUseRoute = (params?: Partial<BackupRouteParams>) => {
+    (useRoute as jest.Mock).mockImplementation(() => ({
+      params,
+    }));
+  };
+
+  const mockUsePasswordInput = (
+    overwriteParams: Partial<ReturnType<typeof usePasswordInput>> = {}
+  ) =>
+    (usePasswordInput as jest.Mock).mockImplementation(() => ({
+      password: 'passw0rd',
+      isValid: false,
+      ...overwriteParams,
+    }));
+
+  beforeEach(() => {
+    mockUseRoute();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`isSubmitDisabled should be true if checkbox isn't checked`, () => {
+    mockUsePasswordInput({ isValid: true });
+
+    const { result } = renderHook(useBackupCloudPasswordScreen);
+
+    expect(result.current.isSubmitDisabled).toBe(true);
+  });
+
+  it(`isSubmitDisabled should be true if both password fields are not valid`, () => {
+    mockUsePasswordInput({ isValid: false });
+
+    const { result } = renderHook(useBackupCloudPasswordScreen);
+
+    act(() => {
+      result.current.onCheckboxPress();
+    });
+
+    expect(result.current.isSubmitDisabled).toBe(true);
+  });
+
+  it(`isSubmitDisabled should be false if both password fields are valid and checkbox is checked`, () => {
+    mockUsePasswordInput({ isValid: true });
+
+    const { result } = renderHook(useBackupCloudPasswordScreen);
+
+    act(() => {
+      result.current.onCheckboxPress();
+    });
+
+    expect(result.current.isSubmitDisabled).toBe(false);
+  });
+
+  it(`should call backupToCloud with password`, async () => {
+    mockUsePasswordInput({ password: 'password' });
+
+    const { result } = renderHook(useBackupCloudPasswordScreen);
+
+    await act(async () => {
+      await result.current.handleBackupToCloud();
+    });
+
+    expect(mockBackupToCloud).toBeCalledTimes(1);
+    expect(mockBackupToCloud).toBeCalledWith({ password: 'password' });
+  });
+
+  it(`should pop the navigation stack if popStackOnSuccess param is present`, async () => {
+    mockUseRoute({ popStackOnSuccess: 1 });
+
+    const { result } = renderHook(useBackupCloudPasswordScreen);
+
+    await act(async () => {
+      await result.current.handleBackupToCloud();
+    });
+
+    expect(mockBackupToCloud).toBeCalledTimes(1);
+    expect(mockNavDispatch).toBeCalledTimes(1);
+    expect(mockNavDispatch).toBeCalledWith(StackActions.pop(1));
+  });
+
+  it(`should call navigateToNextOnboardingStep if popStackOnSuccess param isn't present`, async () => {
+    const { result } = renderHook(useBackupCloudPasswordScreen);
+
+    await act(async () => {
+      await result.current.handleBackupToCloud();
+    });
+
+    expect(mockBackupToCloud).toBeCalledTimes(1);
+    expect(mockNavDispatch).not.toBeCalled();
+    expect(mockNavigateOnboarding).toBeCalledTimes(1);
+  });
+});

--- a/cardstack/src/screens/Backup/BackupRestoreCloudScreen/__tests__/useBackupRestoreCloudScreen.test.ts
+++ b/cardstack/src/screens/Backup/BackupRestoreCloudScreen/__tests__/useBackupRestoreCloudScreen.test.ts
@@ -98,7 +98,7 @@ describe('useBackupRestoreCloudScreen', () => {
     jest.clearAllMocks();
   });
 
-  it(`isSubmitDisable should be true if password input is empty`, () => {
+  it(`should have isSubmitDisabled as true if password input is empty`, () => {
     mockUsePasswordInput({ password: undefined });
 
     const { result } = renderHook(useBackupRestoreCloudScreen);
@@ -106,7 +106,7 @@ describe('useBackupRestoreCloudScreen', () => {
     expect(result.current.isSubmitDisabled).toBe(true);
   });
 
-  it(`isSubmitDisable should be false if password input has at least one character`, () => {
+  it(`should have isSubmitDisabled as false if password input has at least one character`, () => {
     mockUsePasswordInput({ password: 'p' });
 
     const { result } = renderHook(useBackupRestoreCloudScreen);

--- a/cardstack/src/screens/Backup/BackupRestoreCloudScreen/__tests__/useBackupRestoreCloudScreen.test.ts
+++ b/cardstack/src/screens/Backup/BackupRestoreCloudScreen/__tests__/useBackupRestoreCloudScreen.test.ts
@@ -1,0 +1,199 @@
+import { useRoute } from '@react-navigation/native';
+import * as sentry from '@sentry/react-native';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { Alert } from 'react-native';
+
+import { usePasswordInput } from '@cardstack/components';
+import * as backupModel from '@cardstack/models/backup';
+
+import { EthereumWalletType } from '@rainbow-me/helpers/walletTypes';
+import logger from 'logger';
+
+import { strings } from '../strings';
+import { useBackupRestoreCloudScreen } from '../useBackupRestoreCloudScreen';
+
+const mockedBackupData = {
+  wallets: {
+    wallet_1666814362880: {
+      addresses: [
+        {
+          address: '0xa47052b',
+          avatar: null,
+          color: 6,
+          index: 0,
+          label: '',
+        },
+      ],
+      backedUp: true,
+      color: 0,
+      id: 'wallet_1666814362880',
+      imported: true,
+      manuallyBackedUp: true,
+      damaged: false,
+      name: 'My Wallet',
+      primary: true,
+      type: EthereumWalletType.mnemonic,
+    },
+  },
+};
+
+const mockSeedPhrase =
+  'loan velvet fall cluster renew animal trophy clinic adjust fix soon enrich';
+
+jest.mock('@react-navigation/native', () => ({
+  useRoute: jest.fn(),
+}));
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+const mockDismissOverlay = jest.fn();
+const mockShowOverlay = jest.fn();
+const mockDismissKeyboard = jest.fn();
+
+jest.mock('@cardstack/navigation', () => ({
+  useLoadingOverlay: () => ({
+    showLoadingOverlay: mockShowOverlay,
+    dismissLoadingOverlay: mockDismissOverlay,
+  }),
+  dismissKeyboardOnAndroid: () => mockDismissKeyboard,
+}));
+
+const mockedImportWallet = jest.fn();
+
+jest.mock('@rainbow-me/hooks', () => ({
+  useWalletManager: () => ({ importWallet: mockedImportWallet }),
+}));
+
+jest.mock('@cardstack/components/Input/PasswordInput/usePasswordInput', () => ({
+  usePasswordInput: jest.fn(),
+}));
+
+describe('useBackupRestoreCloudScreen', () => {
+  const restoreCloudBackupSpy = jest.spyOn(backupModel, 'restoreCloudBackup');
+  const spyAlert = jest.spyOn(Alert, 'alert');
+  const captureExceptionSpy = jest.spyOn(sentry, 'captureException');
+
+  const mockUsePasswordInput = (
+    overwriteParams: Partial<ReturnType<typeof usePasswordInput>> = {}
+  ) =>
+    (usePasswordInput as jest.Mock).mockImplementation(() => ({
+      password: 'passw0rd',
+      isValid: false,
+      ...overwriteParams,
+    }));
+
+  (useRoute as jest.Mock).mockReturnValue({
+    params: {
+      userData: mockedBackupData,
+    },
+  });
+
+  beforeAll(() => {
+    logger.sentry = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`isSubmitDisable should be true if password input is empty`, () => {
+    mockUsePasswordInput({ password: undefined });
+
+    const { result } = renderHook(useBackupRestoreCloudScreen);
+
+    expect(result.current.isSubmitDisabled).toBe(true);
+  });
+
+  it(`isSubmitDisable should be false if password input has at least one character`, () => {
+    mockUsePasswordInput({ password: 'p' });
+
+    const { result } = renderHook(useBackupRestoreCloudScreen);
+
+    expect(result.current.isSubmitDisabled).toBe(false);
+  });
+
+  it(`should call restoreCloudBackup with password and wallet data`, async () => {
+    mockUsePasswordInput({ password: 'passw0rd' });
+
+    restoreCloudBackupSpy.mockResolvedValue({
+      restoredSeed: mockSeedPhrase,
+      backedUpWallet: mockedBackupData.wallets.wallet_1666814362880,
+    });
+
+    const { result } = renderHook(useBackupRestoreCloudScreen);
+
+    await act(async () => {
+      await result.current.handleRestoreOnPress();
+    });
+
+    expect(restoreCloudBackupSpy).toBeCalledTimes(1);
+    expect(restoreCloudBackupSpy).toBeCalledWith('passw0rd', mockedBackupData);
+  });
+
+  it(`should show an Alert and call Sentry's captureException if restoreCloudBackup returns undefined`, async () => {
+    restoreCloudBackupSpy.mockResolvedValue(undefined);
+
+    const { result } = renderHook(useBackupRestoreCloudScreen);
+
+    await act(async () => {
+      await result.current.handleRestoreOnPress();
+    });
+
+    expect(mockDismissOverlay).toBeCalledTimes(1);
+    expect(spyAlert).toBeCalledWith(
+      strings.errorMessage.title,
+      strings.errorMessage.message,
+      undefined,
+      undefined
+    );
+
+    expect(captureExceptionSpy).toBeCalled();
+  });
+
+  it(`should call importWallet with restoredInfo returned data`, async () => {
+    mockUsePasswordInput({ password: 'passw0rd' });
+
+    restoreCloudBackupSpy.mockResolvedValue({
+      restoredSeed: mockSeedPhrase,
+      backedUpWallet: mockedBackupData.wallets.wallet_1666814362880,
+    });
+
+    const { result } = renderHook(useBackupRestoreCloudScreen);
+
+    await act(async () => {
+      await result.current.handleRestoreOnPress();
+    });
+
+    expect(mockedImportWallet).toBeCalledTimes(1);
+    expect(mockedImportWallet).toBeCalledWith({
+      seed: mockSeedPhrase,
+      backedUpWallet: mockedBackupData.wallets.wallet_1666814362880,
+    });
+  });
+
+  it(`should show error message in case of any error`, async () => {
+    mockUsePasswordInput({ password: 'passw0rd' });
+    restoreCloudBackupSpy.mockResolvedValue({
+      restoredSeed: mockSeedPhrase,
+      backedUpWallet: mockedBackupData.wallets.wallet_1666814362880,
+    });
+
+    mockedImportWallet.mockRejectedValue(new Error('Fake error'));
+
+    const { result } = renderHook(useBackupRestoreCloudScreen);
+
+    await act(async () => {
+      await result.current.handleRestoreOnPress();
+    });
+
+    expect(mockDismissOverlay).toBeCalledTimes(2);
+    expect(spyAlert).toBeCalledWith(
+      strings.errorMessage.title,
+      strings.errorMessage.message,
+      undefined,
+      undefined
+    );
+  });
+});

--- a/cardstack/src/screens/Backup/BackupRestoreExplanationScreen/__tests__/useBackupRestoreExplanationScreen.test.ts
+++ b/cardstack/src/screens/Backup/BackupRestoreExplanationScreen/__tests__/useBackupRestoreExplanationScreen.test.ts
@@ -1,0 +1,127 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { Alert } from 'react-native';
+
+import * as rnCloud from '@cardstack/models/rn-cloud';
+import { Routes } from '@cardstack/navigation';
+import { BackupUserData } from '@cardstack/types';
+
+import { EthereumWalletType } from '@rainbow-me/helpers/walletTypes';
+import logger from 'logger';
+
+import { strings } from '../strings';
+import { useBackupRestoreExplanationScreen } from '../useBackupRestoreExplanationScreen';
+
+const mockNavigate = jest.fn();
+const mockDismissOverlay = jest.fn();
+const mockShowOverlay = jest.fn();
+
+const mockedBackupData: BackupUserData = {
+  wallets: {
+    wallet_1666814362880: {
+      addresses: [
+        {
+          address: '0xa47052b',
+          avatar: null,
+          color: 6,
+          index: 0,
+          label: '',
+        },
+      ],
+      backedUp: true,
+      color: 0,
+      id: 'wallet_1666814362880',
+      imported: true,
+      manuallyBackedUp: true,
+      damaged: false,
+      name: 'My Wallet',
+      primary: true,
+      type: EthereumWalletType.mnemonic,
+    },
+  },
+};
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('@cardstack/navigation', () => ({
+  Routes: {
+    BACKUP_RESTORE_PHRASE: 'BackupRestorePhraseScreen',
+    BACKUP_RESTORE_CLOUD: 'BackupRestoreCloud',
+  },
+  useLoadingOverlay: () => ({
+    showLoadingOverlay: mockShowOverlay,
+    dismissLoadingOverlay: mockDismissOverlay,
+  }),
+}));
+
+describe('useBackupRestoreExplanationScreen', () => {
+  const spyAlert = jest.spyOn(Alert, 'alert');
+
+  const spyFetchUserDataFromCloud = jest.spyOn(
+    rnCloud,
+    'fetchUserDataFromCloud'
+  );
+
+  beforeAll(() => {
+    logger.sentry = jest.fn();
+    logger.log = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should navigate to the restore seed phrase screen after calling handleRestorePhraseOnPress', () => {
+    const { result } = renderHook(useBackupRestoreExplanationScreen);
+
+    act(() => {
+      result.current.handleRestorePhraseOnPress();
+    });
+
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(Routes.BACKUP_RESTORE_PHRASE);
+  });
+
+  it('should navigate to the restore cloud backup screen after calling handleRestoreCloudOnPress with UserData.json as route param', async () => {
+    spyFetchUserDataFromCloud.mockResolvedValueOnce(mockedBackupData);
+    const { result } = renderHook(useBackupRestoreExplanationScreen);
+
+    await act(async () => {
+      await result.current.handleRestoreCloudOnPress();
+    });
+
+    expect(mockShowOverlay).toBeCalledWith({
+      title: 'Fetching backup information...',
+    });
+
+    expect(spyFetchUserDataFromCloud).toBeCalledTimes(1);
+
+    expect(mockNavigate).toBeCalledTimes(1);
+    expect(mockNavigate).toBeCalledWith(Routes.BACKUP_RESTORE_CLOUD, {
+      userData: mockedBackupData,
+    });
+  });
+
+  it(`should show an Alert if there's no backup to restore`, async () => {
+    spyFetchUserDataFromCloud.mockRejectedValueOnce(undefined);
+    const { result } = renderHook(useBackupRestoreExplanationScreen);
+
+    await act(async () => {
+      await result.current.handleRestoreCloudOnPress();
+    });
+
+    expect(mockShowOverlay).toBeCalledWith({
+      title: 'Fetching backup information...',
+    });
+
+    expect(spyFetchUserDataFromCloud).toBeCalledTimes(1);
+
+    expect(spyAlert).toBeCalledWith(
+      strings.errorMessage.title,
+      strings.errorMessage.message,
+      undefined,
+      undefined
+    );
+  });
+});

--- a/cardstack/src/screens/Backup/BackupRestoreExplanationScreen/useBackupRestoreExplanationScreen.ts
+++ b/cardstack/src/screens/Backup/BackupRestoreExplanationScreen/useBackupRestoreExplanationScreen.ts
@@ -5,7 +5,7 @@ import { fetchUserDataFromCloud } from '@cardstack/models/rn-cloud';
 import { Routes, useLoadingOverlay } from '@cardstack/navigation';
 
 import { Alert } from '@rainbow-me/components/alerts';
-import { logger } from '@rainbow-me/utils';
+import logger from 'logger';
 
 import { strings } from './strings';
 

--- a/src/components/settings-menu/DeveloperSettings.js
+++ b/src/components/settings-menu/DeveloperSettings.js
@@ -3,7 +3,7 @@ import { useNavigation } from '@react-navigation/native';
 import React, { useCallback } from 'react';
 import { ScrollView } from 'react-native';
 import { ListFooter, ListItem } from '../list';
-import { deleteAllBackups } from '@cardstack/models/rn-cloud';
+import { deleteAllCloudBackups } from '@cardstack/models/rn-cloud';
 import { Routes } from '@cardstack/navigation';
 import GanacheUtils, { restartApp } from '@cardstack/utils';
 import { resetWallet } from '@rainbow-me/model/wallet';
@@ -31,7 +31,7 @@ const DeveloperSettings = () => {
         testID="reset-keychain-section"
       />
       <ListItem label="🔄 Restart app" onPress={restartApp} />
-      <ListItem label="🗑️ Remove all backups" onPress={deleteAllBackups} />
+      <ListItem label="🗑️ Remove all backups" onPress={deleteAllCloudBackups} />
       <ListItem
         label="‍👾 Connect to ganache"
         onPress={connectToGanache}


### PR DESCRIPTION
### Description

- [x] Completes #CS-4797

Opening this PR as a draft because there will be a lot of lines to be reviewed.

Two things that I noticed while writing the tests:
1. Adding a default `returnKeyType` to the `Input` component added a weird "done" bar on top of the number-pad keyboard in the PinScreen. There's a commit that overrides that.
2. DeveloperSettings screen was using the wrong function name from `rn-cloud`. I remember Dani mentioned that sometime and I was sure I had changed, but seems like I didn't. Sorry!



