### PR TITLE
[CS-4909] Enable Activities in non-CardPay compatible networks

### DIFF
--- a/cardstack/src/components/TransactionList/TransactionList.tsx
+++ b/cardstack/src/components/TransactionList/TransactionList.tsx
@@ -1,5 +1,5 @@
 import { useFocusEffect } from '@react-navigation/native';
-import React, { memo, useCallback, useEffect, useRef } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import { RefreshControl, SectionList, ActivityIndicator } from 'react-native';
 
 import {
@@ -33,15 +33,6 @@ export const TransactionList = memo(({ Header }: TransactionListProps) => {
     refetchLoading,
   } = useFullTransactionList();
 
-  const isLoadingFallback = useRef(true);
-
-  useEffect(() => {
-    if (!isLoadingTransactions) {
-      // Once tx are loading we don't need to track anymore
-      isLoadingFallback.current = false;
-    }
-  }, [isLoadingTransactions]);
-
   const renderSectionHeader = useCallback(
     ({ section: { title } }: { section: { title: string } }) => (
       <Container
@@ -68,14 +59,18 @@ export const TransactionList = memo(({ Header }: TransactionListProps) => {
     []
   );
 
-  const title = isOnCardPayNetwork
-    ? strings.emptyComponent
-    : strings.nonCardPayNetwork(network);
+  const title = useMemo(
+    () =>
+      isOnCardPayNetwork
+        ? strings.emptyComponent
+        : strings.nonCardPayNetwork(network),
+    [isOnCardPayNetwork, network]
+  );
 
   return (
     <SectionList
       ListEmptyComponent={
-        isLoadingTransactions || isLoadingFallback.current ? (
+        isLoadingTransactions ? (
           <TransactionListLoading />
         ) : (
           <Container paddingTop={4}>

--- a/cardstack/src/components/TransactionList/TransactionList.tsx
+++ b/cardstack/src/components/TransactionList/TransactionList.tsx
@@ -11,7 +11,10 @@ import {
 } from '@cardstack/components';
 import { useFullTransactionList } from '@cardstack/hooks';
 
+import { useAccountSettings } from '@rainbow-me/hooks';
+
 import { TransactionListLoading } from './TransactionListLoading';
+import { strings } from './strings';
 
 interface TransactionListProps {
   Header?: JSX.Element;
@@ -19,6 +22,8 @@ interface TransactionListProps {
 }
 
 export const TransactionList = memo(({ Header }: TransactionListProps) => {
+  const { isOnCardPayNetwork, network } = useAccountSettings();
+
   const {
     onEndReached,
     isLoadingTransactions,
@@ -63,20 +68,18 @@ export const TransactionList = memo(({ Header }: TransactionListProps) => {
     []
   );
 
+  const title = isOnCardPayNetwork
+    ? strings.emptyComponent
+    : strings.nonCardPayNetwork(network);
+
   return (
     <SectionList
       ListEmptyComponent={
-        // Use fallback to avoid flickering empty component,
-        // when fetching hasn't started yet
         isLoadingTransactions || isLoadingFallback.current ? (
           <TransactionListLoading />
         ) : (
           <Container paddingTop={4}>
-            <ListEmptyComponent
-              text={`You don't have any\ntransactions yet`}
-              textColor="blueText"
-              hasRoundBox
-            />
+            <ListEmptyComponent text={title} textColor="blueText" hasRoundBox />
           </Container>
         )
       }

--- a/cardstack/src/components/TransactionList/TransactionList.tsx
+++ b/cardstack/src/components/TransactionList/TransactionList.tsx
@@ -31,7 +31,7 @@ export const TransactionList = memo(({ Header }: TransactionListProps) => {
   const isLoadingFallback = useRef(true);
 
   useEffect(() => {
-    if (isLoadingTransactions) {
+    if (!isLoadingTransactions) {
       // Once tx are loading we don't need to track anymore
       isLoadingFallback.current = false;
     }

--- a/cardstack/src/components/TransactionList/strings.ts
+++ b/cardstack/src/components/TransactionList/strings.ts
@@ -1,0 +1,12 @@
+import { getConstantByNetwork } from '@cardstack/cardpay-sdk';
+
+import { NetworkType } from '@cardstack/types';
+
+export const strings = {
+  nonCardPayNetwork: (network: NetworkType) =>
+    `We currently don't show\ntransactions in ${getConstantByNetwork(
+      'name',
+      network
+    )}.`,
+  emptyComponent: `You don't have any\ntransactions yet`,
+};


### PR DESCRIPTION
### Description
This PR fixes the Activities tab in non-CardPay compatible networks.
We are using a workaround to not flicker the empty state while we wait to load the `TransactionList`. The problem is that for networks that are not CardPay compatible, the `isLoadingTransactions` is already `false` when we load the screen, which makes the `isLoadingFallback` never be changed to `false` on the  `useEffect`.

- [x] Completes #CS-4909

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

### Gnosis

https://user-images.githubusercontent.com/690904/204051961-d5d5a207-d10c-4c4f-9948-358f1b2eec1f.mp4

### Ethereum

https://user-images.githubusercontent.com/690904/204051981-48835b6b-f096-4a90-b766-d713e9909ac0.mp4

