### PR TITLE
[CS-4794] Remote config for controlling Wyre

### DIFF
--- a/cardstack/src/components/AssetList/components/AssetSectionHeader.tsx
+++ b/cardstack/src/components/AssetList/components/AssetSectionHeader.tsx
@@ -7,7 +7,7 @@ import {
   Text,
 } from '@cardstack/components';
 import { PinnedHiddenSectionMenu } from '@cardstack/components/PinnedHiddenSection';
-import { Device } from '@cardstack/utils';
+import { useRemoteConfigs } from '@cardstack/hooks';
 
 import { PinnedHiddenSectionOption } from '@rainbow-me/hooks';
 
@@ -24,6 +24,10 @@ const AssetSectionHeader = ({ section, onBuyCardPress }: AssetSectionProps) => {
     header: { type, title, count, showContextMenu, total },
     data,
   } = section;
+
+  const {
+    configs: { featureWyre },
+  } = useRemoteConfigs();
 
   const isPrepaidCardSection = useMemo(
     () => type === PinnedHiddenSectionOption.PREPAID_CARDS,
@@ -68,7 +72,7 @@ const AssetSectionHeader = ({ section, onBuyCardPress }: AssetSectionProps) => {
           {showContextMenu && <PinnedHiddenSectionMenu type={type} />}
         </Container>
       </Container>
-      {isPrepaidCardSection && Device.supportsFiatOnRamp && (
+      {isPrepaidCardSection && featureWyre && (
         <Container
           paddingBottom={4}
           alignItems="center"

--- a/cardstack/src/services/remote-config/remote-config-service.ts
+++ b/cardstack/src/services/remote-config/remote-config-service.ts
@@ -42,4 +42,5 @@ export const remoteFlags = (): { [K in ConfigKey]: RemoteConfigValues[K] } => ({
   ),
   betaAccessGranted: getRemoteConfigAsBoolean('betaAccessGranted'),
   useHttpSokolNode: getRemoteConfigAsBoolean('useHttpSokolNode'),
+  featureWyre: getRemoteConfigAsBoolean('featureWyre'),
 });

--- a/cardstack/src/services/remote-config/remoteConfigDefaults.ts
+++ b/cardstack/src/services/remote-config/remoteConfigDefaults.ts
@@ -8,4 +8,5 @@ export const remoteConfigDefaults = {
   featureProfilePurchaseOnboarding: false,
   betaAccessGranted: false,
   useHttpSokolNode: true,
+  featureWyre: false,
 };

--- a/cardstack/src/utils/device.ts
+++ b/cardstack/src/utils/device.ts
@@ -14,17 +14,14 @@ const Device = {
   screenWidth,
   cloudPlatform: isIOS ? 'iCloud' : 'Google Drive',
   keyboardBehavior: 'padding' as const,
-  supportsNativeWyreIntegration: isIOS,
   supportsHapticFeedback: isIOS,
   scrollSheetOffset: isIOS ? -(screenHeight * 0.2) : 1,
-  tabBarHeightSize: screenHeight * 0.1,
   keyboardEventWillShow: isIOS
     ? ('keyboardWillShow' as const)
     : ('keyboardDidShow' as const),
   keyboardEventWillHide: isIOS
     ? ('keyboardWillHide' as const)
     : ('keyboardDidHide' as const),
-  enableBackup: true,
   iap: {
     provider: isIOS ? IAPProviderType.apple : IAPProviderType.google,
     type: isIOS ? ('iap' as const) : ('inapp' as const),

--- a/cardstack/src/utils/device.ts
+++ b/cardstack/src/utils/device.ts
@@ -14,7 +14,6 @@ const Device = {
   screenWidth,
   cloudPlatform: isIOS ? 'iCloud' : 'Google Drive',
   keyboardBehavior: 'padding' as const,
-  supportsFiatOnRamp: isIOS,
   supportsNativeWyreIntegration: isIOS,
   supportsHapticFeedback: isIOS,
   scrollSheetOffset: isIOS ? -(screenHeight * 0.2) : 1,


### PR DESCRIPTION
### Description

This PR adds a new remote config for controlling prepaid card issuing with Wyre, the flag is called `featureWyre`.
It also removes the Device flag since we can set the flag in firebase to be true for iOS only (use "iOS only" rule). 

`featureWyre` is set to true for iOS right now for testing, it should be switched to false before release.

- [x] Completes #(CS-4794)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

"Buy Prepaid Card" button will be hidden.

<img src="https://user-images.githubusercontent.com/129619/199020576-ba959970-60f5-46bb-b2b2-b7a1682e3fef.png" width="300px" >

