### PR TITLE
[CS-4930]: Explicitly set "promise" on globals

### DIFF
--- a/src/initializers/setup-globals.js
+++ b/src/initializers/setup-globals.js
@@ -27,3 +27,8 @@ if (typeof process === 'undefined') {
 process.browser = false;
 if (typeof Buffer === 'undefined') global.Buffer = require('buffer').Buffer;
 // global.location = global.location || { port: 80 }
+
+// Shiming order is weird, to make sure allSettled works
+// we reset the global Promise in case it doesn't exist yet
+// eslint-disable-next-line import/no-extraneous-dependencies
+if (!Promise?.allSettled) global.Promise = require('promise');


### PR DESCRIPTION
### Description

This PR fixes the wallet load on dev for Android, from what I could gather it seems there's some ordering issue or some packaging is overriding the `Promise` variable, so now we check for allSettled, if it doesn't exists it means it's using the wrong type of promise and it resets to use the promise package.
From yarn why, we can see that there's only one version which is the latest and contains allSettled, so this approach seems reasonable 
<img width="742" alt="image" src="https://user-images.githubusercontent.com/20520102/204910927-4a70b6e0-715c-4626-80a6-fe78b019706d.png">

### Checklist

- [x] Tested on iOS
- [x] Tested on Android
