### PR TITLE
[CS-4923]: Add support to .allSettled to fix wallet not loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,7 +302,8 @@
     "**/@typescript-eslint/eslint-plugin": "4.31.0",
     "**/@typescript-eslint/parser": "4.31.0",
     "**/react-devtools-core": "4.19.1",
-    "**/@types/hammerjs": "^2.0.38"
+    "**/@types/hammerjs": "^2.0.38",
+    "**/promise": "8.3.0"
   },
   "detox": {
     "configurations": {

--- a/src/hooks/useInitializeAccount.ts
+++ b/src/hooks/useInitializeAccount.ts
@@ -1,5 +1,5 @@
 import { captureException } from '@sentry/react-native';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { dataLoadState } from '../redux/data';
@@ -22,10 +22,12 @@ export default function useInitializeAccount() {
 
   const dispatch = useDispatch();
 
+  useEffect(() => {
+    if (accountAddress) WalletConnect.init(accountAddress);
+  }, [accountAddress]);
+
   const loadAccountData = useCallback(async () => {
     logger.sentry('Load wallet account data');
-
-    await WalletConnect.init(accountAddress);
 
     const actions = [
       collectiblesLoadState,
@@ -39,7 +41,7 @@ export default function useInitializeAccount() {
     const promises = mapDispatchToActions(dispatch, actions);
 
     return Promise.allSettled(promises);
-  }, [accountAddress, dispatch, isOnCardPayNetwork]);
+  }, [dispatch, isOnCardPayNetwork]);
 
   const fetchAccountAssets = useCallback(async () => {
     try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8434,7 +8434,7 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-asap@~2.0.3, asap@~2.0.6:
+asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -20448,14 +20448,7 @@ promise-to-callback@^1.0.0:
     is-fn "^1.0.0"
     set-immediate-shim "^1.0.1"
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
-
-promise@^8.2.0:
+promise@8.3.0, promise@^7.1.1, promise@^8.2.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/promise/-/promise-8.3.0.tgz#8cb333d1edeb61ef23869fbb8a4ea0279ab60e0a"
   integrity sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==


### PR DESCRIPTION
### Description

This PR fixes the wallet not loading issue, which was caused by using `Promise.allSettled`, the release build couldn't find this function. `.allSettled` was introduced in the [promise](https://github.com/then/promise)` 8.2.0` version, and react native uses the latest version but there are other older packages which uses older versions like 7.x.x. On the release build there was a confusion between those packages, now by setting the resolution to the latest version we can make sure the promise version used will always be `8.3.0` which is compatible with .allSettled. 
As a bonus I've also added the wc2.0 init fix so we can ship a new version once this PR is merged

### Checklist

- [x] Tested on iOS
- [x] Tested on Android

