### PR TITLE
[CS-4829][CS-4830] Update reward center to list all claims and allow claiming one-by-one

### DIFF
--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -21,6 +21,7 @@ export const MainRoutes = {
   REWARDS_CENTER_SCREEN: 'RewardsCenterScreen',
   REWARDS_REGISTER_SHEET: 'RewardsRegisterSheet',
   REWARDS_CLAIM_SHEET: 'RewardsClaimSheet',
+  REWARD_CLAIM_SINGLE_SHEET: 'RewardClaimSingleSheet',
   REWARD_WITHDRAW_TO: 'RewardWithdrawToScreen',
   REWARD_WITHDRAW_CONFIRMATION: 'RewardWithdrawConfirmationScreen',
   TRANSACTION_CONFIRMATION_SHEET: 'TransactionConfirmationScreen',

--- a/cardstack/src/navigation/screens.ts
+++ b/cardstack/src/navigation/screens.ts
@@ -26,6 +26,7 @@ import {
   RewardsCenterScreen,
   RewardsRegisterSheet,
   RewardsClaimSheet,
+  RewardClaimSingleSheet,
   TransactionConfirmationSheet,
   ColorPickerModal,
   RequestPrepaidCardScreen,
@@ -145,6 +146,10 @@ export const MainScreens: Record<keyof typeof MainRoutes, ScreenNavigation> = {
   },
   REWARDS_CLAIM_SHEET: {
     component: RewardsClaimSheet,
+    options: sheetPreset(),
+  },
+  REWARD_CLAIM_SINGLE_SHEET: {
+    component: RewardClaimSingleSheet,
     options: sheetPreset(),
   },
   REWARD_WITHDRAW_TO: {

--- a/cardstack/src/screens/RewardsCenterScreen/RewardClaimSingleSheet/RewardClaimSingleSheet.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardClaimSingleSheet/RewardClaimSingleSheet.tsx
@@ -1,0 +1,26 @@
+import React, { memo } from 'react';
+
+import {
+  TransactionConfirmationSheet,
+  SafeAreaView,
+} from '@cardstack/components';
+
+import useRewardClaimSingle from './useRewardClaimSingle';
+
+const RewardClaimSingleSheet = () => {
+  const { data, onCancel, onConfirm } = useRewardClaimSingle();
+
+  return (
+    <SafeAreaView backgroundColor="black" flex={1} width="100%">
+      <TransactionConfirmationSheet
+        data={data}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        loading={false}
+        disabledConfirmButton={data.loadingGasEstimate}
+      />
+    </SafeAreaView>
+  );
+};
+
+export default memo(RewardClaimSingleSheet);

--- a/cardstack/src/screens/RewardsCenterScreen/RewardClaimSingleSheet/useRewardClaimSingle.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardClaimSingleSheet/useRewardClaimSingle.ts
@@ -1,0 +1,145 @@
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { useCallback, useMemo, useRef } from 'react';
+
+import { defaultErrorAlert } from '@cardstack/constants';
+import { useMutationEffects } from '@cardstack/hooks';
+import { useLoadingOverlay } from '@cardstack/navigation';
+import { RouteType } from '@cardstack/navigation/types';
+import {
+  useClaimRewardsMutation,
+  useGetClaimRewardsGasEstimateQuery,
+} from '@cardstack/services/rewards-center/rewards-center-api';
+import {
+  RewardProofType,
+  RewardsClaimMutationParams,
+} from '@cardstack/services/rewards-center/rewards-center-types';
+import {
+  RewardsClaimData,
+  TransactionConfirmationType,
+} from '@cardstack/types';
+
+import { Alert } from '@rainbow-me/components/alerts';
+import { useWallets } from '@rainbow-me/hooks';
+
+import { strings } from '../strings';
+import useRewardsDataFetch from '../useRewardsDataFetch';
+
+interface onClaimCallbackProps {
+  title: string;
+  message: string;
+  dismiss?: boolean;
+}
+
+interface RewardParam {
+  reward: RewardProofType;
+}
+
+const useRewardClaimSingle = () => {
+  const { goBack } = useNavigation();
+
+  const { params } = useRoute<RouteType<RewardParam>>();
+
+  const { accountAddress } = useWallets();
+
+  const {
+    rewardSafeForProgram,
+    defaultRewardProgramId,
+  } = useRewardsDataFetch();
+
+  // flag to avoid rerendering the screen after the claim happened
+  const isClaiming = useRef(false);
+  const rewardRef = useRef(params.reward);
+
+  const { dismissLoadingOverlay, showLoadingOverlay } = useLoadingOverlay();
+
+  const [
+    claimRewards,
+    { isSuccess: isClaimSuccess, isError: isClaimError },
+  ] = useClaimRewardsMutation();
+
+  const claimParams: RewardsClaimMutationParams = useMemo(
+    () => ({
+      accountAddress,
+      rewardProgramId: defaultRewardProgramId,
+      tokenAddress: rewardRef.current?.tokenAddress || '',
+      safeAddress: rewardSafeForProgram?.address || '',
+      rewardsToClaim: [rewardRef.current],
+    }),
+    [accountAddress, defaultRewardProgramId, rewardRef, rewardSafeForProgram]
+  );
+
+  const {
+    data: estimatedGasClaim,
+    isLoading: loadingEstimatedGasClaim,
+    isFetching: fetchingEstimatedGasClaim,
+  } = useGetClaimRewardsGasEstimateQuery(claimParams, {
+    skip: isClaiming.current,
+  });
+
+  const screenData = useMemo(
+    () => ({
+      loadingGasEstimate: loadingEstimatedGasClaim || fetchingEstimatedGasClaim,
+      type: TransactionConfirmationType.REWARDS_CLAIM,
+      estGasFee: estimatedGasClaim || '0.10',
+      ...rewardRef.current,
+    }),
+    [
+      estimatedGasClaim,
+      rewardRef,
+      loadingEstimatedGasClaim,
+      fetchingEstimatedGasClaim,
+    ]
+  );
+
+  const onConfirm = useCallback(() => {
+    showLoadingOverlay({ title: strings.claim.loading });
+
+    isClaiming.current = true;
+    claimRewards(claimParams);
+  }, [showLoadingOverlay, claimRewards, claimParams]);
+
+  const onClaimFulfilledAlert = useCallback(
+    ({ title, message, dismiss }: onClaimCallbackProps) => () => {
+      dismissLoadingOverlay();
+
+      Alert({
+        message,
+        title,
+        buttons: [
+          {
+            text: strings.defaultAlertBtn,
+            onPress: dismiss ? goBack : undefined,
+          },
+        ],
+      });
+    },
+    [dismissLoadingOverlay, goBack]
+  );
+
+  useMutationEffects(
+    useMemo(
+      () => ({
+        success: {
+          status: isClaimSuccess,
+          callback: onClaimFulfilledAlert({
+            ...strings.claim.successAlert,
+            dismiss: true,
+          }),
+        },
+        error: {
+          status: isClaimError,
+          callback: onClaimFulfilledAlert(defaultErrorAlert),
+        },
+      }),
+      [isClaimError, isClaimSuccess, onClaimFulfilledAlert]
+    )
+  );
+
+  return {
+    onConfirm,
+    data: screenData as RewardsClaimData, // type casting bc fullBalanceToken type has undefined
+    onCancel: goBack,
+  };
+};
+
+export default useRewardClaimSingle;

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
@@ -23,27 +23,13 @@ const RewardsCenterScreen = () => {
   } = useRewardsCenterScreen();
 
   const mainPoolRowProps = useMemo(
-    () =>
-      hasRewards
-        ? {
-            primaryText: fullBalanceToken?.balance.display || '',
-            subText: fullBalanceToken?.native.balance.display || '',
-            coinSymbol: fullBalanceToken?.token.symbol || '',
-            isClaimable: !!fullBalanceToken?.isClaimable,
-          }
-        : undefined,
-    [hasRewards, fullBalanceToken]
-  );
-
-  const rewardsRowProps = useMemo(
-    () =>
-      rewards?.map(reward => ({
-        primaryText: reward?.balance.display || '',
-        subText: reward?.native.balance.display || '',
-        coinSymbol: reward?.token.symbol || '',
-        isClaimable: true,
-      })),
-    [rewards]
+    () => ({
+      primaryText: fullBalanceToken?.balance.display || '',
+      subText: fullBalanceToken?.native.balance.display || '',
+      coinSymbol: fullBalanceToken?.token.symbol || '',
+      isClaimable: !!fullBalanceToken?.isClaimable,
+    }),
+    [fullBalanceToken]
   );
 
   return (
@@ -56,12 +42,12 @@ const RewardsCenterScreen = () => {
         ) : (
           <Container flex={1}>
             {!isRegistered &&
-              (mainPoolRowProps ? (
+              (hasRewards ? (
                 <RegisterContent {...mainPoolRowProps} />
               ) : (
                 <NoRewardContent />
               ))}
-            {isRegistered && <ClaimContent claimList={rewardsRowProps} />}
+            {isRegistered && <ClaimContent rewards={rewards} />}
           </Container>
         )}
       </Container>

--- a/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
@@ -1,15 +1,13 @@
 import React, { useMemo } from 'react';
-import { StyleSheet } from 'react-native';
 
-import { Container, NavigationStackHeader, Image } from '@cardstack/components';
-
-import rewardBanner from '../../assets/rewards-banner.png';
+import { Container, NavigationStackHeader } from '@cardstack/components';
 
 import {
   RegisterContent,
   NoRewardContent,
   ClaimContent,
   RewardLoadingSkeleton,
+  RewardProgramHeader,
 } from './components';
 import { strings } from './strings';
 import { useRewardsCenterScreen } from './useRewardsCenterScreen';
@@ -18,49 +16,57 @@ const RewardsCenterScreen = () => {
   const {
     isRegistered,
     hasRewards,
+    rewards,
     fullBalanceToken,
     isLoading,
+    rewardProgramExplainer,
   } = useRewardsCenterScreen();
 
   const mainPoolRowProps = useMemo(
-    () => ({
-      primaryText: fullBalanceToken?.balance.display || '',
-      subText: fullBalanceToken?.native.balance.display || '',
-      coinSymbol: fullBalanceToken?.token.symbol || '',
-      isClaimable: !!fullBalanceToken?.isClaimable,
-    }),
-    [fullBalanceToken]
+    () =>
+      hasRewards
+        ? {
+            primaryText: fullBalanceToken?.balance.display || '',
+            subText: fullBalanceToken?.native.balance.display || '',
+            coinSymbol: fullBalanceToken?.token.symbol || '',
+            isClaimable: !!fullBalanceToken?.isClaimable,
+          }
+        : undefined,
+    [hasRewards, fullBalanceToken]
+  );
+
+  const rewardsRowProps = useMemo(
+    () =>
+      rewards?.map(reward => ({
+        primaryText: reward?.balance.display || '',
+        subText: reward?.native.balance.display || '',
+        coinSymbol: reward?.token.symbol || '',
+        isClaimable: true,
+      })),
+    [rewards]
   );
 
   return (
     <Container backgroundColor="white" flex={1}>
       <NavigationStackHeader title={strings.navigation.title} />
       <Container backgroundColor="white" flex={1}>
-        <Image source={rewardBanner} style={styles.headerImage} />
+        <RewardProgramHeader title={rewardProgramExplainer} />
         {isLoading ? (
           <RewardLoadingSkeleton />
         ) : (
           <Container flex={1}>
             {!isRegistered &&
-              (hasRewards ? (
+              (mainPoolRowProps ? (
                 <RegisterContent {...mainPoolRowProps} />
               ) : (
                 <NoRewardContent />
               ))}
-            {isRegistered && (
-              <ClaimContent
-                claimList={hasRewards ? [mainPoolRowProps] : undefined}
-              />
-            )}
+            {isRegistered && <ClaimContent claimList={rewardsRowProps} />}
           </Container>
         )}
       </Container>
     </Container>
   );
 };
-
-const styles = StyleSheet.create({
-  headerImage: { width: '100%' },
-});
 
 export default RewardsCenterScreen;

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -31,7 +31,6 @@ const tabs = [
 
 export const ClaimContent = ({ rewards }: ClaimContentProps) => {
   const { TabHeader, currentTab } = useTabHeader({ tabs });
-
   const { navigate } = useNavigation();
 
   const onClaimSingleRewardPress = useCallback(
@@ -94,7 +93,7 @@ export const ClaimContent = ({ rewards }: ClaimContentProps) => {
       data={rewards}
       renderItem={RewardItem}
       ListHeaderComponent={ListHeader}
-      ListFooterComponent={<ListFooter />}
+      ListFooterComponent={ListFooter()}
     />
   );
 };

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -57,19 +57,6 @@ export const ClaimContent = ({ rewards }: ClaimContentProps) => {
     [title]
   );
 
-  const ListFooter = () => (
-    <Container>
-      <TabHeader />
-      <Container padding={5}>
-        {currentTab.key === Tabs.BALANCE ? (
-          <RewardsBalanceList />
-        ) : (
-          <RewardsHistoryList />
-        )}
-      </Container>
-    </Container>
-  );
-
   const RewardItem = useCallback(
     ({ item }: { item: RewardProofType }) => (
       <Container paddingHorizontal={5} paddingBottom={2}>
@@ -93,7 +80,18 @@ export const ClaimContent = ({ rewards }: ClaimContentProps) => {
       data={rewards}
       renderItem={RewardItem}
       ListHeaderComponent={ListHeader}
-      ListFooterComponent={ListFooter()}
+      ListFooterComponent={
+        <Container>
+          <TabHeader />
+          <Container padding={5}>
+            {currentTab.key === Tabs.BALANCE ? (
+              <RewardsBalanceList />
+            ) : (
+              <RewardsHistoryList />
+            )}
+          </Container>
+        </Container>
+      }
     />
   );
 };

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -49,7 +49,7 @@ export const ClaimContent = ({ mainPool, rewards }: ClaimContentProps) => {
     [rewards]
   );
 
-  const Header = useMemo(
+  const ListHeader = useMemo(
     () => (
       <Container padding={5}>
         <RewardsTitle title={title} width="100%" paddingBottom={5} />
@@ -72,20 +72,17 @@ export const ClaimContent = ({ mainPool, rewards }: ClaimContentProps) => {
     [title, mainPool]
   );
 
-  const Footer = useMemo(
-    () => (
-      <Container>
-        <TabHeader />
-        <Container padding={5}>
-          {currentTab.key === Tabs.BALANCE ? (
-            <RewardsBalanceList />
-          ) : (
-            <RewardsHistoryList />
-          )}
-        </Container>
+  const ListFooter = () => (
+    <Container>
+      <TabHeader />
+      <Container padding={5}>
+        {currentTab.key === Tabs.BALANCE ? (
+          <RewardsBalanceList />
+        ) : (
+          <RewardsHistoryList />
+        )}
       </Container>
-    ),
-    [currentTab]
+    </Container>
   );
 
   const RewardItem = useCallback(
@@ -96,7 +93,7 @@ export const ClaimContent = ({ mainPool, rewards }: ClaimContentProps) => {
           primaryText={item.balance.display}
           subText={item.native.balance.display}
           onClaimPress={
-            !!Number(item.native.balance.amount)
+            Number(item.native.balance.amount)
               ? () => onClaimSingleRewardPress(item)
               : undefined
           }
@@ -110,8 +107,8 @@ export const ClaimContent = ({ mainPool, rewards }: ClaimContentProps) => {
     <FlatList
       data={rewards}
       renderItem={RewardItem}
-      ListHeaderComponent={Header}
-      ListFooterComponent={Footer}
+      ListHeaderComponent={ListHeader}
+      ListFooterComponent={<ListFooter />}
     />
   );
 };

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -42,7 +42,7 @@ export const ClaimContent = ({ claimList }: ClaimContentProps) => {
     navigate,
   ]);
 
-  const renderClaimList = useCallback(
+  const ClaimList = useMemo(
     () =>
       claimList?.map((item, index) => (
         <RewardRow
@@ -71,7 +71,7 @@ export const ClaimContent = ({ claimList }: ClaimContentProps) => {
           title={strings.register.gasInfoBanner.title}
           message={strings.register.gasInfoBanner.message}
         />
-        {renderClaimList()}
+        {ClaimList}
       </Container>
       <TabHeader />
       <Container padding={5}>

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -78,7 +78,7 @@ export const ClaimContent = ({ rewards }: ClaimContentProps) => {
           primaryText={item.balance.display}
           subText={item.native.balance.display}
           onClaimPress={
-            Number(item.native.balance.amount)
+            item.isClaimable && Number(item.native.balance.amount)
               ? () => onClaimSingleRewardPress(item)
               : undefined
           }

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -4,10 +4,7 @@ import { FlatList } from 'react-native';
 
 import { Container, useTabHeader, InfoBanner } from '@cardstack/components';
 import { Routes } from '@cardstack/navigation';
-import {
-  RewardProofType,
-  FullBalanceToken,
-} from '@cardstack/services/rewards-center/rewards-center-types';
+import { RewardProofType } from '@cardstack/services/rewards-center/rewards-center-types';
 
 import { strings } from '../strings';
 
@@ -19,7 +16,6 @@ import {
 } from '.';
 
 interface ClaimContentProps {
-  mainPool?: FullBalanceToken;
   rewards?: Array<RewardProofType>;
 }
 
@@ -33,7 +29,7 @@ const tabs = [
   { title: strings.history.title, key: Tabs.HISTORY },
 ];
 
-export const ClaimContent = ({ mainPool, rewards }: ClaimContentProps) => {
+export const ClaimContent = ({ rewards }: ClaimContentProps) => {
   const { TabHeader, currentTab } = useTabHeader({ tabs });
 
   const { navigate } = useNavigation();
@@ -57,19 +53,9 @@ export const ClaimContent = ({ mainPool, rewards }: ClaimContentProps) => {
           title={strings.register.gasInfoBanner.title}
           message={strings.register.gasInfoBanner.message}
         />
-        {mainPool && (
-          <Container paddingTop={5}>
-            <RewardRow
-              coinSymbol={mainPool.token.symbol}
-              primaryText={mainPool.balance.display}
-              subText={mainPool.native.balance.display}
-              isClaimable={!!mainPool.isClaimable}
-            />
-          </Container>
-        )}
       </Container>
     ),
-    [title, mainPool]
+    [title]
   );
 
   const ListFooter = () => (

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardProgramHeader.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardProgramHeader.tsx
@@ -1,0 +1,18 @@
+import React, { memo } from 'react';
+
+import { CenteredContainer, Image, Text } from '@cardstack/components';
+
+import rewardBanner from '../../../assets/rewards-promo.png';
+
+export const RewardProgramHeader = memo(({ title }: { title?: string }) => (
+  <CenteredContainer>
+    <Image source={rewardBanner} minWidth="100%" />
+    {!!title && (
+      <CenteredContainer position="absolute" width="60%" height="100%">
+        <Text color="white" variant="sectionTitle">
+          {title}
+        </Text>
+      </CenteredContainer>
+    )}
+  </CenteredContainer>
+));

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardProgramHeader.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardProgramHeader.tsx
@@ -2,17 +2,22 @@ import React, { memo } from 'react';
 
 import { CenteredContainer, Image, Text } from '@cardstack/components';
 
-import rewardBanner from '../../../assets/rewards-promo.png';
+import cardstackRewardBanner from '../../../assets/rewards-banner.png';
+import bannerBackground from '../../../assets/rewards-promo.png';
 
 export const RewardProgramHeader = memo(({ title }: { title?: string }) => (
   <CenteredContainer>
-    <Image source={rewardBanner} minWidth="100%" />
-    {!!title && (
-      <CenteredContainer position="absolute" width="60%" height="100%">
-        <Text color="white" variant="promoBannerTitle">
-          {title}
-        </Text>
-      </CenteredContainer>
+    {title ? (
+      <>
+        <Image source={bannerBackground} minWidth="100%" />
+        <CenteredContainer position="absolute" width="60%" height="100%">
+          <Text color="white" variant="promoBannerTitle">
+            {title}
+          </Text>
+        </CenteredContainer>
+      </>
+    ) : (
+      <Image source={cardstackRewardBanner} minWidth="100%" />
     )}
   </CenteredContainer>
 ));

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardProgramHeader.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardProgramHeader.tsx
@@ -9,7 +9,7 @@ export const RewardProgramHeader = memo(({ title }: { title?: string }) => (
     <Image source={rewardBanner} minWidth="100%" />
     {!!title && (
       <CenteredContainer position="absolute" width="60%" height="100%">
-        <Text color="white" variant="sectionTitle">
+        <Text color="white" variant="promoBannerTitle">
           {title}
         </Text>
       </CenteredContainer>

--- a/cardstack/src/screens/RewardsCenterScreen/components/RewardProgramHeader.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/RewardProgramHeader.tsx
@@ -11,7 +11,13 @@ export const RewardProgramHeader = memo(({ title }: { title?: string }) => (
       <>
         <Image source={bannerBackground} minWidth="100%" />
         <CenteredContainer position="absolute" width="60%" height="100%">
-          <Text color="white" variant="promoBannerTitle">
+          <Text
+            color="white"
+            variant="semibold"
+            fontSize={12}
+            textTransform="uppercase"
+            textAlign="center"
+          >
             {title}
           </Text>
         </CenteredContainer>

--- a/cardstack/src/screens/RewardsCenterScreen/components/index.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/components/index.ts
@@ -5,4 +5,5 @@ export * from './RewardsTitle';
 export * from './ClaimContent';
 export * from './RewardsBalanceList';
 export * from './RewardsHistoryList';
+export * from './RewardProgramHeader';
 export { default as RewardLoadingSkeleton } from './RewardLoadingSkeleton';

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsCenterScreen.ts
@@ -10,6 +10,8 @@ export const useRewardsCenterScreen = () => {
     isLoading,
     fullBalanceToken,
     hasRewards,
+    rewards,
+    rewardProgramExplainer,
   } = useRewardsDataFetch();
 
   const registeredPools = useMemo(
@@ -36,7 +38,9 @@ export const useRewardsCenterScreen = () => {
     rewardPoolTokenBalances,
     isRegistered,
     hasRewards,
+    rewards,
     fullBalanceToken,
     isLoading,
+    rewardProgramExplainer,
   };
 };

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
@@ -38,15 +38,6 @@ const useRewardsDataFetch = () => {
     [accountAddress, nativeCurrency, defaultRewardProgramId, network]
   );
 
-  const { data: rewardProgramExplainer } = useGetRewardProgramInfoQuery(
-    defaultRewardProgramId
-  );
-
-  const { data: rewards } = useGetValidRewardsForProgramQuery(
-    query.params,
-    query.options
-  );
-
   const {
     isLoading: isLoadingSafes,
     isFetching,
@@ -59,6 +50,15 @@ const useRewardsDataFetch = () => {
   const rewardSafeForProgram = useMemo(
     () => findByRewardProgramId(rewardSafes, defaultRewardProgramId),
     [rewardSafes, defaultRewardProgramId]
+  );
+
+  const { data: rewardProgramExplainer } = useGetRewardProgramInfoQuery(
+    defaultRewardProgramId
+  );
+
+  const { data: rewards } = useGetValidRewardsForProgramQuery(
+    { ...query.params, safeAddress: rewardSafeForProgram?.address },
+    { ...query.options, skip: query.options.skip || !rewardSafeForProgram }
   );
 
   const {

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { useIsFetchingDataNewAccount } from '@cardstack/hooks';
 import {
   useGetValidRewardsForProgramQuery,
-  useGetRewardProgramInfoQuery,
+  useGetRewardProgramExplainerQuery,
   useGetRewardPoolTokenBalancesQuery,
   useGetRewardsSafeQuery,
 } from '@cardstack/services/rewards-center/rewards-center-api';
@@ -52,7 +52,7 @@ const useRewardsDataFetch = () => {
     [rewardSafes, defaultRewardProgramId]
   );
 
-  const { data: rewardProgramExplainer } = useGetRewardProgramInfoQuery(
+  const { data: rewardProgramExplainer } = useGetRewardProgramExplainerQuery(
     defaultRewardProgramId
   );
 

--- a/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
+++ b/cardstack/src/screens/RewardsCenterScreen/useRewardsDataFetch.ts
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 
 import { useIsFetchingDataNewAccount } from '@cardstack/hooks';
 import {
+  useGetValidRewardsForProgramQuery,
+  useGetRewardProgramInfoQuery,
   useGetRewardPoolTokenBalancesQuery,
   useGetRewardsSafeQuery,
 } from '@cardstack/services/rewards-center/rewards-center-api';
@@ -12,7 +14,7 @@ import { findByRewardProgramId, isLayer1 } from '@cardstack/utils';
 import { useAccountSettings } from '@rainbow-me/hooks';
 
 const rewardDefaultProgramId: { [key in NetworkType]?: string } = {
-  [NetworkType.sokol]: '0x0885ce31D73b63b0Fcb1158bf37eCeaD8Ff0fC72',
+  [NetworkType.sokol]: '0xab20c80fcc025451a3fc73bB953aaE1b9f640949',
   [NetworkType.gnosis]: '0x979C9F171fb6e9BC501Aa7eEd71ca8dC27cF1185',
 };
 
@@ -34,6 +36,15 @@ const useRewardsDataFetch = () => {
       },
     }),
     [accountAddress, nativeCurrency, defaultRewardProgramId, network]
+  );
+
+  const { data: rewardProgramExplainer } = useGetRewardProgramInfoQuery(
+    defaultRewardProgramId
+  );
+
+  const { data: rewards } = useGetValidRewardsForProgramQuery(
+    query.params,
+    query.options
   );
 
   const {
@@ -134,9 +145,11 @@ const useRewardsDataFetch = () => {
     fullBalanceToken,
     defaultRewardProgramId,
     hasRewards,
+    rewards,
     hasClaimableRewards,
     claimableBalanceToken,
     rewardSafeForProgram,
+    rewardProgramExplainer,
   };
 };
 

--- a/cardstack/src/screens/index.ts
+++ b/cardstack/src/screens/index.ts
@@ -29,6 +29,7 @@ export { default as ChoosePrepaidCardSheet } from './sheets/ChoosePrepaidCardShe
 export { default as RewardsCenterScreen } from './RewardsCenterScreen/RewardsCenterScreen';
 export { default as RewardsRegisterSheet } from './RewardsCenterScreen/RewardsRegisterSheet/RewardsRegisterSheet';
 export { default as RewardsClaimSheet } from './RewardsCenterScreen/RewardsClaimSheet/RewardsClaimSheet';
+export { default as RewardClaimSingleSheet } from './RewardsCenterScreen/RewardClaimSingleSheet/RewardClaimSingleSheet';
 export { default as TransactionConfirmationSheet } from './sheets/TransactionConfirmationSheet/TransactionConfirmationSheet';
 export { default as RequestPrepaidCardScreen } from './RequestPrepaidCardScreen/RequestPrepaidCardScreen';
 export { default as PinScreen } from './PinScreen/PinScreen';

--- a/cardstack/src/services/rewards-center/rewards-center-api.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-api.ts
@@ -29,7 +29,7 @@ import {
   RewardWithdrawGasEstimateParams,
   RewardWithdrawParams,
   SuccessfulTransactionReceipt,
-  RewardsValidProofsParams,
+  RewardsSafeQueryParams,
   RewardValidProofsResult,
 } from './rewards-center-types';
 
@@ -37,12 +37,12 @@ const rewardsApi = safesApi.injectEndpoints({
   endpoints: builder => ({
     getValidRewardsForProgram: builder.query<
       RewardValidProofsResult,
-      RewardsValidProofsParams
+      RewardsSafeQueryParams
     >({
       async queryFn(params) {
         return queryPromiseWrapper<
           RewardValidProofsResult,
-          RewardsValidProofsParams
+          RewardsSafeQueryParams
         >(fetchValidProofsWithToken, params, {
           errorLogMessage: 'Error fetching reward program proofs',
         });

--- a/cardstack/src/services/rewards-center/rewards-center-api.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-api.ts
@@ -209,11 +209,11 @@ export const {
   useGetRewardPoolTokenBalancesQuery,
   useRegisterToRewardProgramMutation,
   useClaimRewardsMutation,
+  useGetClaimRewardsGasEstimateQuery,
   useGetRewardProgramInfoQuery,
   useLazyGetRegisterRewardeeGasEstimateQuery,
   useWithdrawRewardBalanceMutation,
   useGetRewardWithdrawGasEstimateQuery,
-  useGetClaimRewardsGasEstimateQuery,
   useGetClaimAllRewardsGasEstimateQuery,
   useClaimAllRewardsMutation,
 } = rewardsApi;

--- a/cardstack/src/services/rewards-center/rewards-center-api.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-api.ts
@@ -8,12 +8,14 @@ import {
   claimAllRewards,
   fetchRewardPoolTokenBalances,
   fetchRewardsSafe,
+  fetchValidProofsWithToken,
   getClaimRewardsGasEstimate,
   getClaimAllRewardsGasEstimate,
   getRegisterGasEstimate,
   getWithdrawGasEstimate,
   registerToRewardProgram,
   withdrawFromRewardSafe,
+  getRewardProgramInfo,
 } from './rewards-center-service';
 import {
   RegisterGasEstimateQueryParams,
@@ -27,10 +29,25 @@ import {
   RewardWithdrawGasEstimateParams,
   RewardWithdrawParams,
   SuccessfulTransactionReceipt,
+  RewardsValidProofsParams,
+  RewardValidProofsResult,
 } from './rewards-center-types';
 
 const rewardsApi = safesApi.injectEndpoints({
   endpoints: builder => ({
+    getValidRewardsForProgram: builder.query<
+      RewardValidProofsResult,
+      RewardsValidProofsParams
+    >({
+      async queryFn(params) {
+        return queryPromiseWrapper<
+          RewardValidProofsResult,
+          RewardsValidProofsParams
+        >(fetchValidProofsWithToken, params, {
+          errorLogMessage: 'Error fetching reward program proofs',
+        });
+      },
+    }),
     getRewardsSafe: builder.query<
       RewardsSafeQueryResult,
       RewardsSafeQueryParams
@@ -58,6 +75,17 @@ const rewardsApi = safesApi.injectEndpoints({
         });
       },
       providesTags: [CacheTags.REWARDS_POOL],
+    }),
+    getRewardProgramInfo: builder.query<string, string>({
+      async queryFn(params) {
+        return queryPromiseWrapper<string, string>(
+          getRewardProgramInfo,
+          params,
+          {
+            errorLogMessage: 'Error fetching reward program info',
+          }
+        );
+      },
     }),
     getRegisterRewardeeGasEstimate: builder.query<
       number,
@@ -176,10 +204,12 @@ const rewardsApi = safesApi.injectEndpoints({
 });
 
 export const {
+  useGetValidRewardsForProgramQuery,
   useGetRewardsSafeQuery,
   useGetRewardPoolTokenBalancesQuery,
   useRegisterToRewardProgramMutation,
   useClaimRewardsMutation,
+  useGetRewardProgramInfoQuery,
   useLazyGetRegisterRewardeeGasEstimateQuery,
   useWithdrawRewardBalanceMutation,
   useGetRewardWithdrawGasEstimateQuery,

--- a/cardstack/src/services/rewards-center/rewards-center-api.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-api.ts
@@ -15,7 +15,7 @@ import {
   getWithdrawGasEstimate,
   registerToRewardProgram,
   withdrawFromRewardSafe,
-  getRewardProgramInfo,
+  getRewardProgramExplainer,
 } from './rewards-center-service';
 import {
   RegisterGasEstimateQueryParams,
@@ -29,7 +29,6 @@ import {
   RewardWithdrawGasEstimateParams,
   RewardWithdrawParams,
   SuccessfulTransactionReceipt,
-  RewardsSafeQueryParams,
   RewardValidProofsResult,
 } from './rewards-center-types';
 
@@ -76,10 +75,10 @@ const rewardsApi = safesApi.injectEndpoints({
       },
       providesTags: [CacheTags.REWARDS_POOL],
     }),
-    getRewardProgramInfo: builder.query<string, string>({
+    getRewardProgramExplainer: builder.query<string, string>({
       async queryFn(params) {
         return queryPromiseWrapper<string, string>(
-          getRewardProgramInfo,
+          getRewardProgramExplainer,
           params,
           {
             errorLogMessage: 'Error fetching reward program info',
@@ -210,7 +209,7 @@ export const {
   useRegisterToRewardProgramMutation,
   useClaimRewardsMutation,
   useGetClaimRewardsGasEstimateQuery,
-  useGetRewardProgramInfoQuery,
+  useGetRewardProgramExplainerQuery,
   useLazyGetRegisterRewardeeGasEstimateQuery,
   useWithdrawRewardBalanceMutation,
   useGetRewardWithdrawGasEstimateQuery,

--- a/cardstack/src/services/rewards-center/rewards-center-service.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-service.ts
@@ -87,7 +87,7 @@ export const fetchValidProofsWithToken = async ({
 }: RewardsSafeQueryParams): Promise<RewardValidProofsResult> => {
   const rewardPoolInstance = await getRewardsPoolInstance();
 
-  const proofs = await rewardPoolInstance.getUnclaimedValidProofs(
+  const allProofs = await rewardPoolInstance.getUnclaimedValidProofs(
     accountAddress,
     rewardProgramId
   );
@@ -100,8 +100,8 @@ export const fetchValidProofsWithToken = async ({
       )
     : [];
 
-  const proofsWithNativeCurrency = await Promise.all(
-    proofs?.map(async proof => {
+  const allProofsWithNativeCurrency = await Promise.all(
+    allProofs?.map(async proof => {
       const tokenWithPrice = await addNativePriceToToken(
         ({
           token: { symbol: proof.tokenSymbol },
@@ -111,6 +111,8 @@ export const fetchValidProofsWithToken = async ({
         true
       );
 
+      // Adds data needed for claiming a proof to the general proofs list
+      // rootHash is used as a merging ID.
       const claimingInfo =
         claimableProofs.find(
           findProof => findProof.rootHash === proof.rootHash
@@ -125,7 +127,7 @@ export const fetchValidProofsWithToken = async ({
     })
   );
 
-  return proofsWithNativeCurrency;
+  return allProofsWithNativeCurrency;
 };
 
 export const fetchRewardsSafe = async ({

--- a/cardstack/src/services/rewards-center/rewards-center-service.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-service.ts
@@ -30,7 +30,7 @@ import {
   RewardWithdrawGasEstimateParams,
   RewardWithdrawParams,
   ValidProofsParams,
-  RewardsValidProofsParams,
+  RewardsSafeQueryParams,
   RewardValidProofsResult,
 } from './rewards-center-types';
 
@@ -85,7 +85,7 @@ export const fetchValidProofsWithToken = async ({
   accountAddress,
   safeAddress,
   nativeCurrency,
-}: RewardsValidProofsParams): Promise<RewardValidProofsResult> => {
+}: RewardsSafeQueryParams): Promise<RewardValidProofsResult> => {
   const rewardPoolInstance = await getRewardsPoolInstance();
 
   const proofs = await rewardPoolInstance.getUnclaimedValidProofs(

--- a/cardstack/src/services/rewards-center/rewards-center-service.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-service.ts
@@ -52,13 +52,6 @@ const getRewardManagerInstance = async (signedParams?: EthersSignerParams) => {
 
 let cachedValidProofs: WithSymbol<Proof>[] | null = null;
 
-// TODO: func to get proofs and hidrate token info
-/**
-    const web3 = await Web3Instance.get();
-    const assets = await getSDK('Assets', web3);
-    const balance = await assets.getBalanceForToken(address, accountAddress);
- */
-
 const getValidProofs = async ({
   tokenAddress,
   rewardProgramId,
@@ -114,8 +107,6 @@ export const fetchValidProofsWithToken = async ({
     })
   );
 
-  console.log('::: proofs', JSON.stringify(proofsWithNativeCurrency, null, 2));
-
   return proofsWithNativeCurrency;
 };
 
@@ -155,10 +146,6 @@ export const fetchRewardPoolTokenBalances = async ({
 }: RewardsSafeQueryParams) => {
   const rewardPoolInstance = await getRewardsPoolInstance();
 
-  // TODO: 1 Check if this calls are already correctly filtering by rewardProgramId : they are
-  // if so, filters in useRewardsDataFetch aren't needed anymore.
-
-  // TODO: 2 Check if rewardProgram.balances can be used to replace the below
   const rewardTokens = safeAddress
     ? await rewardPoolInstance.rewardTokenBalancesWithoutDust(
         accountAddress,
@@ -299,7 +286,6 @@ export const getRewardProgramInfo = async (rewardProgramId: string) => {
   const rewardManager = await getRewardManagerInstance();
 
   const programInfo = await rewardManager.getRewardProgramInfo(rewardProgramId);
-  console.log('::: program info', JSON.stringify(programInfo));
 
   return programInfo.programExplainer;
 };

--- a/cardstack/src/services/rewards-center/rewards-center-service.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-service.ts
@@ -30,7 +30,6 @@ import {
   RewardWithdrawGasEstimateParams,
   RewardWithdrawParams,
   ValidProofsParams,
-  RewardsSafeQueryParams,
   RewardValidProofsResult,
 } from './rewards-center-types';
 
@@ -304,7 +303,7 @@ export const getWithdrawGasEstimate = async ({
   return gasEstimate.amount;
 };
 
-export const getRewardProgramInfo = async (rewardProgramId: string) => {
+export const getRewardProgramExplainer = async (rewardProgramId: string) => {
   const rewardManager = await getRewardManagerInstance();
 
   const programInfo = await rewardManager.getRewardProgramInfo(rewardProgramId);

--- a/cardstack/src/services/rewards-center/rewards-center-types.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-types.ts
@@ -83,13 +83,6 @@ export interface RewardWithdrawParams
 
 export type RewardWithdrawGasEstimateParams = RewardWithdrawBaseParams;
 
-export interface RewardsValidProofsParams {
-  accountAddress: string;
-  safeAddress?: string;
-  rewardProgramId: string;
-  nativeCurrency: NativeCurrency;
-}
-
 export type RewardProofType = WithSymbol<Proof | ClaimableProof> & TokenType;
 
 export type RewardValidProofsResult = RewardProofType[];

--- a/cardstack/src/services/rewards-center/rewards-center-types.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-types.ts
@@ -2,6 +2,7 @@ import {
   NativeCurrency,
   RewardSafe,
   Proof,
+  ClaimableProof,
   WithSymbol,
 } from '@cardstack/cardpay-sdk';
 import { TransactionReceipt } from 'web3-core';
@@ -55,6 +56,7 @@ export interface RewardsClaimMutationParams
   extends RewardsPoolSignedBaseParams,
     ValidProofsParams {
   safeAddress: string;
+  rewardsToClaim?: RewardProofType[];
 }
 
 export interface RegisterGasEstimateQueryParams {
@@ -83,25 +85,11 @@ export type RewardWithdrawGasEstimateParams = RewardWithdrawBaseParams;
 
 export interface RewardsValidProofsParams {
   accountAddress: string;
+  safeAddress?: string;
   rewardProgramId: string;
   nativeCurrency: NativeCurrency;
 }
 
-declare type WithTokenBalance<T> = T & {
-  token: {
-    symbol: string;
-  };
-  balance: {
-    amount: string;
-    display: string;
-    wei: string;
-  };
-  native: {
-    balance: {
-      amount: number;
-      display: string;
-    };
-  };
-};
+export type RewardProofType = WithSymbol<Proof | ClaimableProof> & TokenType;
 
-export type RewardValidProofsResult = WithTokenBalance<WithSymbol<Proof>>[];
+export type RewardValidProofsResult = RewardProofType[];

--- a/cardstack/src/services/rewards-center/rewards-center-types.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-types.ts
@@ -1,4 +1,9 @@
-import { NativeCurrency, RewardSafe } from '@cardstack/cardpay-sdk';
+import {
+  NativeCurrency,
+  RewardSafe,
+  Proof,
+  WithSymbol,
+} from '@cardstack/cardpay-sdk';
 import { TransactionReceipt } from 'web3-core';
 
 import { EthersSignerParams } from '@cardstack/models/ethers-wallet';
@@ -75,3 +80,28 @@ export interface RewardWithdrawParams
     Omit<RewardsPoolSignedBaseParams, 'rewardProgramId'> {}
 
 export type RewardWithdrawGasEstimateParams = RewardWithdrawBaseParams;
+
+export interface RewardsValidProofsParams {
+  accountAddress: string;
+  rewardProgramId: string;
+  nativeCurrency: NativeCurrency;
+}
+
+declare type WithTokenBalance<T> = T & {
+  token: {
+    symbol: string;
+  };
+  balance: {
+    amount: string;
+    display: string;
+    wei: string;
+  };
+  native: {
+    balance: {
+      amount: number;
+      display: string;
+    };
+  };
+};
+
+export type RewardValidProofsResult = WithTokenBalance<WithSymbol<Proof>>[];

--- a/cardstack/src/services/rewards-center/rewards-center-types.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-types.ts
@@ -83,6 +83,9 @@ export interface RewardWithdrawParams
 
 export type RewardWithdrawGasEstimateParams = RewardWithdrawBaseParams;
 
-export type RewardProofType = WithSymbol<Proof | ClaimableProof> & TokenType;
+export type RewardProofType = WithSymbol<Proof | ClaimableProof> &
+  TokenType & {
+    isClaimable?: boolean;
+  };
 
 export type RewardValidProofsResult = RewardProofType[];

--- a/cardstack/src/theme/textVariants.ts
+++ b/cardstack/src/theme/textVariants.ts
@@ -79,7 +79,7 @@ export const textVariants = {
     textTransform: 'uppercase',
     ...fontFamilyVariants.bold,
   },
-  sectionTitle: {
+  promoBannerTitle: {
     fontSize: 12,
     letterSpacing: 1.2,
     textTransform: 'uppercase',

--- a/cardstack/src/theme/textVariants.ts
+++ b/cardstack/src/theme/textVariants.ts
@@ -79,4 +79,11 @@ export const textVariants = {
     textTransform: 'uppercase',
     ...fontFamilyVariants.bold,
   },
+  sectionTitle: {
+    fontSize: 12,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+    textAlign: 'center',
+    ...fontFamilyVariants.semiBold,
+  },
 };

--- a/cardstack/src/theme/textVariants.ts
+++ b/cardstack/src/theme/textVariants.ts
@@ -79,11 +79,4 @@ export const textVariants = {
     textTransform: 'uppercase',
     ...fontFamilyVariants.bold,
   },
-  promoBannerTitle: {
-    fontSize: 12,
-    letterSpacing: 1.2,
-    textTransform: 'uppercase',
-    textAlign: 'center',
-    ...fontFamilyVariants.semiBold,
-  },
 };


### PR DESCRIPTION
### Description

This PR adds a new API resource to fetch individual reward proofs for given program and it's info from the SDK and refactor Reward Center Screen to display the program explainer and the individual proofs.

Notes:
Total claim available item is not being shown because it was too confusing, it's hard to indicate it's the total of the below cells, so I prefer to keep only the individual proofs visible.

The UI is WIP, I appreciate feedbacks. It's still not showing the proof explanation, coming in the next PR.

- [x] Completes #(CS-4829)
- [x] Completes #(CS-4830)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/202204171-1c051565-e512-4a63-b9b1-11c01053a570.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/202204259-e7db20eb-2c14-437c-b8ab-b2a2d6ddaf59.png">

