### PR TITLE
[CS-4921] Buggy Scrollview Indicator

### DIFF
--- a/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/RewardsCenterScreen.tsx
@@ -33,7 +33,7 @@ const RewardsCenterScreen = () => {
   );
 
   return (
-    <Container backgroundColor="white" flex={1}>
+    <Container backgroundColor="white" flex={1} width="100%">
       <NavigationStackHeader title={strings.navigation.title} />
       <Container backgroundColor="white" flex={1}>
         <RewardProgramHeader title={rewardProgramExplainer} />

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -5,6 +5,7 @@ import { FlatList } from 'react-native';
 import { Container, useTabHeader, InfoBanner } from '@cardstack/components';
 import { Routes } from '@cardstack/navigation';
 import { RewardProofType } from '@cardstack/services/rewards-center/rewards-center-types';
+import { sectionStyle } from '@cardstack/utils';
 
 import { strings } from '../strings';
 
@@ -78,6 +79,7 @@ export const ClaimContent = ({ rewards }: ClaimContentProps) => {
 
   return (
     <FlatList
+      style={sectionStyle.sectionList}
       data={rewards}
       renderItem={RewardItem}
       ListHeaderComponent={ListHeader}


### PR DESCRIPTION
### Description

Fixes Flatlist width size on ClaimContent component so layout is correct even before loading the inner cells. This should fix it and avoid the need to hide the scroll indicator.

- [x] Completes #(CS-4921)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/204353091-88e57405-7bbd-498f-b13c-5f7fe07c6542.png">
