### PR TITLE
[CS-4937] Prevent Settings screen to be interactive below current screen

### DIFF
--- a/cardstack/src/navigation/screenGroups/settings.tsx
+++ b/cardstack/src/navigation/screenGroups/settings.tsx
@@ -64,7 +64,7 @@ export const SettingsGroup = ({ Stack }: { Stack: StackType }) => {
     <Stack.Group
       screenOptions={{
         ...slideLeftToRightPreset,
-        detachPreviousScreen: false,
+        detachPreviousScreen: true,
         gestureDirection: 'horizontal',
         headerStyle: {
           backgroundColor: palette.blueDark,


### PR DESCRIPTION
### Description
This PR changes a property in the `screenOptions` configuration of the Settings `Stack.Group`. When set to `false`, the Settings screen is kept below any of the Settings screens the user enters (Notifications, Currency, etc). By setting it to `true`, react-navigation "destroys" that screen.

- [x] Completes #CS-4937

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

https://user-images.githubusercontent.com/690904/206265706-db1fcfd2-1815-49a6-9812-5fad7cdc80c6.mp4

