### PR TITLE
[CS-4910] Update OpenSea URL to work with Polygon too

### DIFF
--- a/cardstack/src/services/opensea-api.ts
+++ b/cardstack/src/services/opensea-api.ts
@@ -4,6 +4,7 @@ import { isNil, pick } from 'lodash';
 import { OPENSEA_API_KEY } from 'react-native-dotenv';
 
 import { CollectibleType, NetworkType } from '@cardstack/types';
+import { isMainnet } from '@cardstack/utils';
 
 import AssetTypes from '@rainbow-me/helpers/assetTypes';
 import logger from 'logger';
@@ -26,7 +27,7 @@ export const apiFetchCollectiblesForOwner = async (
   page: number
 ): Promise<CollectibleType[]> => {
   try {
-    const networkPrefix = network === NetworkType.mainnet ? '' : `${network}-`;
+    const networkPrefix = isMainnet(network) ? '' : `testnets-`;
     const offset = page * OPENSEA_LIMIT_PER_PAGE;
     const url = `https://${networkPrefix}api.opensea.io/api/v1/assets?owner=${ownerAddress}&limit=${OPENSEA_LIMIT_PER_PAGE}&offset=${offset}`;
     const response = await api.get(url);


### PR DESCRIPTION
### Description
This PR updates the OpenSea URL to work with Polygon and other mainnets too. From the [OpenSea Docs](https://docs.opensea.io/reference/api-overview), we should be either using the API without prefix for mainnets and with `testnets-` for testnets, not the with the network name.

- [x] Completes #CS-4910

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
