### PR TITLE
[CS-4991] FCM token saving refactor

### DIFF
--- a/cardstack/src/models/firebase.ts
+++ b/cardstack/src/models/firebase.ts
@@ -46,7 +46,7 @@ export const removeFCMToken = async (walletAddress?: string) => {
       }
     }
   } catch (e) {
-    logger.sentry('Unregister FcmToken failed --', e);
+    logger.sentry('Unregister FcmToken failed', e);
   }
 };
 

--- a/cardstack/src/models/firebase.ts
+++ b/cardstack/src/models/firebase.ts
@@ -19,8 +19,10 @@ import {
   deleteSecureFCMToken,
 } from './secure-storage';
 
-export const getFCMToken = async (): Promise<string | undefined> => {
-  const keyAddress = (await loadAddress()) || '';
+export const getFCMToken = async (
+  walletAddress?: string
+): Promise<string | undefined> => {
+  const keyAddress = walletAddress || (await loadAddress()) || '';
   const keyNetwork: NetworkType = await getNetwork();
 
   const fcmToken = await getSecureFCMToken(keyAddress, keyNetwork);
@@ -28,17 +30,17 @@ export const getFCMToken = async (): Promise<string | undefined> => {
   return fcmToken;
 };
 
-export const removeFCMToken = async () => {
+export const removeFCMToken = async (walletAddress?: string) => {
   try {
-    const fcmToken = await getFCMToken();
+    const fcmToken = await getFCMToken(walletAddress);
 
     if (fcmToken) {
-      const response = await unregisterFcmToken();
+      const response = await unregisterFcmToken(fcmToken);
 
       if ('data' in response) {
-        logger.sentry('Unregistering FCM Token', response);
+        logger.log('Unregistering FCM Token', response);
 
-        const keyAddress = (await loadAddress()) || '';
+        const keyAddress = walletAddress || (await loadAddress()) || '';
         const keyNetwork: NetworkType = await getNetwork();
         await deleteSecureFCMToken(keyAddress, keyNetwork);
       }

--- a/cardstack/src/models/firebase.ts
+++ b/cardstack/src/models/firebase.ts
@@ -1,6 +1,4 @@
-import messaging, {
-  FirebaseMessagingTypes,
-} from '@react-native-firebase/messaging';
+import messaging from '@react-native-firebase/messaging';
 import { requestNotifications } from 'react-native-permissions';
 
 import {
@@ -19,9 +17,7 @@ import {
   deleteSecureFCMToken,
 } from './secure-storage';
 
-export const getFCMToken = async (
-  walletAddress?: string
-): Promise<string | undefined> => {
+export const getFCMToken = async (walletAddress?: string) => {
   const keyAddress = walletAddress || (await loadAddress()) || '';
   const keyNetwork: NetworkType = await getNetwork();
 
@@ -80,12 +76,9 @@ export const storeRegisteredFCMToken = async () => {
   }
 };
 
-export const getPermissionStatus = (): Promise<FirebaseMessagingTypes.AuthorizationStatus> =>
-  messaging().hasPermission();
+export const getPermissionStatus = () => messaging().hasPermission();
 
-export const needsNotificationPermission = async (): Promise<
-  boolean | undefined
-> => {
+export const needsNotificationPermission = async () => {
   try {
     const { DENIED, AUTHORIZED, PROVISIONAL } = messaging.AuthorizationStatus;
 

--- a/cardstack/src/models/firebase.ts
+++ b/cardstack/src/models/firebase.ts
@@ -9,15 +9,73 @@ import {
 } from '@cardstack/services/hub/notifications/hub-notifications-service';
 import { NetworkType } from '@cardstack/types';
 
-import { getLocal, saveLocal } from '@rainbow-me/handlers/localstorage/common';
 import { getNetwork } from '@rainbow-me/handlers/localstorage/globalSettings';
 import { loadAddress } from '@rainbow-me/model/wallet';
 import logger from 'logger';
 
-const DEVICE_FCM_TOKEN_KEY = 'cardwalletFcmToken';
-type FCMTokenStorageType = {
-  fcmToken: string | null;
-  addressesByNetwork?: Record<NetworkType, string[]>;
+import {
+  saveSecureFCMToken,
+  getSecureFCMToken,
+  deleteSecureFCMToken,
+} from './secure-storage';
+
+export const getFCMToken = async (): Promise<string | undefined> => {
+  const keyAddress = (await loadAddress()) || '';
+  const keyNetwork: NetworkType = await getNetwork();
+
+  const fcmToken = await getSecureFCMToken(keyAddress, keyNetwork);
+
+  return fcmToken;
+};
+
+export const removeFCMToken = async () => {
+  try {
+    const fcmToken = await getFCMToken();
+
+    if (fcmToken) {
+      const response = await unregisterFcmToken();
+
+      if ('data' in response) {
+        logger.sentry('Unregistering FCM Token', response);
+
+        const keyAddress = (await loadAddress()) || '';
+        const keyNetwork: NetworkType = await getNetwork();
+        await deleteSecureFCMToken(keyAddress, keyNetwork);
+      }
+    }
+  } catch (e) {
+    logger.sentry('Unregister FcmToken failed --', e);
+  }
+};
+
+/**
+ * The Push Token needs to be re-registered within each network, this function
+ * validates if the device token is saved for current selected network,
+ * if not we register it in the Hub and store the token locally
+ * associated with the selected network.
+ */
+export const storeRegisteredFCMToken = async () => {
+  try {
+    const fcmToken = await getFCMToken();
+    const newFcmToken = await messaging().getToken();
+
+    if (fcmToken !== newFcmToken) {
+      const { error } = await registerFcmToken(newFcmToken);
+
+      if (error) throw error;
+
+      const keyAddress = (await loadAddress()) || '';
+      const keyNetwork: NetworkType = await getNetwork();
+
+      await saveSecureFCMToken(newFcmToken, keyAddress, keyNetwork);
+
+      logger.log('New FCM token now registered');
+    } else {
+      logger.log('FCM token already registered for this account');
+    }
+  } catch (error) {
+    logger.sentry('Error trying to register FCM token', error);
+  }
 };
 
 export const getPermissionStatus = (): Promise<FirebaseMessagingTypes.AuthorizationStatus> =>
@@ -41,142 +99,6 @@ export const needsNotificationPermission = async (): Promise<
       'Error checking if a user has push notifications permission',
       error
     );
-  }
-};
-
-export const getFCMToken = async (): Promise<FCMTokenStorageType> => {
-  try {
-    const {
-      data: { fcmToken, ...addressesByNetwork },
-    } = ((await getLocal(DEVICE_FCM_TOKEN_KEY)) || {
-      data: { fcmToken: null },
-    }) as any;
-
-    if (!fcmToken) {
-      return { fcmToken: null };
-    }
-
-    return { fcmToken, addressesByNetwork };
-  } catch {
-    return { fcmToken: null };
-  }
-};
-
-export const removeFCMToken = async (address: string) => {
-  try {
-    const network: NetworkType = await getNetwork();
-    const { fcmToken, addressesByNetwork } = await getFCMToken();
-
-    if (
-      fcmToken &&
-      addressesByNetwork &&
-      addressesByNetwork[network] &&
-      addressesByNetwork[network].includes(address)
-    ) {
-      const response = await unregisterFcmToken();
-
-      if ('data' in response) {
-        logger.sentry('Unregistering FCM Token', response);
-
-        // remove address from AsyncStorage for all networks
-        for (const networkName in addressesByNetwork) {
-          addressesByNetwork[networkName as NetworkType] = addressesByNetwork[
-            networkName as NetworkType
-          ].filter((addr: string) => addr !== address);
-        }
-
-        await saveLocal(DEVICE_FCM_TOKEN_KEY, {
-          data: {
-            ...addressesByNetwork,
-            fcmToken,
-          },
-        });
-      }
-    }
-  } catch (e) {
-    logger.sentry('Unregister FcmToken failed --', e);
-  }
-};
-
-interface FCMTokenStoredReturn {
-  isTokenStored: boolean;
-  addressesByNetwork?: Record<NetworkType, string[]>;
-  fcmToken: string | null;
-}
-
-// check if token's stored by confirming addresses includes wallet address
-export const isFCMTokenStored = async (
-  walletAddress: string
-): Promise<FCMTokenStoredReturn> => {
-  const { fcmToken, addressesByNetwork } = await getFCMToken();
-  const network: NetworkType = await getNetwork();
-  return {
-    isTokenStored:
-      !!fcmToken &&
-      (addressesByNetwork?.[network] || []).includes(walletAddress),
-    fcmToken,
-    addressesByNetwork,
-  };
-};
-
-/**
- * The Push Token needs to be re-registered within each network, this function
- * validates if the device token is saved for current selected network,
- * if not we register it in the Hub and store the token locally
- * associated with the selected network.
- */
-export const storeRegisteredFCMToken = async () => {
-  try {
-    const walletAddress = (await loadAddress()) || '';
-
-    const {
-      isTokenStored,
-      addressesByNetwork,
-      fcmToken,
-    } = await isFCMTokenStored(walletAddress);
-
-    if (!isTokenStored) {
-      const newFcmToken = await messaging().getToken();
-
-      const { error } = await registerFcmToken(newFcmToken);
-
-      if (!error) {
-        const network: NetworkType = await getNetwork();
-
-        // if newFcmToken is same as old stored one, then add wallet address to asyncStorage,
-        // otherwise replace addresses value with [walletAddress] so can be replaced in next app load on other accounts
-        if (fcmToken !== newFcmToken) {
-          saveLocal(DEVICE_FCM_TOKEN_KEY, {
-            data: { fcmToken: newFcmToken, [network]: [walletAddress] },
-          });
-
-          logger.log('FCM token changed and was registered for', network);
-        } else {
-          saveLocal(DEVICE_FCM_TOKEN_KEY, {
-            data: {
-              fcmToken: newFcmToken,
-              ...addressesByNetwork,
-              [network]: [
-                ...(addressesByNetwork?.[network] || []),
-                walletAddress,
-              ].filter(
-                (address, index, self) => self.indexOf(address) === index // remove duplicates
-              ),
-            },
-          });
-
-          logger.log('FCM token registered for', network);
-        }
-
-        return;
-      }
-
-      logger.sentry('FCM token register failed!', walletAddress);
-    } else {
-      logger.log('FCM token already registered for this account');
-    }
-  } catch (error) {
-    logger.sentry('Error trying to register FCM token', error);
   }
 };
 
@@ -206,17 +128,15 @@ export const registerTokenRefreshListener = () =>
     try {
       const walletAddress = (await loadAddress()) || '';
 
-      const { data } = await registerFcmToken(fcmToken);
+      const { error } = await registerFcmToken(fcmToken);
 
-      if (data) {
-        const network = await getNetwork();
-        saveLocal(DEVICE_FCM_TOKEN_KEY, {
-          data: { fcmToken, [network]: [walletAddress] },
-        });
-      }
+      if (error) throw error;
+
+      const network = await getNetwork();
+      await saveSecureFCMToken(fcmToken, walletAddress, network);
     } catch (error) {
       logger.sentry(
-        'registerTokenRefreshListener - cannot register refreshed fcm token',
+        'Error on registerTokenRefreshListener, cannot register refreshed fcm token',
         error
       );
     }

--- a/cardstack/src/services/hub/hub-service.ts
+++ b/cardstack/src/services/hub/hub-service.ts
@@ -74,7 +74,7 @@ export const fetchHubBaseQuery: BaseQueryFn<
 
   // Append FCM Token to URL.
   if (extraOptionsOverwrite.appendFCMToken) {
-    const { fcmToken } = await getFCMToken();
+    const fcmToken = (await getFCMToken()) || '';
 
     if (typeof args === 'string') {
       args += `/${fcmToken}`;

--- a/cardstack/src/services/hub/notifications/hub-notifications-api.ts
+++ b/cardstack/src/services/hub/notifications/hub-notifications-api.ts
@@ -28,11 +28,10 @@ export const hubNotifications = hubApi.injectEndpoints({
         }),
       }),
     }),
-    unregisterFcmToken: builder.mutation<string, void>({
-      query: () => ({
-        url: `${routes.registerFCMToken}`,
+    unregisterFcmToken: builder.mutation<string, RegisterFCMTokenQueryParams>({
+      query: ({ fcmToken }) => ({
+        url: `${routes.registerFCMToken}/${fcmToken}`,
         method: 'DELETE',
-        extraOptions: { appendFCMToken: true },
         responseHandler: response => response.text(),
       }),
     }),

--- a/cardstack/src/services/hub/notifications/hub-notifications-service.ts
+++ b/cardstack/src/services/hub/notifications/hub-notifications-service.ts
@@ -9,5 +9,7 @@ export const registerFcmToken = (fcmToken: string) =>
     hubNotifications.endpoints.registerFcmToken.initiate({ fcmToken })
   );
 
-export const unregisterFcmToken = () =>
-  store.dispatch(hubNotifications.endpoints.unregisterFcmToken.initiate());
+export const unregisterFcmToken = (fcmToken: string) =>
+  store.dispatch(
+    hubNotifications.endpoints.unregisterFcmToken.initiate({ fcmToken })
+  );


### PR DESCRIPTION
### Description

This PR simplifies to the bare minimum the data stored for FCM tokens. It also saves now on SecureStore, even though FCM tokens are fine being outside secure store, I think it doesn't hurt to be saved securely and makes now all tokens saved in the same place.

Also it's now one less place that uses react-native-store.

I refrained from creating a firebase hook, because there's not enough advantages and doesn't really exclude the need for imperative calls or the model.

- [x] Completes #(CS-4991)

### Checklist

- [x] Tested on iOS
- [x] Tested on Android

*no ui changes*