### PR TITLE
[CS-4725] UI: Screen for enabling push notifications and permission type selection

### DIFF
--- a/cardstack/src/components/Checkbox/Checkbox.tsx
+++ b/cardstack/src/components/Checkbox/Checkbox.tsx
@@ -4,6 +4,7 @@ import { Touchable, Container, Text, Icon } from '../.';
 import { IconProps } from '../Icon';
 
 type CheckboxPositionType = 'left' | 'right';
+type VerticalAlignType = 'flex-start' | 'flex-end' | 'center';
 
 interface CheckboxProps {
   onPress?: () => void;
@@ -12,6 +13,7 @@ interface CheckboxProps {
   iconProps?: IconProps;
   isSelected?: boolean;
   checkboxPosition?: CheckboxPositionType;
+  verticalAlign?: VerticalAlignType;
   children?: ReactNode;
 }
 
@@ -23,6 +25,7 @@ export const Checkbox = ({
   isDisabled,
   isSelected = false,
   checkboxPosition = 'right',
+  verticalAlign = 'center',
   children,
 }: CheckboxProps) => {
   const [selected, setSelected] = useState(isSelected);
@@ -45,7 +48,7 @@ export const Checkbox = ({
   return (
     <Touchable
       flexDirection={flexDirection}
-      alignItems="center"
+      alignItems={verticalAlign}
       onPress={handleCall}
       disabled={disabled}
     >

--- a/cardstack/src/models/firebase.ts
+++ b/cardstack/src/models/firebase.ts
@@ -25,6 +25,26 @@ type FCMTokenStorageType = {
 const getPermissionStatus = (): Promise<FirebaseMessagingTypes.AuthorizationStatus> =>
   messaging().hasPermission();
 
+export const needsToAskForNotificationsPermissions = async (): Promise<
+  boolean | undefined
+> => {
+  let permissionStatus = null;
+
+  try {
+    permissionStatus = await getPermissionStatus();
+
+    return (
+      permissionStatus !== messaging.AuthorizationStatus.AUTHORIZED &&
+      permissionStatus !== messaging.AuthorizationStatus.PROVISIONAL
+    );
+  } catch (error) {
+    logger.sentry(
+      'Error checking if a user has push notifications permission',
+      error
+    );
+  }
+};
+
 export const getFCMToken = async (): Promise<FCMTokenStorageType> => {
   try {
     const {
@@ -166,21 +186,7 @@ export const requestPermission = () =>
 
 export const checkPushPermissionAndRegisterToken = async () => {
   return new Promise(async resolve => {
-    let permissionStatus = null;
-
-    try {
-      permissionStatus = await getPermissionStatus();
-    } catch (error) {
-      logger.sentry(
-        'Error checking if a user has push notifications permission',
-        error
-      );
-    }
-
-    if (
-      permissionStatus !== messaging.AuthorizationStatus.AUTHORIZED &&
-      permissionStatus !== messaging.AuthorizationStatus.PROVISIONAL
-    ) {
+    if (await needsToAskForNotificationsPermissions()) {
       Alert({
         buttons: [
           {

--- a/cardstack/src/models/firebase.ts
+++ b/cardstack/src/models/firebase.ts
@@ -28,15 +28,14 @@ const getPermissionStatus = (): Promise<FirebaseMessagingTypes.AuthorizationStat
 export const needsToAskForNotificationsPermissions = async (): Promise<
   boolean | undefined
 > => {
-  let permissionStatus = null;
-
   try {
-    permissionStatus = await getPermissionStatus();
+    const { AUTHORIZED, PROVISIONAL } = messaging.AuthorizationStatus;
 
-    return (
-      permissionStatus !== messaging.AuthorizationStatus.AUTHORIZED &&
-      permissionStatus !== messaging.AuthorizationStatus.PROVISIONAL
-    );
+    const permissionStatus = await getPermissionStatus();
+
+    const isAuthorized = [AUTHORIZED, PROVISIONAL].includes(permissionStatus);
+
+    return !isAuthorized;
   } catch (error) {
     logger.sentry(
       'Error checking if a user has push notifications permission',

--- a/cardstack/src/navigation/routes.ts
+++ b/cardstack/src/navigation/routes.ts
@@ -53,6 +53,7 @@ const SharedRoutes = {
   LOADING_OVERLAY: 'LoadingOverlay',
   MESSAGE_OVERLAY: 'MessageOverlay',
   SEED_PHRASE_BACKUP: 'SeedPhraseBackup',
+  NOTIFICATIONS_PERMISSION: 'NotificationsPermissionScreen',
   // non-migrated
   MODAL_SCREEN: 'ModalScreen',
 } as const;

--- a/cardstack/src/navigation/tabBarNavigator.tsx
+++ b/cardstack/src/navigation/tabBarNavigator.tsx
@@ -19,6 +19,7 @@ import {
   LoadingOverlayScreen,
   SeedPhraseBackup,
   MessageOverlayScreen,
+  NotificationsPermissionScreen,
 } from '@cardstack/screens';
 import { colors } from '@cardstack/theme';
 import { Device, useWorker } from '@cardstack/utils';
@@ -123,6 +124,11 @@ const SharedScreens = ({ navigationKey }: { navigationKey: string }) => (
     <Stack.Screen
       component={PinScreen}
       name={Routes.PIN_SCREEN}
+      options={horizontalInterpolator}
+    />
+    <Stack.Screen
+      component={NotificationsPermissionScreen}
+      name={Routes.NOTIFICATIONS_PERMISSION}
       options={horizontalInterpolator}
     />
     <Stack.Screen

--- a/cardstack/src/screens/Backup/BackupManualScreen/BackupManualScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupManualScreen/BackupManualScreen.tsx
@@ -1,6 +1,5 @@
 import { useNavigation, useRoute } from '@react-navigation/native';
 import React, { memo, useCallback } from 'react';
-import { StyleSheet } from 'react-native';
 
 import {
   Button,
@@ -13,16 +12,11 @@ import {
 } from '@cardstack/components';
 import { Routes } from '@cardstack/navigation';
 import { RouteType } from '@cardstack/navigation/types';
+import { listStyle } from '@cardstack/utils';
 
 import { BackupRouteParams } from '../types';
 
 import { strings } from './strings';
-
-const style = StyleSheet.create({
-  scrollview: {
-    paddingBottom: 30,
-  },
-});
 
 const BackupManualScreen = () => {
   const { navigate } = useNavigation();
@@ -37,7 +31,7 @@ const BackupManualScreen = () => {
     <PageWithStackHeader showSkip={false}>
       <ScrollView
         showsVerticalScrollIndicator={false}
-        contentContainerStyle={style.scrollview}
+        contentContainerStyle={listStyle.paddingBottom}
       >
         <Container flex={1} width="90%" marginBottom={10}>
           <Text variant="pageHeader" paddingBottom={4}>

--- a/cardstack/src/screens/Backup/BackupSeedPhraseScreen/BackupSeedPhraseScreen.tsx
+++ b/cardstack/src/screens/Backup/BackupSeedPhraseScreen/BackupSeedPhraseScreen.tsx
@@ -1,5 +1,4 @@
 import React, { memo, useMemo } from 'react';
-import { StyleSheet } from 'react-native';
 
 import {
   BackupStatus,
@@ -12,16 +11,10 @@ import {
   SeedPhraseTable,
   Text,
 } from '@cardstack/components';
-import { Device } from '@cardstack/utils';
+import { Device, listStyle } from '@cardstack/utils';
 
 import { strings } from './strings';
 import { useBackupSeedPhraseScreen } from './useBackupSeedPhraseScreen';
-
-const style = StyleSheet.create({
-  scrollview: {
-    paddingBottom: 30,
-  },
-});
 
 const BackupSeedPhraseScreen = () => {
   const {
@@ -76,7 +69,7 @@ const BackupSeedPhraseScreen = () => {
     >
       <ScrollView
         showsVerticalScrollIndicator={false}
-        contentContainerStyle={style.scrollview}
+        contentContainerStyle={listStyle.paddingBottom}
       >
         <Container flex={1} width="90%" marginBottom={8}>
           <Text variant="pageHeader" paddingBottom={2}>

--- a/cardstack/src/screens/DepotScreen.tsx
+++ b/cardstack/src/screens/DepotScreen.tsx
@@ -28,7 +28,7 @@ import { RouteType } from '@cardstack/navigation/types';
 import { colors } from '@cardstack/theme';
 import { DepotType } from '@cardstack/types';
 import { getAddressPreview } from '@cardstack/utils';
-import { sectionStyle } from '@cardstack/utils/layouts';
+import { listStyle } from '@cardstack/utils/layouts';
 
 import { useRainbowSelector } from '@rainbow-me/redux/hooks';
 import { showActionSheetWithOptions } from '@rainbow-me/utils';
@@ -187,7 +187,7 @@ const Activities = React.memo(({ depotAddress }: { depotAddress: string }) => {
         ListFooterComponent={
           isFetchingMore ? <ActivityIndicator color="white" /> : null
         }
-        contentContainerStyle={sectionStyle.contentContainerStyle}
+        contentContainerStyle={listStyle.sheetHeightPaddingBottom}
         renderItem={props => <TransactionItem {...props} includeBorder />}
         sections={sections}
         renderSectionHeader={({ section: { title } }) => (
@@ -209,7 +209,7 @@ const Activities = React.memo(({ depotAddress }: { depotAddress: string }) => {
         }
         onEndReached={onEndReached}
         onEndReachedThreshold={1}
-        style={sectionStyle.sectionList}
+        style={listStyle.fullWidth}
       />
     </Container>
   );

--- a/cardstack/src/screens/NotificationsPermissionScreen/NotificationsPermissionScreen.tsx
+++ b/cardstack/src/screens/NotificationsPermissionScreen/NotificationsPermissionScreen.tsx
@@ -41,17 +41,18 @@ const NotificationsPermissionScreen = () => {
         <>
           <HorizontalDivider backgroundColor="blueDarkest" />
           <Container>
-            <Checkbox checkboxPosition="left">
-              <Text color="white">{notificationType}</Text>
+            <Checkbox checkboxPosition="left" verticalAlign="flex-start">
+              <Container width="100%">
+                <Text color="white">{notificationType}</Text>
+                <NotificationBanner
+                  width="80%"
+                  paddingTop={6}
+                  paddingBottom={3}
+                  title="Cardstack"
+                  body={notificationType}
+                />
+              </Container>
             </Checkbox>
-            <NotificationBanner
-              paddingTop={6}
-              paddingRight={8}
-              paddingBottom={3}
-              paddingLeft={10}
-              title="Cardstack"
-              body={notificationType}
-            />
           </Container>
         </>
       );

--- a/cardstack/src/screens/NotificationsPermissionScreen/NotificationsPermissionScreen.tsx
+++ b/cardstack/src/screens/NotificationsPermissionScreen/NotificationsPermissionScreen.tsx
@@ -1,4 +1,5 @@
-import React, { memo } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
+import { FlatList, ListRenderItemInfo } from 'react-native';
 
 import {
   Button,
@@ -7,30 +8,117 @@ import {
   PageWithStackHeader,
   PageWithStackHeaderFooter,
   Text,
+  NotificationBanner,
+  Checkbox,
+  HorizontalDivider,
+  Skeleton,
+  Notice,
 } from '@cardstack/components';
+import { NotificationsOptionsStrings } from '@cardstack/hooks/notifications-preferences/useUpdateNotificationPreferences';
+import { NotificationsPreferenceDataType } from '@cardstack/types';
+import { listStyle } from '@cardstack/utils';
 
 import { strings } from './strings';
 import { useNotificationsPermissionScreen } from './useNotificationsPermissionScreen';
 
 const NotificationsPermissionScreen = () => {
   const {
+    options,
+    isError,
     handleSkipOnPress,
     handleEnableNotificationsOnPress,
   } = useNotificationsPermissionScreen();
 
-  return (
-    <PageWithStackHeader
-      canGoBack={false}
-      skipPressCallback={handleSkipOnPress}
-    >
-      <Container flex={1} width="90%">
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<NotificationsPreferenceDataType>) => {
+      const notificationType =
+        NotificationsOptionsStrings[
+          item?.attributes[
+            'notification-type'
+          ] as keyof typeof NotificationsOptionsStrings
+        ];
+
+      return (
+        <>
+          <HorizontalDivider backgroundColor="blueDarkest" />
+          <Container>
+            <Checkbox checkboxPosition="left">
+              <Text color="white">{notificationType}</Text>
+            </Checkbox>
+            <NotificationBanner
+              paddingTop={6}
+              paddingRight={8}
+              paddingBottom={3}
+              paddingLeft={10}
+              title="Cardstack"
+              body={notificationType}
+            />
+          </Container>
+        </>
+      );
+    },
+    []
+  );
+
+  const PageHeader = useMemo(
+    () => (
+      <Container flex={1} width="90%" paddingBottom={6}>
         <Text variant="pageHeader" paddingBottom={4}>
           {strings.title}
         </Text>
         <Text color="grayText" letterSpacing={0.4}>
           {strings.description}
         </Text>
+        <Text color="teal" letterSpacing={0.4}>
+          {strings.highlight}
+        </Text>
       </Container>
+    ),
+    []
+  );
+
+  const ListError = useMemo(
+    () => (
+      <Container
+        alignItems="center"
+        width="100%"
+        justifyContent="center"
+        backgroundColor="backgroundDarkerPurple"
+        marginTop={6}
+        padding={6}
+        borderRadius={10}
+      >
+        <Text color="white">{strings.errorMessage}</Text>
+      </Container>
+    ),
+    []
+  );
+
+  const ListLoading = useMemo(
+    () => (
+      <Container flexDirection="column" paddingVertical={8}>
+        {[...Array(3)].map((v, i) => (
+          <Skeleton height={150} key={`${i}`} marginBottom={6} width="100%" />
+        ))}
+      </Container>
+    ),
+    []
+  );
+
+  return (
+    <PageWithStackHeader
+      canGoBack={false}
+      skipPressCallback={handleSkipOnPress}
+    >
+      <FlatList
+        style={listStyle.fullWidth}
+        contentContainerStyle={listStyle.paddingBottom}
+        showsVerticalScrollIndicator={false}
+        data={options}
+        renderItem={renderItem}
+        ListHeaderComponent={PageHeader}
+        ListEmptyComponent={isError ? ListError : ListLoading}
+      />
       <PageWithStackHeaderFooter>
         <CenteredContainer>
           <Button onPress={handleEnableNotificationsOnPress} marginBottom={4}>

--- a/cardstack/src/screens/NotificationsPermissionScreen/NotificationsPermissionScreen.tsx
+++ b/cardstack/src/screens/NotificationsPermissionScreen/NotificationsPermissionScreen.tsx
@@ -12,7 +12,6 @@ import {
   Checkbox,
   HorizontalDivider,
   Skeleton,
-  Notice,
 } from '@cardstack/components';
 import { NotificationsOptionsStrings } from '@cardstack/hooks/notifications-preferences/useUpdateNotificationPreferences';
 import { NotificationsPreferenceDataType } from '@cardstack/types';

--- a/cardstack/src/screens/NotificationsPermissionScreen/NotificationsPermissionScreen.tsx
+++ b/cardstack/src/screens/NotificationsPermissionScreen/NotificationsPermissionScreen.tsx
@@ -1,0 +1,45 @@
+import React, { memo } from 'react';
+
+import {
+  Button,
+  CenteredContainer,
+  Container,
+  PageWithStackHeader,
+  PageWithStackHeaderFooter,
+  Text,
+} from '@cardstack/components';
+
+import { strings } from './strings';
+import { useNotificationsPermissionScreen } from './useNotificationsPermissionScreen';
+
+const NotificationsPermissionScreen = () => {
+  const {
+    handleSkipOnPress,
+    handleEnableNotificationsOnPress,
+  } = useNotificationsPermissionScreen();
+
+  return (
+    <PageWithStackHeader
+      canGoBack={false}
+      skipPressCallback={handleSkipOnPress}
+    >
+      <Container flex={1} width="90%">
+        <Text variant="pageHeader" paddingBottom={4}>
+          {strings.title}
+        </Text>
+        <Text color="grayText" letterSpacing={0.4}>
+          {strings.description}
+        </Text>
+      </Container>
+      <PageWithStackHeaderFooter>
+        <CenteredContainer>
+          <Button onPress={handleEnableNotificationsOnPress} marginBottom={4}>
+            {strings.confirmBtn}
+          </Button>
+        </CenteredContainer>
+      </PageWithStackHeaderFooter>
+    </PageWithStackHeader>
+  );
+};
+
+export default memo(NotificationsPermissionScreen);

--- a/cardstack/src/screens/NotificationsPermissionScreen/strings.ts
+++ b/cardstack/src/screens/NotificationsPermissionScreen/strings.ts
@@ -4,5 +4,7 @@ export const strings = {
     'Choose which security alerts and important updates you want to receive.',
   highlight:
     'We strongly recommend you opt in for payment and transaction notifications to fully utilize your wallet.',
+  errorMessage:
+    'Failed to get notificition options. You can skip this step and try again next time you open the app.',
   confirmBtn: 'Enable notifications',
 };

--- a/cardstack/src/screens/NotificationsPermissionScreen/strings.ts
+++ b/cardstack/src/screens/NotificationsPermissionScreen/strings.ts
@@ -1,0 +1,8 @@
+export const strings = {
+  title: 'Turn on security notifications',
+  description:
+    'Choose which security alerts and important updates you want to receive.',
+  highlight:
+    'We strongly recommend you opt in for payment and transaction notifications to fully utilize your wallet.',
+  confirmBtn: 'Enable notifications',
+};

--- a/cardstack/src/screens/NotificationsPermissionScreen/useNotificationsPermissionScreen.ts
+++ b/cardstack/src/screens/NotificationsPermissionScreen/useNotificationsPermissionScreen.ts
@@ -1,13 +1,9 @@
 import { useCallback } from 'react';
 
-import { useUpdateNotificationPreferences } from '@cardstack/hooks/notifications-preferences/useUpdateNotificationPreferences';
+import { useUpdateNotificationPreferences } from '@cardstack/hooks';
 
 export const useNotificationsPermissionScreen = () => {
-  const {
-    options,
-    isError,
-    // onUpdateOptionStatus,
-  } = useUpdateNotificationPreferences();
+  const { options, isError } = useUpdateNotificationPreferences();
 
   const handleSkipOnPress = useCallback(() => {
     // TBD

--- a/cardstack/src/screens/NotificationsPermissionScreen/useNotificationsPermissionScreen.ts
+++ b/cardstack/src/screens/NotificationsPermissionScreen/useNotificationsPermissionScreen.ts
@@ -1,6 +1,14 @@
 import { useCallback } from 'react';
 
+import { useUpdateNotificationPreferences } from '@cardstack/hooks/notifications-preferences/useUpdateNotificationPreferences';
+
 export const useNotificationsPermissionScreen = () => {
+  const {
+    options,
+    isError,
+    // onUpdateOptionStatus,
+  } = useUpdateNotificationPreferences();
+
   const handleSkipOnPress = useCallback(() => {
     // TBD
   }, []);
@@ -10,6 +18,8 @@ export const useNotificationsPermissionScreen = () => {
   }, []);
 
   return {
+    options,
+    isError,
     handleSkipOnPress,
     handleEnableNotificationsOnPress,
   };

--- a/cardstack/src/screens/NotificationsPermissionScreen/useNotificationsPermissionScreen.ts
+++ b/cardstack/src/screens/NotificationsPermissionScreen/useNotificationsPermissionScreen.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+
+export const useNotificationsPermissionScreen = () => {
+  const handleSkipOnPress = useCallback(() => {
+    // TBD
+  }, []);
+
+  const handleEnableNotificationsOnPress = useCallback(() => {
+    // TBD
+  }, []);
+
+  return {
+    handleSkipOnPress,
+    handleEnableNotificationsOnPress,
+  };
+};

--- a/cardstack/src/screens/PrepaidCardModal.tsx
+++ b/cardstack/src/screens/PrepaidCardModal.tsx
@@ -16,7 +16,7 @@ import {
 } from '@cardstack/components';
 import { usePrepaidCardTransactions } from '@cardstack/hooks';
 import { Device } from '@cardstack/utils';
-import { sectionStyle } from '@cardstack/utils/layouts';
+import { listStyle } from '@cardstack/utils/layouts';
 
 import { TransactionListLoading } from '../components/TransactionList/TransactionListLoading';
 
@@ -64,7 +64,7 @@ const PrepaidCardModal = () => {
         ) : (
           <SectionList
             ListEmptyComponent={<ListEmptyComponent text="No transactions" />}
-            contentContainerStyle={sectionStyle.contentContainerStyle}
+            contentContainerStyle={listStyle.sheetHeightPaddingBottom}
             renderItem={props => (
               <TransactionItem
                 {...props}
@@ -83,7 +83,7 @@ const PrepaidCardModal = () => {
                 <Text color="blueText">{title}</Text>
               </Container>
             )}
-            style={sectionStyle.sectionList}
+            style={listStyle.fullWidth}
           />
         )}
       </Container>

--- a/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
+++ b/cardstack/src/screens/RewardsCenterScreen/components/ClaimContent.tsx
@@ -5,7 +5,7 @@ import { FlatList } from 'react-native';
 import { Container, useTabHeader, InfoBanner } from '@cardstack/components';
 import { Routes } from '@cardstack/navigation';
 import { RewardProofType } from '@cardstack/services/rewards-center/rewards-center-types';
-import { sectionStyle } from '@cardstack/utils';
+import { listStyle } from '@cardstack/utils';
 
 import { strings } from '../strings';
 
@@ -79,7 +79,7 @@ export const ClaimContent = ({ rewards }: ClaimContentProps) => {
 
   return (
     <FlatList
-      style={sectionStyle.sectionList}
+      style={listStyle.fullWidth}
       data={rewards}
       renderItem={RewardItem}
       ListHeaderComponent={ListHeader}

--- a/cardstack/src/screens/index.ts
+++ b/cardstack/src/screens/index.ts
@@ -46,3 +46,4 @@ export { default as MessageOverlayScreen } from './MessageOverlayScreen';
 export { default as WalletAddressScreen } from './WalletAddressScreen/WalletAddressScreen';
 export { default as WalletConnectSessions } from './WalletConnect/WalletConnectSessionsSection';
 export { default as DesignSystemScreen } from './Dev/DesignSystemScreen';
+export { default as NotificationsPermissionScreen } from './NotificationsPermissionScreen/NotificationsPermissionScreen';

--- a/cardstack/src/screens/sheets/AvailableBalanceSheet/AvailableBalanceSheet.tsx
+++ b/cardstack/src/screens/sheets/AvailableBalanceSheet/AvailableBalanceSheet.tsx
@@ -16,7 +16,7 @@ import {
 import { useMerchantTransactions } from '@cardstack/hooks';
 import { RouteType } from '@cardstack/navigation/types';
 import { MerchantSafeType } from '@cardstack/types';
-import { sectionStyle } from '@cardstack/utils';
+import { listStyle } from '@cardstack/utils';
 
 import { strings } from './strings';
 
@@ -122,7 +122,7 @@ const Activities = ({ address }: Pick<MerchantSafeType, 'address'>) => {
           ListFooterComponent={
             isFetchingMore ? <ActivityIndicator color="white" /> : null
           }
-          contentContainerStyle={sectionStyle.contentContainerStyle}
+          contentContainerStyle={listStyle.sheetHeightPaddingBottom}
           onEndReached={onEndReached}
           onEndReachedThreshold={1}
           refreshControl={
@@ -141,7 +141,7 @@ const Activities = ({ address }: Pick<MerchantSafeType, 'address'>) => {
             </Container>
           )}
           sections={sections}
-          style={sectionStyle.sectionList}
+          style={listStyle.fullWidth}
         />
       )}
     </Container>

--- a/cardstack/src/utils/layouts.ts
+++ b/cardstack/src/utils/layouts.ts
@@ -1,8 +1,9 @@
 import { LayoutAnimation, StyleSheet } from 'react-native';
 
-export const sectionStyle = StyleSheet.create({
-  contentContainerStyle: { paddingBottom: 400 },
-  sectionList: { width: '100%' },
+export const listStyle = StyleSheet.create({
+  sheetHeightPaddingBottom: { paddingBottom: 400 },
+  paddingBottom: { paddingBottom: 30 },
+  fullWidth: { width: '100%' },
 });
 
 const SMALL = 5;


### PR DESCRIPTION
### Description

Adds `NotificationsPermissionScreen` that shows available notification types options for user to select as they are asked to enable notifications.

- [x] Completes #(CS-4725)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/205330461-614d6f59-cf76-4812-b0bc-0817a25eee41.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/205330544-9dd4875a-b190-4af9-a0dc-618d2e09f8b0.png">

<img width="300" alt="Screenshot" src="https://user-images.githubusercontent.com/129619/205330555-6b5c24c4-2edb-4992-8da1-c360ce83ccf9.png">
