### PR TITLE
[CS-4826] Handle wallet navigation after dApp notification

### DIFF
--- a/cardstack/src/hooks/transaction-confirmation/use-close-screen.ts
+++ b/cardstack/src/hooks/transaction-confirmation/use-close-screen.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { InteractionManager } from 'react-native';
 import { useDispatch } from 'react-redux';
 
+import { Routes } from '@cardstack/navigation';
 import { WCRedirectTypes } from '@cardstack/screens/sheets/WalletConnectRedirectSheet';
 
 import { useGas } from '@rainbow-me/hooks';
@@ -17,7 +18,7 @@ import { useRouteParams } from './use-route-params';
 
 export const useCloseScreen = () => {
   const dispatch = useDispatch();
-  const { goBack } = useNavigation();
+  const { goBack, canGoBack, navigate } = useNavigation();
 
   const pendingRedirect = useRainbowSelector(
     ({ walletconnect }) => walletconnect.pendingRedirect
@@ -36,7 +37,11 @@ export const useCloseScreen = () => {
 
   const closeScreen = useCallback(
     canceled => {
-      goBack();
+      if (canGoBack()) {
+        goBack();
+      } else {
+        navigate(Routes.WALLET_SCREEN);
+      }
 
       if (!isMessageRequest) {
         stopPollingGasPrices();
@@ -68,6 +73,8 @@ export const useCloseScreen = () => {
       method,
       dappScheme,
       dispatch,
+      canGoBack,
+      navigate,
     ]
   );
 

--- a/cardstack/src/redux/requests.ts
+++ b/cardstack/src/redux/requests.ts
@@ -1,6 +1,7 @@
 import { AnyAction } from '@reduxjs/toolkit';
 import { filter, get, omit, values } from 'lodash';
 
+import { Navigation, Routes } from '@cardstack/navigation';
 import { getRequestDisplayDetails } from '@cardstack/parsers/signing-requests';
 
 import {
@@ -23,6 +24,17 @@ const REQUESTS_CLEAR_STATE = 'requests/REQUESTS_CLEAR_STATE';
 
 // Requests expire automatically after 1 hour
 const EXPIRATION_THRESHOLD_IN_MS = 1000 * 60 * 60;
+
+export const handleWalletConnectRequests = (request?: any) => {
+  if (request) {
+    setTimeout(() => {
+      Navigation.handleAction(Routes.CONFIRM_REQUEST, {
+        openAutomatically: true,
+        transactionDetails: request,
+      });
+    }, 1000);
+  }
+};
 
 export const requestsLoadState = () => async (
   dispatch: AppDispatch,

--- a/src/hooks/useRequests.js
+++ b/src/hooks/useRequests.js
@@ -21,5 +21,6 @@ export default function useRequests() {
   return {
     pendingRequestCount,
     requests: sortedRequests,
+    latestRequest: sortedRequests?.[0],
   };
 }

--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -10,7 +10,7 @@ import {
   pickBy,
   values,
 } from 'lodash';
-import { Alert, InteractionManager, Linking } from 'react-native';
+import { Alert, Linking } from 'react-native';
 import {
   getAllValidWalletConnectSessions,
   removeWalletConnectSessions,
@@ -23,7 +23,10 @@ import { isSigningMethod } from '../utils/signingMethods';
 import { appName } from '@cardstack/constants';
 import { getFCMToken } from '@cardstack/models/firebase';
 import { Navigation, Routes } from '@cardstack/navigation';
-import { addRequestToApprove } from '@cardstack/redux/requests';
+import {
+  addRequestToApprove,
+  handleWalletConnectRequests,
+} from '@cardstack/redux/requests';
 import { WCRedirectTypes } from '@cardstack/screens/sheets/WalletConnectRedirectSheet';
 import { enableActionsOnReadOnlyWallet } from '@rainbow-me/config/debug';
 import logger from 'logger';
@@ -209,16 +212,7 @@ const listenOnNewMessages = walletConnector => (dispatch, getState) => {
           )
         : null;
 
-      if (request) {
-        InteractionManager.runAfterInteractions(() => {
-          setTimeout(() => {
-            Navigation.handleAction(Routes.CONFIRM_REQUEST, {
-              openAutomatically: true,
-              transactionDetails: request,
-            });
-          }, 1000);
-        });
-      }
+      handleWalletConnectRequests(request);
     }
   });
   walletConnector.on('disconnect', error => {


### PR DESCRIPTION
### Description
This PR attempts to solve an issue where a notification from the dApp to the wallet for authorization wasn't being correctly handled if the app was in background mode and specially if the biometric auth failed.

~I'm opening as a draft because running the tests locally is giving me flaky results.~

- [x] Completes #CS-4826

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
