### PR TITLE
Additional steps that may be required on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,19 @@ Follow steps 1 through 4 from the iOS steps above, then:
 
 5. Run `bundle exec fastlane sync_google_service_info`
 
-6. Run `yarn android`
+6. Run `yarn start` to start the React Native Bundler.
 
-7. Launch an Android emulator or connect a test device
+7. Run `yarn android`
+
+8. Launch an Android emulator or connect a test device
+
+
+### Troubleshooting
+
+Error regarding file system watches on linux. You may need to increase the maximum number of file system watches. You can do this by running the following command:
+
+    echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+
 
 ## How to run the tests
 
@@ -65,6 +75,12 @@ Follow steps 1 through 4 from the iOS steps above, then:
   - Syncs app vars for lane specific variables to `.env.${LANE}` file (lanes are alpha, beta, release)
 - `yarn contexts:sync`
   - Syncs all app and lane-specific variables from the context repo
+
+##### Troubleshooting
+
+If you get an error saying the cryptex password is incorrect but you have checked it is correct, you may need the following fastlane plugin branch https://github.com/IanCal/fastlane-plugin-cryptex
+
+On some filesystems the temp files written are not available immediately and a short sleep is required to allow the file to be written.
 
 #### Publishing
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,10 @@ Follow steps 1 through 4 from the iOS steps above, then:
 
 5. Run `bundle exec fastlane sync_google_service_info`
 
-6. Run `yarn start` to start the React Native Bundler.
+6. Run `yarn android`
 
-7. Run `yarn android`
+7. Launch an Android emulator or connect a test device
 
-8. Launch an Android emulator or connect a test device
 
 
 ### Troubleshooting
@@ -58,6 +57,7 @@ Error regarding file system watches on linux. You may need to increase the maxim
 
     echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
+If you get an error about metro not running you can start the server manually by running `yarn start`.
 
 ## How to run the tests
 


### PR DESCRIPTION
Just added a couple of things to the readme:

* File system watches issue on linux
* A very odd fastlane plugin issue that I created a branch for on the original repo
* A note that yarn start is required for android dev too
