### PR TITLE
[CS-4936] Get gas estimates working on Polygon/Mumbai

### DIFF
--- a/cardstack/src/hooks/transaction-confirmation/use-close-screen.ts
+++ b/cardstack/src/hooks/transaction-confirmation/use-close-screen.ts
@@ -6,22 +6,19 @@ import { useDispatch } from 'react-redux';
 import { Routes } from '@cardstack/navigation';
 import { WCRedirectTypes } from '@cardstack/screens/sheets/WalletConnectRedirectSheet';
 
-import { useGas } from '@rainbow-me/hooks';
 import { useRainbowSelector } from '@rainbow-me/redux/hooks';
 import { walletConnectRemovePendingRedirect } from '@rainbow-me/redux/walletconnect';
 import { SEND_TRANSACTION } from '@rainbow-me/utils/signingMethods';
 
 import { useRouteParams } from './use-route-params';
 
-export const useCloseScreen = (isMessageRequest: boolean) => {
+export const useCloseScreen = () => {
   const dispatch = useDispatch();
   const { goBack, canGoBack, navigate } = useNavigation();
 
   const pendingRedirect = useRainbowSelector(
     ({ walletconnect }) => walletconnect.pendingRedirect
   );
-
-  const { stopPollingGasPrices } = useGas();
 
   const {
     transactionDetails: {
@@ -36,10 +33,6 @@ export const useCloseScreen = (isMessageRequest: boolean) => {
         goBack();
       } else {
         navigate(Routes.WALLET_SCREEN);
-      }
-
-      if (!isMessageRequest) {
-        stopPollingGasPrices();
       }
 
       if (pendingRedirect) {
@@ -60,17 +53,7 @@ export const useCloseScreen = (isMessageRequest: boolean) => {
         });
       }
     },
-    [
-      goBack,
-      isMessageRequest,
-      pendingRedirect,
-      stopPollingGasPrices,
-      method,
-      dappScheme,
-      dispatch,
-      canGoBack,
-      navigate,
-    ]
+    [goBack, pendingRedirect, method, dappScheme, dispatch, canGoBack, navigate]
   );
 
   return closeScreen;

--- a/cardstack/src/hooks/transaction-confirmation/use-confirm-transaction.ts
+++ b/cardstack/src/hooks/transaction-confirmation/use-confirm-transaction.ts
@@ -46,7 +46,7 @@ export const useTransactionActions = (isMessageRequest: boolean) => {
 
   const [isAuthorizing, setIsAuthorizing] = useState(false);
 
-  const closeScreen = useCloseScreen(isMessageRequest);
+  const closeScreen = useCloseScreen();
 
   const sendResponseToWalletConnect = useCallback(
     (signatureOrHash?: string | null) => {

--- a/cardstack/src/hooks/transaction-confirmation/use-transaction-confirmation.ts
+++ b/cardstack/src/hooks/transaction-confirmation/use-transaction-confirmation.ts
@@ -75,7 +75,7 @@ export const useTransactionConfirmation = () => {
       setLoading(false);
     };
 
-    setDecodedData();
+    if (domain?.verifyingContract) setDecodedData();
   }, [message, domain, primaryType, network, nativeCurrency]);
 
   return {

--- a/cardstack/src/models/web3-provider.ts
+++ b/cardstack/src/models/web3-provider.ts
@@ -38,8 +38,6 @@ const Web3WsProvider = {
         ? hubConfigResponse.web3.layer2RpcNodeHttpsUrl
         : rpcNodeWssUrl;
 
-      console.log('NODE', node);
-
       provider = new Web3.providers.WebsocketProvider(node, {
         timeout: 30000,
         reconnect: {

--- a/cardstack/src/models/web3-provider.ts
+++ b/cardstack/src/models/web3-provider.ts
@@ -38,6 +38,8 @@ const Web3WsProvider = {
         ? hubConfigResponse.web3.layer2RpcNodeHttpsUrl
         : rpcNodeWssUrl;
 
+      console.log('NODE', node);
+
       provider = new Web3.providers.WebsocketProvider(node, {
         timeout: 30000,
         reconnect: {

--- a/cardstack/src/screens/TransactionConfirmation.tsx
+++ b/cardstack/src/screens/TransactionConfirmation.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { StatusBar } from 'react-native';
 
 import {
-  Container,
   TransactionConfirmationSheet,
   SafeAreaView,
 } from '@cardstack/components';
@@ -17,13 +16,7 @@ const TransactionConfirmation = () => {
     <SafeAreaView backgroundColor="black" flex={1} width="100%">
       <StatusBar barStyle="light-content" />
       <TransactionConfirmationSheet {...props} />
-      <Container height={150}>
-        {!props.isMessageRequest && (
-          <Container>
-            <GasSpeedButton type="transaction" />
-          </Container>
-        )}
-      </Container>
+      {!props.isMessageRequest && <GasSpeedButton type="transaction" />}
     </SafeAreaView>
   );
 };

--- a/cardstack/src/services/hub/gas-prices/gas-prices-api.ts
+++ b/cardstack/src/services/hub/gas-prices/gas-prices-api.ts
@@ -1,0 +1,29 @@
+import { transformObjKeysToCamelCase } from '@cardstack/utils';
+
+import { hubApi } from '../hub-api';
+
+import {
+  GasPricesAttrsType,
+  GasPricesQueryParams,
+  GasPricesQueryResults,
+} from './gas-prices-types';
+
+const routes = {
+  gasPrices: '/gas-station',
+};
+
+export const hubGasPrices = hubApi.injectEndpoints({
+  endpoints: builder => ({
+    getGasPrices: builder.query<GasPricesQueryResults, GasPricesQueryParams>({
+      query: ({ chainId }) => ({
+        url: `${routes.gasPrices}/${chainId}`,
+        method: 'GET',
+        transformResponse: (response: {
+          data: { attributes: GasPricesAttrsType };
+        }) => transformObjKeysToCamelCase(response?.data?.attributes),
+      }),
+    }),
+  }),
+});
+
+export const { useGetGasPricesQuery } = hubGasPrices;

--- a/cardstack/src/services/hub/gas-prices/gas-prices-api.ts
+++ b/cardstack/src/services/hub/gas-prices/gas-prices-api.ts
@@ -1,6 +1,11 @@
 import { transformObjKeysToCamelCase } from '@cardstack/utils';
 
+import { defaultGasPriceFormat } from '@rainbow-me/parsers';
+import { gasUtils } from '@rainbow-me/utils';
+
 import { hubApi } from '../hub-api';
+
+const { CUSTOM, NORMAL, FAST, SLOW } = gasUtils;
 
 import {
   GasPricesAttrsType,
@@ -18,10 +23,21 @@ export const hubGasPrices = hubApi.injectEndpoints({
       query: ({ chainId }) => ({
         url: `${routes.gasPrices}/${chainId}`,
         method: 'GET',
-        transformResponse: (response: {
-          data: { attributes: GasPricesAttrsType };
-        }) => transformObjKeysToCamelCase(response?.data?.attributes),
       }),
+      transformResponse: (response: {
+        data: { attributes: GasPricesAttrsType };
+      }) => {
+        const attributes = transformObjKeysToCamelCase(
+          response.data.attributes
+        );
+
+        return {
+          [CUSTOM]: null,
+          [FAST]: defaultGasPriceFormat(FAST, null, attributes.fast),
+          [NORMAL]: defaultGasPriceFormat(NORMAL, null, attributes.standard),
+          [SLOW]: defaultGasPriceFormat(SLOW, null, attributes.slow),
+        };
+      },
     }),
   }),
 });

--- a/cardstack/src/services/hub/gas-prices/gas-prices-types.ts
+++ b/cardstack/src/services/hub/gas-prices/gas-prices-types.ts
@@ -1,4 +1,4 @@
-import { KebabToCamelCaseKeys } from 'globals';
+import { defaultGasPriceFormat } from '@rainbow-me/parsers';
 
 export type GasPricesQueryParams = {
   chainId: number;
@@ -11,4 +11,7 @@ export type GasPricesAttrsType = {
   fast: string;
 };
 
-export type GasPricesQueryResults = KebabToCamelCaseKeys<GasPricesAttrsType>;
+export type GasPricesQueryResults = Record<
+  string,
+  ReturnType<typeof defaultGasPriceFormat> | null
+>;

--- a/cardstack/src/services/hub/gas-prices/gas-prices-types.ts
+++ b/cardstack/src/services/hub/gas-prices/gas-prices-types.ts
@@ -1,0 +1,14 @@
+import { KebabToCamelCaseKeys } from 'globals';
+
+export type GasPricesQueryParams = {
+  chainId: number;
+};
+
+export type GasPricesAttrsType = {
+  'chain-id': string;
+  slow: string;
+  standard: string;
+  fast: string;
+};
+
+export type GasPricesQueryResults = KebabToCamelCaseKeys<GasPricesAttrsType>;

--- a/cardstack/src/services/index.ts
+++ b/cardstack/src/services/index.ts
@@ -10,3 +10,4 @@ export * from './prepaid-cards/prepaid-card-api';
 export * from './opensea-api';
 export * from './hub/endpoints/hub-profile-api';
 export * from './hub/endpoints/hub-wyre-api';
+export * from './hub/gas-prices/gas-prices-api';

--- a/cardstack/src/test-utils/jest-setup.js
+++ b/cardstack/src/test-utils/jest-setup.js
@@ -183,6 +183,7 @@ jest.mock('@rainbow-me/redux/gas', () => ({
 jest.mock('@rainbow-me/utils', () => ({
   magicMemo: jest.fn(),
   neverRerender: jest.fn(),
+  gasUtils: jest.fn(),
 }));
 
 jest.mock('@rainbow-me/hooks/charts/useChartThrottledPoints', () => ({

--- a/src/components/send/SendTransactionSpeed.js
+++ b/src/components/send/SendTransactionSpeed.js
@@ -1,7 +1,4 @@
-import {
-  convertAmountToBalanceDisplay,
-  getConstantByNetwork,
-} from '@cardstack/cardpay-sdk';
+import { getConstantByNetwork } from '@cardstack/cardpay-sdk';
 import { get } from 'lodash';
 import React, { useMemo } from 'react';
 import {
@@ -25,30 +22,21 @@ export default function SendTransactionSpeed({
   isSufficientGas,
 }) {
   const { network } = useAccountSettings();
+
   const nativeTokenSymbol = getConstantByNetwork('nativeTokenSymbol', network);
   const isDepot = sendType === SendSheetType.SEND_FROM_DEPOT;
+
   const feeDescription = useMemo(() => {
     if (isDepot) {
-      return `${get(
-        gasPrice,
-        'nativeDisplay',
-        0
-      )} ≈ ${nativeCurrencySymbol}${get(gasPrice, 'amount', 0)}`;
-    } else {
-      const nativeValueDisplay = convertAmountToBalanceDisplay(
-        get(gasPrice, 'txFee.native.value.amount', 0),
-        {
-          decimals: 6,
-          symbol: nativeTokenSymbol,
-        }
-      );
-      return `${nativeValueDisplay} ≈ ${get(
-        gasPrice,
-        'txFee.native.value.display',
-        `${nativeCurrencySymbol}0.00`
-      )}`;
+      return `${gasPrice?.nativeDisplay} ≈ ${nativeCurrencySymbol}${gasPrice?.amount}`;
     }
-  }, [gasPrice, isDepot, nativeCurrencySymbol, nativeTokenSymbol]);
+
+    if (!gasPrice.txFee) {
+      return 'Loading gas prices';
+    }
+
+    return `${gasPrice.txFee?.value.display} ≈ ${gasPrice.txFee?.native.value.display}`;
+  }, [gasPrice, isDepot, nativeCurrencySymbol]);
 
   const hasTimeAmount = useMemo(
     () => !!(isDepot ? 0 : get(gasPrice, 'estimatedTime.amount', 0)),

--- a/src/hooks/useGas.js
+++ b/src/hooks/useGas.js
@@ -39,7 +39,7 @@ export default function useGas() {
     })
   );
 
-  const { data } = useGetGasPricesQuery(
+  const { data: gasPricesData } = useGetGasPricesQuery(
     {
       chainId: getConstantByNetwork('chainId', network),
     },
@@ -49,8 +49,8 @@ export default function useGas() {
   );
 
   const startPollingGasPrices = useCallback(
-    () => dispatch(saveGasPrices(data)),
-    [dispatch, data]
+    () => dispatch(saveGasPrices(gasPricesData)),
+    [dispatch, gasPricesData]
   );
 
   const updateDefaultGasLimit = useCallback(

--- a/src/hooks/useGas.js
+++ b/src/hooks/useGas.js
@@ -1,16 +1,23 @@
+import { getConstantByNetwork } from '@cardstack/cardpay-sdk';
+
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-  gasPricesStartPolling,
-  gasPricesStopPolling,
   gasUpdateCustomValues,
   gasUpdateDefaultGasLimit,
   gasUpdateGasPriceOption,
   gasUpdateTxFee,
+  saveGasPrices,
 } from '../redux/gas';
+
+import useAccountSettings from './useAccountSettings';
+import { useGetGasPricesQuery } from '@cardstack/services';
+
+const GAS_PRICE_POLLING_INTERVAL = 15000; // 15s
 
 export default function useGas() {
   const dispatch = useDispatch();
+  const { network } = useAccountSettings();
 
   const gasData = useSelector(
     ({
@@ -32,13 +39,18 @@ export default function useGas() {
     })
   );
 
-  const startPollingGasPrices = useCallback(
-    () => dispatch(gasPricesStartPolling()),
-    [dispatch]
+  const { data } = useGetGasPricesQuery(
+    {
+      chainId: getConstantByNetwork('chainId', network),
+    },
+    {
+      pollingInterval: GAS_PRICE_POLLING_INTERVAL,
+    }
   );
-  const stopPollingGasPrices = useCallback(
-    () => dispatch(gasPricesStopPolling()),
-    [dispatch]
+
+  const startPollingGasPrices = useCallback(
+    () => dispatch(saveGasPrices(data)),
+    [dispatch, data]
   );
 
   const updateDefaultGasLimit = useCallback(
@@ -63,7 +75,6 @@ export default function useGas() {
 
   return {
     startPollingGasPrices,
-    stopPollingGasPrices,
     updateCustomValues,
     updateDefaultGasLimit,
     updateGasPriceOption,

--- a/src/parsers/gas.js
+++ b/src/parsers/gas.js
@@ -12,71 +12,7 @@ import ethUnits from '../references/ethereum-units.json';
 import timeUnits from '../references/time-units.json';
 import { gasUtils } from '../utils';
 
-const { CUSTOM, FAST, NORMAL, SLOW, GasSpeedOrder } = gasUtils;
-
-/**
- * @desc parse ether gas prices
- * @param {Object} data
- * @param {Boolean} short - use short format or not
- */
-export const getFallbackGasPrices = (short = true) => ({
-  [CUSTOM]: null,
-  [FAST]: defaultGasPriceFormat(FAST, '0.5', '200', short),
-  [NORMAL]: defaultGasPriceFormat(NORMAL, '2.5', '100', short),
-  [SLOW]: defaultGasPriceFormat(SLOW, '2.5', '100', short),
-});
-
-const parseGasPricesEtherscan = data => ({
-  [CUSTOM]: null,
-  [FAST]: defaultGasPriceFormat(FAST, data.fastWait, data.fast, true),
-  [NORMAL]: defaultGasPriceFormat(NORMAL, data.avgWait, data.average, true),
-  [SLOW]: defaultGasPriceFormat(SLOW, data.safeLowWait, data.safeLow, true),
-});
-
-const parseGasPricesEthGasStation = data => ({
-  [CUSTOM]: null,
-  [FAST]: defaultGasPriceFormat(
-    FAST,
-    data.fastestWait,
-    Number(data.fastest) / 10,
-    true
-  ),
-  [NORMAL]: defaultGasPriceFormat(
-    NORMAL,
-    data.fastWait,
-    Number(data.fast) / 10,
-    true
-  ),
-  [SLOW]: defaultGasPriceFormat(
-    SLOW,
-    data.avgWait,
-    Number(data.average) / 10,
-    true
-  ),
-});
-
-/**
- * @desc parse ether gas prices
- * @param {Object} data
- * @param {Boolean} short - use short format or not
- */
-export const parseGasPrices = (data, source = 'etherscan') =>
-  !data
-    ? getFallbackGasPrices()
-    : source === 'etherscan'
-    ? parseGasPricesEtherscan(data)
-    : parseGasPricesEthGasStation(data);
-
-export const parseLayer2GasPrices = data => ({
-  [CUSTOM]: null,
-  [FAST]: defaultGasPriceFormat(FAST, null, data.fast ? data.fast : 1),
-  [NORMAL]: defaultGasPriceFormat(
-    NORMAL,
-    null,
-    data.average ? data.average : 1
-  ),
-  [SLOW]: defaultGasPriceFormat(SLOW, null, data.slow ? data.slow : 1),
-});
+const { GasSpeedOrder } = gasUtils;
 
 export const defaultGasPriceFormat = (option, timeWait, value) => {
   const timeAmount = timeWait ? multiply(timeWait, timeUnits.ms.minute) : null;

--- a/src/parsers/gas.js
+++ b/src/parsers/gas.js
@@ -78,7 +78,7 @@ export const parseLayer2GasPrices = data => ({
 
 export const defaultGasPriceFormat = (option, timeWait, value) => {
   const timeAmount = timeWait ? multiply(timeWait, timeUnits.ms.minute) : null;
-  const weiAmount = multiply(value, ethUnits.gwei);
+
   return {
     estimatedTime: {
       amount: timeAmount,
@@ -86,7 +86,7 @@ export const defaultGasPriceFormat = (option, timeWait, value) => {
     },
     option,
     value: {
-      amount: weiAmount,
+      amount: value,
       display: `${parseInt(value, 10)} Gwei`,
     },
   };

--- a/src/parsers/gas.js
+++ b/src/parsers/gas.js
@@ -5,6 +5,7 @@ import {
   getConstantByNetwork,
   multiply,
 } from '@cardstack/cardpay-sdk';
+import { utils } from 'ethers';
 import { get, map, zipObject } from 'lodash';
 import { getMinimalTimeUnitStringForMs } from '../helpers/time';
 import ethUnits from '../references/ethereum-units.json';
@@ -88,7 +89,7 @@ export const defaultGasPriceFormat = (option, timeWait, value) => {
     option,
     value: {
       amount: value,
-      display: `${parseInt(value, 10)} Gwei`,
+      display: `${utils.formatUnits(value, 'gwei')} Gwei`,
     },
   };
 };

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -7,9 +7,6 @@ export {
   parseAssetsNative,
 } from './accounts';
 export {
-  getFallbackGasPrices,
-  parseGasPrices,
-  parseLayer2GasPrices,
   defaultGasPriceFormat,
   parseTxFees,
   gweiToWei,

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -33,7 +33,6 @@ import {
   getTitle,
   getTransactionLabel,
   parseAccountAssets,
-  parseAsset,
   parseNewTransaction,
   parseTransactions,
 } from '@rainbow-me/parsers';

--- a/src/redux/data.js
+++ b/src/redux/data.js
@@ -5,9 +5,7 @@ import {
   filter,
   get,
   isEmpty,
-  isNil,
   map,
-  mapValues,
   partition,
   remove,
   toLower,
@@ -243,35 +241,6 @@ export const addressAssetsReceived = (
   });
   saveAssets(parsedAssets, accountAddress, network);
   dispatch(collectiblesRefreshState());
-};
-
-export const assetPricesReceived = message => dispatch => {
-  const assets = get(message, 'payload.prices', {});
-  if (isEmpty(assets)) return;
-  const parsedAssets = mapValues(assets, asset => parseAsset(asset));
-  dispatch({
-    payload: parsedAssets,
-    type: DATA_UPDATE_GENERIC_ASSETS,
-  });
-};
-
-export const assetPricesChanged = message => (dispatch, getState) => {
-  const price = get(message, 'payload.prices[0].price');
-  const assetAddress = get(message, 'meta.asset_code');
-  if (isNil(price) || isNil(assetAddress)) return;
-  const { genericAssets } = getState().data;
-  const genericAsset = {
-    ...get(genericAssets, assetAddress),
-    price,
-  };
-  const updatedAssets = {
-    ...genericAssets,
-    [assetAddress]: genericAsset,
-  };
-  dispatch({
-    payload: updatedAssets,
-    type: DATA_UPDATE_GENERIC_ASSETS,
-  });
 };
 
 export const dataAddNewTransaction = (

--- a/src/redux/gas.js
+++ b/src/redux/gas.js
@@ -19,26 +19,6 @@ const GAS_UPDATE_GAS_PRICE_OPTION = 'gas/GAS_UPDATE_GAS_PRICE_OPTION';
 
 // -- Actions --------------------------------------------------------------- //
 
-export const updateGasPriceForSpeed = (speed, newPrice) => async (
-  dispatch,
-  getState
-) => {
-  const { gasPrices } = getState().gas;
-
-  const newGasPrices = { ...gasPrices };
-  newGasPrices[speed].value = {
-    amount: newPrice,
-    display: `${newPrice} Gwei`,
-  };
-
-  dispatch({
-    payload: {
-      gasPrices,
-    },
-    type: GAS_PRICES_SUCCESS,
-  });
-};
-
 export const saveGasPrices = fetchedGasPrices => async dispatch => {
   dispatch({
     payload: {

--- a/src/redux/gas.js
+++ b/src/redux/gas.js
@@ -1,34 +1,14 @@
-import {
-  fromWei,
-  getConstantByNetwork,
-  greaterThanOrEqualTo,
-} from '@cardstack/cardpay-sdk';
-import { captureException } from '@sentry/react-native';
+import { fromWei, greaterThanOrEqualTo } from '@cardstack/cardpay-sdk';
 import { get, isEmpty } from 'lodash';
-import { NetworkType } from '@cardstack/types';
-import { isLayer1 } from '@cardstack/utils';
-import {
-  etherscanGetGasEstimates,
-  etherscanGetGasPrices,
-  ethGasStationGetGasPrices,
-  getEstimatedTimeForGasPrice,
-} from '@rainbow-me/handlers/gasPrices';
-import {
-  defaultGasPriceFormat,
-  getFallbackGasPrices,
-  parseGasPrices,
-  parseLayer2GasPrices,
-  parseTxFees,
-} from '@rainbow-me/parsers';
+import { getEstimatedTimeForGasPrice } from '@rainbow-me/handlers/gasPrices';
+import { defaultGasPriceFormat, parseTxFees } from '@rainbow-me/parsers';
 import { ethUnits } from '@rainbow-me/references';
 
 import { ethereumUtils, gasUtils } from '@rainbow-me/utils';
-import logger from 'logger';
 
 const { CUSTOM, NORMAL } = gasUtils;
 
 // -- Constants ------------------------------------------------------------- //
-const GAS_MULTIPLIER = 1.101;
 const GAS_UPDATE_DEFAULT_GAS_LIMIT = 'gas/GAS_UPDATE_DEFAULT_GAS_LIMIT';
 const GAS_PRICES_DEFAULT = 'gas/GAS_PRICES_DEFAULT';
 const GAS_PRICES_SUCCESS = 'gas/GAS_PRICES_SUCCESS';
@@ -38,29 +18,6 @@ const GAS_UPDATE_TX_FEE = 'gas/GAS_UPDATE_TX_FEE';
 const GAS_UPDATE_GAS_PRICE_OPTION = 'gas/GAS_UPDATE_GAS_PRICE_OPTION';
 
 // -- Actions --------------------------------------------------------------- //
-let gasPricesHandle = null;
-
-const getDefaultTxFees = () => (dispatch, getState) => {
-  const { defaultGasLimit } = getState().gas;
-  const { nativeCurrency } = getState().settings;
-  const fallbackGasPrices = getFallbackGasPrices();
-  const ethPriceUnit = ethereumUtils.getEthPriceUnit();
-  const txFees = parseTxFees(
-    fallbackGasPrices,
-    ethPriceUnit,
-    defaultGasLimit,
-    nativeCurrency
-  );
-  const selectedGasPrice = {
-    ...txFees[NORMAL],
-    ...fallbackGasPrices[NORMAL],
-  };
-  return {
-    fallbackGasPrices,
-    selectedGasPrice,
-    txFees,
-  };
-};
 
 export const updateGasPriceForSpeed = (speed, newPrice) => async (
   dispatch,
@@ -82,112 +39,13 @@ export const updateGasPriceForSpeed = (speed, newPrice) => async (
   });
 };
 
-export const gasPricesStartPolling = () => async (dispatch, getState) => {
-  const { gasPrices } = getState().gas;
-
-  const { fallbackGasPrices, selectedGasPrice, txFees } = dispatch(
-    getDefaultTxFees()
-  );
-  // We only set the default if we don't have any price
-  // The previous price will be always more accurate than our default values!
-  if (isEmpty(gasPrices)) {
-    dispatch({
-      payload: {
-        gasPrices: fallbackGasPrices,
-        selectedGasPrice,
-        txFees,
-      },
-      type: GAS_PRICES_DEFAULT,
-    });
-  }
-
-  const getGasPrices = () =>
-    new Promise(async (fetchResolve, fetchReject) => {
-      try {
-        const { gasPrices: existingGasPrice } = getState().gas;
-        const { network } = getState().settings;
-
-        if (isLayer1(network)) {
-          let adjustedGasPrices;
-          let source = 'etherscan';
-
-          try {
-            // Use etherscan as our Gas Price Oracle
-            const {
-              data: { result: etherscanGasPrices },
-            } = await etherscanGetGasPrices();
-
-            const priceData = {
-              average: Number(etherscanGasPrices.ProposeGasPrice),
-              fast: Number(etherscanGasPrices.FastGasPrice),
-              safeLow: Number(etherscanGasPrices.SafeGasPrice),
-            };
-            // Add gas estimates
-            adjustedGasPrices = await etherscanGetGasEstimates(priceData);
-          } catch (e) {
-            logger.log('falling back to eth gas station', e);
-            source = 'ethGasStation';
-            // Fallback to ETHGasStation if Etherscan fails
-            const {
-              data: ethGasStationPrices,
-            } = await ethGasStationGetGasPrices();
-            // Only bumping for ETHGasStation
-            adjustedGasPrices = bumpGasPrices(ethGasStationPrices);
-          }
-
-          let gasPrices = parseGasPrices(adjustedGasPrices, source);
-          if (existingGasPrice[CUSTOM] !== null) {
-            // Preserve custom values while updating prices
-            gasPrices[CUSTOM] = existingGasPrice[CUSTOM];
-          }
-
-          dispatch({
-            payload: {
-              gasPrices,
-            },
-            type: GAS_PRICES_SUCCESS,
-          });
-        } else {
-          const apiBaseUrl = getConstantByNetwork(
-            'apiBaseUrl',
-            NetworkType.gnosis
-          );
-
-          const response = await fetch(`${apiBaseUrl}/v1/gas-price-oracle`);
-          const data = await response.json();
-          const parsedData = parseLayer2GasPrices(data);
-
-          dispatch({
-            payload: {
-              gasPrices: parsedData,
-            },
-            type: GAS_PRICES_SUCCESS,
-          });
-        }
-
-        fetchResolve(true);
-      } catch (error) {
-        dispatch({
-          payload: fallbackGasPrices,
-          type: GAS_PRICES_FAILURE,
-        });
-        captureException(error);
-        fetchReject(error);
-      }
-    });
-
-  const watchGasPrices = async () => {
-    gasPricesHandle && clearTimeout(gasPricesHandle);
-    try {
-      await getGasPrices();
-      // eslint-disable-next-line no-empty
-    } catch (e) {
-    } finally {
-      gasPricesHandle = setTimeout(watchGasPrices, 15000); // 15 secs
-    }
-  };
-
-  watchGasPrices();
+export const saveGasPrices = fetchedGasPrices => async dispatch => {
+  dispatch({
+    payload: {
+      gasPrices: fetchedGasPrices,
+    },
+    type: GAS_PRICES_SUCCESS,
+  });
 };
 
 export const gasUpdateGasPriceOption = newGasPriceOption => (
@@ -309,23 +167,6 @@ const getSelectedGasPrice = (
       ...gasPrices[selectedGasPriceOption],
     },
   };
-};
-
-const bumpGasPrices = data => {
-  const processedData = { ...data };
-  const gasPricesKeys = ['average', 'fast', 'fastest', 'safeLow'];
-  Object.keys(processedData).forEach(key => {
-    if (gasPricesKeys.indexOf(key) !== -1) {
-      processedData[key] = (
-        parseFloat(processedData[key]) * GAS_MULTIPLIER
-      ).toFixed(2);
-    }
-  });
-  return processedData;
-};
-
-export const gasPricesStopPolling = () => () => {
-  gasPricesHandle && clearTimeout(gasPricesHandle);
 };
 
 // -- Reducer --------------------------------------------------------------- //

--- a/src/redux/gas.js
+++ b/src/redux/gas.js
@@ -111,26 +111,29 @@ export const gasUpdateTxFee = (gasLimit, overrideGasOption) => (
   getState
 ) => {
   const { defaultGasLimit, gasPrices, selectedGasPriceOption } = getState().gas;
+
   const _gasLimit = gasLimit || defaultGasLimit;
   const _selectedGasPriceOption = overrideGasOption || selectedGasPriceOption;
   if (isEmpty(gasPrices)) return;
+
   const { assets } = getState().data;
-  const { nativeCurrency } = getState().settings;
+  const { nativeCurrency, network } = getState().settings;
+
   const ethPriceUnit = ethereumUtils.getEthPriceUnit();
+
   const txFees = parseTxFees(
     gasPrices,
     ethPriceUnit,
     _gasLimit,
-    nativeCurrency
+    nativeCurrency,
+    network
   );
-  const { network } = getState().settings;
 
   const results = getSelectedGasPrice(
     assets,
     gasPrices,
     txFees,
-    _selectedGasPriceOption,
-    network
+    _selectedGasPriceOption
   );
   dispatch({
     payload: {

--- a/src/screens/SendSheetEOA.js
+++ b/src/screens/SendSheetEOA.js
@@ -52,7 +52,6 @@ const useSendSheetScreen = () => {
     isSufficientGas,
     selectedGasPrice,
     startPollingGasPrices,
-    stopPollingGasPrices,
     txFees,
     updateDefaultGasLimit,
     updateGasPriceOption,
@@ -95,10 +94,7 @@ const useSendSheetScreen = () => {
 
   useEffect(() => {
     InteractionManager.runAfterInteractions(() => startPollingGasPrices());
-    return () => {
-      InteractionManager.runAfterInteractions(() => stopPollingGasPrices());
-    };
-  }, [startPollingGasPrices, stopPollingGasPrices]);
+  }, [startPollingGasPrices]);
 
   // Recalculate balance when gas price changes
   useEffect(() => {


### PR DESCRIPTION
### Description
This PR has some changes into how we are fetching the gas prices. The extensive logic that was in redux is being replaced by using the Hub's `/gas-station` endpoint. The data transformation is being done in the RTK `transformResponse`. 

Since we are using RTK, we started using its `polling` feature instead of manually refetching with a `setTimeout`. Once the screen isn't mounted anymore, the RTK stops polling automatically.

- [x] Completes #CS-4963

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android
