### PR TITLE
Use decimals from token contract in reward explanations

### DIFF
--- a/cardstack/src/services/rewards-center/rewards-center-service.ts
+++ b/cardstack/src/services/rewards-center/rewards-center-service.ts
@@ -82,12 +82,10 @@ const getValidProofs = async ({
   return validProofs;
 };
 
-const getTokenSymbolForAddress = async (tokenAddress: string) => {
-  const rewardPoolInstance = await getRewardsPoolInstance();
-
-  const token = await rewardPoolInstance.addTokenSymbol([{ tokenAddress }]);
-
-  return token?.[0]?.tokenSymbol;
+const getTokenDetailsForAddress = async (tokenAddress: string) => {
+  const [web3, signer] = await getWeb3ProviderWithEthSigner();
+  const assetsAPI = await getSDK('Assets', web3, signer);
+  return await assetsAPI.getTokenInfo(tokenAddress);
 };
 
 // Queries
@@ -139,25 +137,27 @@ export const fetchValidProofsWithToken = async ({
       };
 
       if (proof.explanationData?.token) {
-        const tokenSymbol = await getTokenSymbolForAddress(
+        const { symbol, decimals } = await getTokenDetailsForAddress(
           proof.explanationData.token
         );
 
-        if (tokenSymbol) {
-          proof.explanationData.token = tokenSymbol;
+        if (symbol) {
+          proof.explanationData.token = symbol;
         }
-      }
 
-      if (proof.explanationData?.amount) {
-        proof.explanationData.amount = parseExplanationAmount(
-          proof.explanationData.amount
-        );
-      }
+        if (proof.explanationData?.amount) {
+          proof.explanationData.amount = parseExplanationAmount(
+            proof.explanationData.amount,
+            decimals
+          );
+        }
 
-      if (proof.explanationData?.rollover_amount) {
-        proof.explanationData.rollover_amount = parseExplanationAmount(
-          proof.explanationData.rollover_amount
-        );
+        if (proof.explanationData?.rollover_amount) {
+          proof.explanationData.rollover_amount = parseExplanationAmount(
+            proof.explanationData.rollover_amount,
+            decimals
+          );
+        }
       }
 
       if (proof.explanationData && proof.explanationTemplate) {

--- a/cardstack/src/services/utils/__tests__/reward-explanation.test.ts
+++ b/cardstack/src/services/utils/__tests__/reward-explanation.test.ts
@@ -40,17 +40,24 @@ describe('Rewards explanation', () => {
     expect(parseTemplateExplanation(template, data)).toBe('Template Value B');
   });
 
-  it('should parse WEI amount to human readable string with default 2 decimals', () => {
-    const wei = '3498646326433040826368';
+  it('should parse token amount to human readable string with default 2 decimals', () => {
+    const amount = '3498646326433040826368';
     const token = '3498.65';
 
-    expect(parseExplanationAmount(wei)).toBe(token);
+    expect(parseExplanationAmount(amount, 18, 2)).toBe(token);
   });
 
-  it('should parse WEI amount to human readable string with defined decimals', () => {
-    const wei = '3498646326433040826368';
+  it('should parse token amount to human readable string with defined decimals', () => {
+    const amount = '3498646326433040826368';
     const token = '3498.646';
 
-    expect(parseExplanationAmount(wei, 3)).toBe(token);
+    expect(parseExplanationAmount(amount, 18, 3)).toBe(token);
+  });
+
+  it('should parse token amount to human readable string with defined decimals, and different token decimals', () => {
+    const amount = '3498646326433040826368';
+    const token = '3498646326433.0408';
+
+    expect(parseExplanationAmount(amount, 9, 4)).toBe(token);
   });
 });

--- a/cardstack/src/services/utils/reward-explanation.ts
+++ b/cardstack/src/services/utils/reward-explanation.ts
@@ -1,4 +1,3 @@
-import { fromWei } from '@cardstack/cardpay-sdk';
 import BigNumber from 'bignumber.js';
 
 /**
@@ -22,11 +21,13 @@ export const parseTemplateExplanation = (template: string, data?: any) => {
 
 /**
  * parseExplanationAmount
- * @param weiAmount amount number in WEI as defined in explanationData.
- * @param decimals numbers to add in return string.
- * @returns formatted string with WEI converted to readable string.
+ * @param amount amount number in WEI as defined in explanationData.
+ * @param tokenDecimals places to shift the decimal point.
+ * @param resultDecimals decimal places to keep in the result
+ * @returns formatted string with amount converted to readable string.
  */
 export const parseExplanationAmount = (
-  weiAmount: BigNumber.Value,
-  decimals = 2
-) => parseFloat(fromWei(weiAmount)).toFixed(decimals);
+  amount: BigNumber.Value,
+  tokenDecimals: number,
+  resultDecimals = 2
+) => new BigNumber(amount).shiftedBy(-tokenDecimals).toFixed(resultDecimals);


### PR DESCRIPTION
### Description

This swaps over to using the decimals defined in the token contract instead of assuming 18. 18 is common but not universal, USDC is 6.

I was able to build and test on an android emulator but don't have access to a mac for building for iOS.

- [x] Completes #(CS-4953)

### Checklist

- [ ] Tested on a small device
- [ ] Tested on iOS
- [x] Tested on Android

### Screenshots

![image](https://user-images.githubusercontent.com/53767/207865483-0d71c3f3-63cb-4b53-afc6-62b49abd317e.png)
