### PR TITLE
[Fix]: Add missing fcmtoken for wc push notifications

### DIFF
--- a/src/redux/walletconnect.js
+++ b/src/redux/walletconnect.js
@@ -58,7 +58,7 @@ const baseCloudFunctionsUrl =
 // -- Actions ---------------------------------------- //
 const getNativeOptions = async () => {
   const language = 'en'; // TODO use lang from settings
-  const token = (await getFCMToken()).fcmToken;
+  const token = await getFCMToken();
 
   const nativeOptions = {
     clientMeta: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2472,13 +2472,6 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
-"@bankify/react-native-animate-number@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@bankify/react-native-animate-number/-/react-native-animate-number-0.2.1.tgz#80b2d700d0556b2d57ec1757a37454fcfbd968b8"
-  integrity sha512-rBIiZZWAU6Nfr7bqJ6Dc0vAqk8Xf0LU3otrad9jbrJQOUJRUSUf9nWttQVLW4/alKTYq1kXkGYJ1l4dsTQbLmA==
-  dependencies:
-    babel-plugin-syntax-async-functions "^6.8.0"
-
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
@@ -8952,11 +8945,6 @@ babel-plugin-rewire@^1.2.0:
     "@babel/helper-module-imports" "^7.16.0"
     babel-plugin-syntax-jsx "^6.18.0"
     lodash "^4.17.11"
-
-babel-plugin-syntax-async-functions@^6.8.0:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
-  integrity sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=
 
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"


### PR DESCRIPTION
### Description

After the fcm refactor I've noticed an error on the logs, and this function was trying to get the token in the old way, this PR fixes the issue, to keep wc notification working, it also updates the yarn.lock to remove an old dependency.