### PR TITLE
[CS-4911] Remove Rewards banner from Wallet screen if there's no CardPay

### DIFF
--- a/cardstack/src/components/AssetList/AssetList.tsx
+++ b/cardstack/src/components/AssetList/AssetList.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, createRef } from 'react';
+import React, { useCallback, createRef, useMemo } from 'react';
 import { RefreshControl, SectionList, ActivityIndicator } from 'react-native';
 
 import { Container, Text, RewardsPromoBanner } from '@cardstack/components';
 import { PinHideOptionsFooter } from '@cardstack/components/PinnedHiddenSection';
 
+import { useAccountSettings } from '@rainbow-me/hooks';
 import logger from 'logger';
 
 import { AssetListLoading } from './components/AssetListLoading';
@@ -18,6 +19,7 @@ const onScrollToIndexFailed = () => {
 
 export const AssetList = () => {
   const sectionListRef = createRef<SectionList>();
+  const { isOnCardPayNetwork } = useAccountSettings();
 
   const {
     sections,
@@ -67,6 +69,17 @@ export const AssetList = () => {
     [isFetchingSafes]
   );
 
+  const renderListHeaderComponent = useMemo(
+    () =>
+      isOnCardPayNetwork ? (
+        <RewardsPromoBanner
+          hasUnclaimedRewards={hasClaimableRewards}
+          paddingTop={2}
+        />
+      ) : null,
+    [hasClaimableRewards, isOnCardPayNetwork]
+  );
+
   if (isLoading) {
     return <AssetListLoading />;
   }
@@ -74,12 +87,7 @@ export const AssetList = () => {
   return (
     <>
       <SectionList
-        ListHeaderComponent={
-          <RewardsPromoBanner
-            hasUnclaimedRewards={hasClaimableRewards}
-            paddingTop={2}
-          />
-        }
+        ListHeaderComponent={renderListHeaderComponent}
         onScrollToIndexFailed={onScrollToIndexFailed}
         ref={sectionListRef}
         refreshControl={


### PR DESCRIPTION
### Description
This PR removes the rewards banner from all the networks that are not CardPay compatible.
~Will be waiting for @danibonilha to merge her PR https://github.com/cardstack/cardwallet/pull/1102 to replace `isCardPayCompatible` with the SDK function.~

- [x] Completes #CS-4911

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/690904/203855197-8e7361bc-30df-4458-bed8-ec5552f6f177.png">
