### PR TITLE
[CS-4992] Removes deprecated checkHubAuth

### DIFF
--- a/cardstack/src/screens/RequestPrepaidCardScreen/__tests__/useRequestPrepaidCardScreen.test.ts
+++ b/cardstack/src/screens/RequestPrepaidCardScreen/__tests__/useRequestPrepaidCardScreen.test.ts
@@ -28,7 +28,6 @@ jest.mock('@cardstack/services', () => ({
       isError: false,
     },
   ]),
-  useCheckHubAuthQuery: jest.fn().mockResolvedValue({ data: true }),
   hubApi: jest.fn(),
 }));
 

--- a/cardstack/src/services/hub/hub-api.ts
+++ b/cardstack/src/services/hub/hub-api.ts
@@ -3,15 +3,12 @@ import { createApi } from '@reduxjs/toolkit/query/react';
 
 import { transformObjKeysToCamelCase } from '@cardstack/utils';
 
-import { queryPromiseWrapper } from '../utils';
-
-import { checkHubAuth, fetchHubBaseQuery, hubBodyBuilder } from './hub-service';
+import { fetchHubBaseQuery, hubBodyBuilder } from './hub-service';
 import {
   RequestCardDropQueryParams,
   EoaClaimedAttrsType,
   GetEoaClaimedQueryParams,
   GetEoaClaimedQueryResult,
-  CheckHubAuthQueryParams,
   GetExchangeRatesQueryParams,
 } from './hub-types';
 
@@ -51,17 +48,6 @@ export const hubApi = createApi({
       }) => transformObjKeysToCamelCase(response?.data?.attributes),
       providesTags: [HubCacheTags.EOA_CLAIM],
     }),
-    checkHubAuth: builder.query<boolean, CheckHubAuthQueryParams>({
-      async queryFn(params) {
-        return queryPromiseWrapper<boolean, CheckHubAuthQueryParams>(
-          checkHubAuth,
-          params,
-          {
-            errorLogMessage: 'Error checking hub auth',
-          }
-        );
-      },
-    }),
     getExchangeRates: builder.query<
       Record<NativeCurrency | string, number>,
       GetExchangeRatesQueryParams | void
@@ -78,6 +64,5 @@ export const hubApi = createApi({
 export const {
   useGetEoaClaimedQuery,
   useRequestEmailCardDropMutation,
-  useCheckHubAuthQuery,
   useGetExchangeRatesQuery,
 } = hubApi;

--- a/cardstack/src/services/hub/hub-service.ts
+++ b/cardstack/src/services/hub/hub-service.ts
@@ -13,7 +13,6 @@ import {
   getHubToken,
   deleteHubToken,
 } from '@cardstack/models/secure-storage';
-import Web3Instance from '@cardstack/models/web3-instance';
 import { MerchantSafeType, NetworkType } from '@cardstack/types';
 
 import { getNetwork } from '@rainbow-me/handlers/localstorage/globalSettings';
@@ -25,7 +24,6 @@ import { safesApi } from '../safes-api';
 import { hubApi } from './hub-api';
 import {
   BaseQueryExtraOptions,
-  CheckHubAuthQueryParams,
   GetExchangeRatesQueryParams,
   PostProfilePurchaseQueryParams,
   UpdateProfileInfoParams,
@@ -214,25 +212,6 @@ export const getHubAuthToken = async (
 
     return null;
   }
-};
-
-export const checkHubAuth = async ({
-  accountAddress,
-  network,
-}: CheckHubAuthQueryParams) => {
-  const authToken = await getHubAuthToken(accountAddress, network);
-
-  if (!authToken) {
-    return false;
-  }
-
-  const web3 = Web3Instance.get();
-  const hubUrl = getConstantByNetwork('hubUrl', network);
-
-  const hubAuthInstance = await getSDK('HubAuth', web3, hubUrl);
-  const isAuthenticated = await hubAuthInstance.checkValidAuth(authToken);
-
-  return isAuthenticated;
 };
 
 // External Queries

--- a/cardstack/src/services/hub/hub-types.ts
+++ b/cardstack/src/services/hub/hub-types.ts
@@ -1,11 +1,7 @@
 import { NativeCurrency } from '@cardstack/cardpay-sdk';
 import { KebabToCamelCaseKeys } from 'globals';
 
-import {
-  CustodialWalletAttrs,
-  IAPProviderType,
-  NetworkType,
-} from '@cardstack/types';
+import { CustodialWalletAttrs, IAPProviderType } from '@cardstack/types';
 
 export interface HubBaseResponse<Attrs> {
   id: string;
@@ -37,11 +33,6 @@ export type EoaClaimedAttrsType = {
 };
 
 export type GetEoaClaimedQueryResult = KebabToCamelCaseKeys<EoaClaimedAttrsType>;
-
-export interface CheckHubAuthQueryParams {
-  accountAddress: string;
-  network: NetworkType;
-}
 
 export interface GetExchangeRatesQueryParams {
   from: NativeCurrency | string;


### PR DESCRIPTION
### Description

Removes deprecated checkHubAuth. 

It was once used by `useRequestPrepaidCardScreen` before starting the request, but since that check was removed and hub-api now handles unauthorized requests better by renewing the token and retrying the request.

- [x] Completes #(CS-4992)
