### PR TITLE
[CS-4841] Remove network toast error from the non-authorized flow

### DIFF
--- a/cardstack/src/screens/Backup/BackupRestoreExplanationScreen/useBackupRestoreExplanationScreen.ts
+++ b/cardstack/src/screens/Backup/BackupRestoreExplanationScreen/useBackupRestoreExplanationScreen.ts
@@ -27,6 +27,7 @@ export const useBackupRestoreExplanationScreen = () => {
         navigate(Routes.BACKUP_RESTORE_CLOUD, { userData: data });
       }
     } catch (e) {
+      dismissLoadingOverlay();
       logger.sentry('[BACKUP] Error getting userData', e);
       Alert(strings.errorMessage);
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import ErrorBoundary from '@cardstack/components/ErrorBoundary/ErrorBoundary';
 import { MinimumVersion } from '@cardstack/components/MinimumVersion';
 import { apolloClient } from '@cardstack/graphql/apollo-client';
 import { AppContainer } from '@cardstack/navigation';
+import { useAuthSelectorAndActions } from '@cardstack/redux/authSlice';
 import theme from '@cardstack/theme';
 import { Device } from '@cardstack/utils';
 
@@ -57,6 +58,7 @@ if (Device.isAndroid) {
 
 const App = () => {
   const { forceUpdate, maintenance } = useAppInit();
+  const { hasWallet } = useAuthSelectorAndActions();
 
   if (maintenance.active) {
     return <MaintenanceMode message={maintenance.message} />;
@@ -71,7 +73,7 @@ const App = () => {
       <SafeAreaProvider>
         <PinnedHiddenItemOptionProvider>
           <AppContainer />
-          <OfflineToast />
+          {hasWallet && <OfflineToast />}
         </PinnedHiddenItemOptionProvider>
       </SafeAreaProvider>
     </MainThemeProvider>

--- a/src/useAppInit.ts
+++ b/src/useAppInit.ts
@@ -27,7 +27,7 @@ const WALLETCONNECT_SYNC_DELAY = 500;
 
 export const useAppInit = () => {
   const walletReady = useRainbowSelector(state => state.appState.walletReady);
-  const appRequiments = useAppRequirements();
+  const appRequirements = useAppRequirements();
 
   const { justBecameActive, movedFromBackground } = useAppState();
 
@@ -136,7 +136,7 @@ export const useAppInit = () => {
     }
   }, [justBecameActive]);
 
-  return appRequiments;
+  return appRequirements;
 };
 
 const useDevSetup = () => {


### PR DESCRIPTION
### Description
This PR removes the network toast error from the non-authorized flow. The account creation is local, so the user can create an account and go through the manual backup flow. Everything that needs internet connection (backup recovery or cloud backup creation after creating a new account) is covered with good error handling.

Minor things:
- dismiss the loading overlay after error when fetching the backup file from cloud;
- typo in `useAppInit` hook;

- [x] Completes #CS-4841

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
