### PR TITLE
[CS-4726] Notification Banner for not. example

### DIFF
--- a/cardstack/src/components/NotificationBanner/NotificationBanner.tsx
+++ b/cardstack/src/components/NotificationBanner/NotificationBanner.tsx
@@ -1,0 +1,43 @@
+import React, { memo } from 'react';
+
+import { ContainerProps, Container, Text, Image } from '@cardstack/components';
+
+import cardstackLogo from '../../assets/cardstackLogo.png';
+
+interface NotificationBannerProps extends ContainerProps {
+  title?: string;
+  body?: string;
+}
+
+const NotificationBanner = ({
+  title,
+  body,
+  ...containerProps
+}: NotificationBannerProps) => (
+  <Container
+    shadowRadius={30}
+    shadowOpacity={0.5}
+    shadowOffset={{
+      width: 0,
+      height: 15,
+    }}
+    {...containerProps}
+  >
+    <Container
+      flexDirection="row"
+      paddingHorizontal={4}
+      paddingVertical={5}
+      backgroundColor="grayBannerBackgroud"
+      borderRadius={10}
+      alignItems="center"
+    >
+      <Image source={cardstackLogo} width={36} height={36} />
+      <Container paddingHorizontal={4}>
+        <Text variant="bold">{title}</Text>
+        <Text>{body}</Text>
+      </Container>
+    </Container>
+  </Container>
+);
+
+export default memo(NotificationBanner);

--- a/cardstack/src/components/NotificationBanner/NotificationBanner.tsx
+++ b/cardstack/src/components/NotificationBanner/NotificationBanner.tsx
@@ -5,9 +5,14 @@ import { ContainerProps, Container, Text, Image } from '@cardstack/components';
 import cardstackLogo from '../../assets/cardstackLogo.png';
 
 interface NotificationBannerProps extends ContainerProps {
-  title?: string;
-  body?: string;
+  title: string;
+  body: string;
 }
+
+const shadowOffset = {
+  width: 0,
+  height: 15,
+};
 
 const NotificationBanner = ({
   title,
@@ -17,10 +22,7 @@ const NotificationBanner = ({
   <Container
     shadowRadius={30}
     shadowOpacity={0.5}
-    shadowOffset={{
-      width: 0,
-      height: 15,
-    }}
+    shadowOffset={shadowOffset}
     {...containerProps}
   >
     <Container

--- a/cardstack/src/components/NotificationBanner/index.ts
+++ b/cardstack/src/components/NotificationBanner/index.ts
@@ -1,0 +1,1 @@
+export { default as NotificationBanner } from './NotificationBanner';

--- a/cardstack/src/components/index.ts
+++ b/cardstack/src/components/index.ts
@@ -60,3 +60,4 @@ export * from './PageWithStackHeader';
 export * from './SeedPhraseTable';
 export * from './WordPressable';
 export * from './NetworkToast/NetworkToast';
+export * from './NotificationBanner';

--- a/cardstack/src/theme/colors.ts
+++ b/cardstack/src/theme/colors.ts
@@ -76,6 +76,7 @@ export const colors = {
   settingsTeal: palette.tealDark,
   settingsGrayDark: palette.grayMostDark,
   settingsGrayChevron: palette.grayLessDark,
+  grayBannerBackgroud: palette.grayLessDark,
   green: palette.green,
   lightGreen: palette.lightGreen,
   red: palette.red,


### PR DESCRIPTION
### Description

Adds new `NofiticationBanner` component to loosely mimic a Push notification, for exemplify notifications content.

It displays cardstack's logo, we might use the gray circle as seen in mocks, we'll need to discuss this with design team later. Designs aren't up-to-date with latest discussions.

- [x] Completes #(CS-4726)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [ ] Tested on Android - I'm having an issue on loading the wallet on Android that I'm investigating.

### Screenshots

<!-- Use tag bellow to format image size -->

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/204896450-10e2698e-18d7-4d32-9c01-2fe61c35c4b0.png">

