### PR TITLE
[CS-4969]: Updates UI when gasPrices changes 

### DIFF
--- a/cardstack/src/hooks/transaction-confirmation/use-calculate-gas.ts
+++ b/cardstack/src/hooks/transaction-confirmation/use-calculate-gas.ts
@@ -11,7 +11,7 @@ export const useCalculateGas = (
   isMessageRequest: boolean,
   rawPayloadParams: any
 ) => {
-  const { gasLimit, gasPrices, updateTxFee } = useGas();
+  const { gasLimit, gasPrices, updateTxFee, shouldUpdateTxFee } = useGas();
 
   const calculatingGasLimit = useRef(false);
 
@@ -57,6 +57,7 @@ export const useCalculateGas = (
     gasPrices,
     isMessageRequest,
     rawPayloadParams,
+    shouldUpdateTxFee,
     updateTxFee,
   ]);
 };

--- a/src/hooks/useGas.js
+++ b/src/hooks/useGas.js
@@ -12,7 +12,7 @@ import {
 } from '../redux/gas';
 
 import useAccountSettings from './useAccountSettings';
-import { usePrevious } from '.';
+import usePrevious from './usePrevious';
 import { useGetGasPricesQuery } from '@cardstack/services';
 
 const GAS_PRICE_POLLING_INTERVAL = 10000; // 10s

--- a/src/screens/SendSheetEOA.js
+++ b/src/screens/SendSheetEOA.js
@@ -56,6 +56,7 @@ const useSendSheetScreen = () => {
     updateDefaultGasLimit,
     updateGasPriceOption,
     updateTxFee,
+    shouldUpdateTxFee,
   } = useGas();
 
   const recipientFieldRef = useRef();
@@ -419,6 +420,7 @@ const useSendSheetScreen = () => {
     network,
     recipient,
     selected,
+    shouldUpdateTxFee, // Flag to rerender screen with new gasEstimations
     updateTxFee,
   ]);
 


### PR DESCRIPTION
### Description

This PR adds a flag (shouldUpdateTxFee) to be used on the gasCalculations useEffects dependencies and trigger a re-render with updated values, even though the prices were being polled correctly, the UI was never updated since it only uses txFee from redux.

### Checklist

- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->

It would be nice to add some sort if animation when the price changes, but it's lower priority right now

![Simulator Screen Recording - iPhone 14 - 2022-12-08 at 14 18 49](https://user-images.githubusercontent.com/20520102/206520013-5c073070-0301-4f1a-8a08-05c86431c5e5.gif)

