### PR TITLE
[CS-4840]: Add dependabot check for github actions update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Set update schedule for GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: 'weekly'


### PR DESCRIPTION
This PR adds a config to allow dependabot to check when there's a github action update.