### PR TITLE
[CS-4927] Update push token on network change

### DIFF
--- a/cardstack/src/models/firebase.ts
+++ b/cardstack/src/models/firebase.ts
@@ -119,9 +119,13 @@ export const isFCMTokenStored = async (
   };
 };
 
-// check if token is registered in hub with checking stored in asyncStorage associated with wallet address
-// and if not stored, register to hub, then update asyncStorage)
-export const saveFCMToken = async () => {
+/**
+ * The Push Token needs to be re-registered within each network, this function
+ * validates if the device token is saved for current selected network,
+ * if not we register it in the Hub and store the token locally
+ * associated with the selected network.
+ */
+export const registerFCMToken = async () => {
   try {
     const walletAddress = (await loadAddress()) || '';
 
@@ -145,6 +149,8 @@ export const saveFCMToken = async () => {
           saveLocal(DEVICE_FCM_TOKEN_KEY, {
             data: { fcmToken: newFcmToken, [network]: [walletAddress] },
           });
+
+          logger.log('FCM token changed and was registered for', network);
         } else {
           saveLocal(DEVICE_FCM_TOKEN_KEY, {
             data: {
@@ -158,19 +164,19 @@ export const saveFCMToken = async () => {
               ),
             },
           });
-        }
 
-        logger.log('FCM token registered!!!');
+          logger.log('FCM token registered for', network);
+        }
 
         return;
       }
 
       logger.sentry('FCM token register failed!', walletAddress);
     } else {
-      logger.sentry('FCM token already registered for this account!');
+      logger.log('FCM token already registered for this account');
     }
   } catch (error) {
-    logger.sentry('error fcm token - cannot register fcm token!', error);
+    logger.sentry('Error trying to register FCM token', error);
   }
 };
 
@@ -192,7 +198,7 @@ export const checkPushPermissionAndRegisterToken = async () => {
     }
   }
 
-  await saveFCMToken();
+  await registerFCMToken();
 };
 
 export const registerTokenRefreshListener = () =>

--- a/cardstack/src/models/firebase.ts
+++ b/cardstack/src/models/firebase.ts
@@ -98,7 +98,7 @@ export const removeFCMToken = async (address: string) => {
   }
 };
 
-interface isFCMTokenStoredProps {
+interface FCMTokenStoredReturn {
   isTokenStored: boolean;
   addressesByNetwork?: Record<NetworkType, string[]>;
   fcmToken: string | null;
@@ -107,7 +107,7 @@ interface isFCMTokenStoredProps {
 // check if token's stored by confirming addresses includes wallet address
 export const isFCMTokenStored = async (
   walletAddress: string
-): Promise<isFCMTokenStoredProps> => {
+): Promise<FCMTokenStoredReturn> => {
   const { fcmToken, addressesByNetwork } = await getFCMToken();
   const network: NetworkType = await getNetwork();
   return {

--- a/cardstack/src/models/firebase.ts
+++ b/cardstack/src/models/firebase.ts
@@ -125,7 +125,7 @@ export const isFCMTokenStored = async (
  * if not we register it in the Hub and store the token locally
  * associated with the selected network.
  */
-export const storeRegisterFCMToken = async () => {
+export const storeRegisteredFCMToken = async () => {
   try {
     const walletAddress = (await loadAddress()) || '';
 
@@ -198,7 +198,7 @@ export const checkPushPermissionAndRegisterToken = async () => {
     }
   }
 
-  await storeRegisterFCMToken();
+  await storeRegisteredFCMToken();
 };
 
 export const registerTokenRefreshListener = () =>

--- a/cardstack/src/models/firebase.ts
+++ b/cardstack/src/models/firebase.ts
@@ -125,7 +125,7 @@ export const isFCMTokenStored = async (
  * if not we register it in the Hub and store the token locally
  * associated with the selected network.
  */
-export const registerFCMToken = async () => {
+export const storeRegisterFCMToken = async () => {
   try {
     const walletAddress = (await loadAddress()) || '';
 
@@ -198,7 +198,7 @@ export const checkPushPermissionAndRegisterToken = async () => {
     }
   }
 
-  await registerFCMToken();
+  await storeRegisterFCMToken();
 };
 
 export const registerTokenRefreshListener = () =>

--- a/src/hooks/useWalletManager.ts
+++ b/src/hooks/useWalletManager.ts
@@ -24,7 +24,7 @@ import {
 import useAccountSettings from './useAccountSettings';
 import useInitializeAccount from './useInitializeAccount';
 
-import { storeRegisterFCMToken } from '@cardstack/models/firebase';
+import { storeRegisteredFCMToken } from '@cardstack/models/firebase';
 import { getPin, getSeedPhrase } from '@cardstack/models/secure-storage';
 import { Routes, useLoadingOverlay } from '@cardstack/navigation';
 import { appStateUpdate } from '@cardstack/redux/appState';
@@ -165,7 +165,7 @@ export default function useWalletManager() {
       await fetchAccountAssets();
 
       // The push token needs to be re-registered within each network.
-      await storeRegisterFCMToken();
+      await storeRegisteredFCMToken();
 
       dispatch(appStateUpdate({ walletReady: true }));
     } catch (error) {

--- a/src/hooks/useWalletManager.ts
+++ b/src/hooks/useWalletManager.ts
@@ -24,6 +24,7 @@ import {
 import useAccountSettings from './useAccountSettings';
 import useInitializeAccount from './useInitializeAccount';
 
+import { registerFCMToken } from '@cardstack/models/firebase';
 import { getPin, getSeedPhrase } from '@cardstack/models/secure-storage';
 import { Routes, useLoadingOverlay } from '@cardstack/navigation';
 import { appStateUpdate } from '@cardstack/redux/appState';
@@ -162,6 +163,9 @@ export default function useWalletManager() {
       logger.sentry('loaded account data');
 
       await fetchAccountAssets();
+
+      // The push token needs to be re-registered within each network.
+      await registerFCMToken();
 
       dispatch(appStateUpdate({ walletReady: true }));
     } catch (error) {

--- a/src/hooks/useWalletManager.ts
+++ b/src/hooks/useWalletManager.ts
@@ -24,7 +24,7 @@ import {
 import useAccountSettings from './useAccountSettings';
 import useInitializeAccount from './useInitializeAccount';
 
-import { registerFCMToken } from '@cardstack/models/firebase';
+import { storeRegisterFCMToken } from '@cardstack/models/firebase';
 import { getPin, getSeedPhrase } from '@cardstack/models/secure-storage';
 import { Routes, useLoadingOverlay } from '@cardstack/navigation';
 import { appStateUpdate } from '@cardstack/redux/appState';
@@ -165,7 +165,7 @@ export default function useWalletManager() {
       await fetchAccountAssets();
 
       // The push token needs to be re-registered within each network.
-      await registerFCMToken();
+      await storeRegisterFCMToken();
 
       dispatch(appStateUpdate({ walletReady: true }));
     } catch (error) {


### PR DESCRIPTION
### Description

On latest push permission refactor, saving and registering FCM token in the hub while changing networks was removed by mistake.

This PR restores that functionality and changes some functions naming for clarity.

- [x] Completes #(CS-4927)

### Checklist

- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

*no visual changes*