### PR TITLE
[CS-4994]: Avoid creating multiple websockets for same network 

### DIFF
--- a/cardstack/src/components/AssetList/useAssetList.ts
+++ b/cardstack/src/components/AssetList/useAssetList.ts
@@ -27,10 +27,7 @@ export const useAssetList = ({
   const { navigate, setParams } = useNavigation();
   const { params } = useRoute<AssetListRouteType>();
 
-  const {
-    hasClaimableRewards,
-    isLoading: rewardsFetchLoading,
-  } = useRewardsDataFetch();
+  const { hasClaimableRewards } = useRewardsDataFetch();
 
   const {
     sections,
@@ -108,8 +105,7 @@ export const useAssetList = ({
   ]);
 
   return {
-    isLoading:
-      isLoadingAssets || isLoadingSafesDiffAccount || rewardsFetchLoading,
+    isLoading: isLoadingAssets || isLoadingSafesDiffAccount,
     isFetchingSafes,
     refreshing: isRefetching,
     sections,

--- a/cardstack/src/models/ethers-wallet.ts
+++ b/cardstack/src/models/ethers-wallet.ts
@@ -1,4 +1,4 @@
-import { utils, Wallet } from 'ethers';
+import { ethers, utils, Wallet } from 'ethers';
 
 import {
   DEFAULT_HD_PATH,
@@ -8,6 +8,7 @@ import {
 import logger from 'logger';
 
 import Web3Instance from './web3-instance';
+import Web3WsProvider from './web3-provider';
 
 export interface EthersSignerWithSeedParams {
   accountIndex: number;
@@ -54,7 +55,9 @@ const getEthersWallet = async (accountAddress?: string) => {
   try {
     const privateKey = await loadPrivateKey(accountAddress);
 
-    return new Wallet(privateKey);
+    const provider = (await Web3WsProvider.getEthers()) as ethers.providers.Provider;
+
+    return new Wallet(privateKey, provider);
   } catch (e) {
     logger.sentry('Error getting ethersWallet' + e);
   }

--- a/cardstack/src/models/web3-instance.ts
+++ b/cardstack/src/models/web3-instance.ts
@@ -1,5 +1,3 @@
-import { ethers } from 'ethers';
-import { ExternalProvider } from 'ethers/node_modules/@ethersproject/providers';
 import Web3 from 'web3';
 import { WebsocketProvider } from 'web3-core';
 
@@ -11,8 +9,6 @@ import logger from 'logger';
 import Web3WsProvider from './web3-provider';
 
 const web3Instance: Web3 = new Web3();
-
-let ethersWeb3Instance: ethers.providers.Web3Provider | null = null;
 
 const Web3Instance = {
   get: async () => {
@@ -34,27 +30,6 @@ const Web3Instance = {
   // Separated instance with custom network for wc requests
   withNetwork: async (network: NetworkType) =>
     new Web3(await Web3WsProvider.get(network)),
-  getEthers: async (network?: NetworkType) => {
-    if (!ethersWeb3Instance) {
-      try {
-        const currentNetwork = network || (await getNetwork());
-
-        const provider = ((await Web3WsProvider.get(
-          currentNetwork
-        )) as unknown) as ExternalProvider;
-
-        ethersWeb3Instance = new ethers.providers.Web3Provider(provider);
-
-        await ethersWeb3Instance?._ready();
-
-        logger.log('[Web3-Ethers]: ready!');
-      } catch (e) {
-        logger.error('[Web3-Ethers]: Failed getting provider', e);
-      }
-    }
-
-    return ethersWeb3Instance as ethers.providers.Provider;
-  },
 };
 
 export default Web3Instance;

--- a/cardstack/src/models/web3-instance.ts
+++ b/cardstack/src/models/web3-instance.ts
@@ -3,6 +3,7 @@ import { WebsocketProvider } from 'web3-core';
 
 import { NetworkType } from '@cardstack/types';
 
+import { getNetwork } from '@rainbow-me/handlers/localstorage/globalSettings';
 import logger from 'logger';
 
 import Web3WsProvider from './web3-provider';
@@ -16,7 +17,9 @@ const Web3Instance = {
 
     try {
       if (web3Instance.currentProvider === null || isProviderDisconnected) {
-        web3Instance.setProvider(await Web3WsProvider.get());
+        const network = await getNetwork();
+
+        web3Instance.setProvider(await Web3WsProvider.get(network));
       }
     } catch (e) {
       logger.log('Failed while getting web3Instance', e);

--- a/cardstack/src/models/web3-instance.ts
+++ b/cardstack/src/models/web3-instance.ts
@@ -34,20 +34,26 @@ const Web3Instance = {
   // Separated instance with custom network for wc requests
   withNetwork: async (network: NetworkType) =>
     new Web3(await Web3WsProvider.get(network)),
-  getEthers: async (network: NetworkType) => {
+  getEthers: async (network?: NetworkType) => {
     if (!ethersWeb3Instance) {
       try {
+        const currentNetwork = network || (await getNetwork());
+
         const provider = ((await Web3WsProvider.get(
-          network
+          currentNetwork
         )) as unknown) as ExternalProvider;
 
         ethersWeb3Instance = new ethers.providers.Web3Provider(provider);
+
+        await ethersWeb3Instance?._ready();
+
+        logger.log('[Web3-Ethers]: ready!');
       } catch (e) {
         logger.error('[Web3-Ethers]: Failed getting provider', e);
       }
     }
 
-    return ethersWeb3Instance?.ready;
+    return ethersWeb3Instance as ethers.providers.Provider;
   },
 };
 

--- a/cardstack/src/models/web3-instance.ts
+++ b/cardstack/src/models/web3-instance.ts
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers';
+import { ExternalProvider } from 'ethers/node_modules/@ethersproject/providers';
 import Web3 from 'web3';
 import { WebsocketProvider } from 'web3-core';
 
@@ -9,6 +11,8 @@ import logger from 'logger';
 import Web3WsProvider from './web3-provider';
 
 const web3Instance: Web3 = new Web3();
+
+let ethersWeb3Instance: ethers.providers.Web3Provider | null = null;
 
 const Web3Instance = {
   get: async () => {
@@ -30,6 +34,21 @@ const Web3Instance = {
   // Separated instance with custom network for wc requests
   withNetwork: async (network: NetworkType) =>
     new Web3(await Web3WsProvider.get(network)),
+  getEthers: async (network: NetworkType) => {
+    if (!ethersWeb3Instance) {
+      try {
+        const provider = ((await Web3WsProvider.get(
+          network
+        )) as unknown) as ExternalProvider;
+
+        ethersWeb3Instance = new ethers.providers.Web3Provider(provider);
+      } catch (e) {
+        logger.error('[Web3-Ethers]: Failed getting provider', e);
+      }
+    }
+
+    return ethersWeb3Instance?.ready;
+  },
 };
 
 export default Web3Instance;

--- a/cardstack/src/models/web3-provider.ts
+++ b/cardstack/src/models/web3-provider.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import {
   getConstantByNetwork,
   getWeb3ConfigByNetwork,
@@ -10,71 +9,90 @@ import { WebsocketProvider } from 'web3-core';
 import { remoteFlags } from '@cardstack/services/remote-config';
 import { NetworkType } from '@cardstack/types';
 
-import { getNetwork } from '@rainbow-me/handlers/localstorage/globalSettings';
 import logger from 'logger';
+
+const createProvider = async (network: NetworkType) => {
+  const hubConfig = new HubConfig(getConstantByNetwork('hubUrl', network));
+
+  const shouldUseSokolHttpNode =
+    network === NetworkType.sokol && remoteFlags().useHttpSokolNode;
+
+  const hubConfigResponse = await hubConfig.getConfig();
+
+  const { rpcNodeWssUrl } = getWeb3ConfigByNetwork(hubConfigResponse, network);
+
+  const node = shouldUseSokolHttpNode
+    ? hubConfigResponse.web3.layer2RpcNodeHttpsUrl
+    : rpcNodeWssUrl;
+
+  const wssProvider = new Web3.providers.WebsocketProvider(node, {
+    timeout: 30000,
+    reconnect: {
+      auto: true,
+      delay: 1000,
+      onTimeout: true,
+      maxAttempts: 10,
+    },
+    clientConfig: {
+      keepalive: true,
+      keepaliveInterval: 60000,
+      maxReceivedFrameSize: 100000000,
+      maxReceivedMessageSize: 100000000,
+    },
+  });
+
+  wssProvider?.on('connect', () => {
+    logger.sentry('[WS socket] connected', network);
+  });
+
+  //@ts-expect-error it's wrongly typed bc it says it doesn't have param, but it does
+  wssProvider?.on('error', e => {
+    provider?.reconnect();
+    logger.sentry('[WS socket] error', e, network);
+  });
+
+  //@ts-expect-error ditto
+  wssProvider?.on('end', e => {
+    provider?.reconnect();
+    logger.sentry('[WS socket] ended', e);
+  });
+
+  //@ts-expect-error ditto
+  wssProvider?.on('close', e => {
+    provider?.reconnect();
+    logger.sentry('[WS socket] close', e);
+  });
+
+  return wssProvider;
+};
 
 let provider: WebsocketProvider | null = null;
 
+// Flag to avoid creating multiple instances while connecting
+let isConnecting = false;
+
+const checkProviderConnection = () =>
+  new Promise<WebsocketProvider>(resolve => {
+    const timer = setInterval(() => {
+      if (provider?.connected) {
+        clearInterval(timer);
+        isConnecting = false;
+        resolve(provider);
+      }
+    }, 10);
+  });
+
 const Web3WsProvider = {
-  get: async (network?: NetworkType) => {
-    if (provider === null || network || !provider?.connected) {
-      const currentNetwork = network || (await getNetwork());
+  get: async (network: NetworkType) => {
+    if (!provider?.connected && !isConnecting) {
+      isConnecting = true;
 
-      const hubConfig = new HubConfig(
-        getConstantByNetwork('hubUrl', currentNetwork)
-      );
-
-      const shouldUseSokolHttpNode =
-        currentNetwork === NetworkType.sokol && remoteFlags().useHttpSokolNode;
-
-      const hubConfigResponse = await hubConfig.getConfig();
-
-      const { rpcNodeWssUrl } = getWeb3ConfigByNetwork(
-        hubConfigResponse,
-        currentNetwork
-      );
-
-      const node = shouldUseSokolHttpNode
-        ? hubConfigResponse.web3.layer2RpcNodeHttpsUrl
-        : rpcNodeWssUrl;
-
-      provider = new Web3.providers.WebsocketProvider(node, {
-        timeout: 30000,
-        reconnect: {
-          auto: true,
-          delay: 1000,
-          onTimeout: true,
-          maxAttempts: 10,
-        },
-        clientConfig: {
-          keepalive: true,
-          keepaliveInterval: 60000,
-          maxReceivedFrameSize: 100000000,
-          maxReceivedMessageSize: 100000000,
-        },
-      });
-
-      provider?.on('connect', () => {
-        logger.sentry('[WS socket] connected', network);
-      });
-
-      //@ts-ignore it's wrongly typed bc it says it doesn't have param, but it does
-      provider?.on('error', e => {
-        logger.sentry('[WS socket] error', e, network);
-      });
-
-      //@ts-ignore
-      provider?.on('end', e => {
-        logger.sentry('[WS socket] ended', e);
-      });
-
-      //@ts-ignore
-      provider?.on('close', e => {
-        logger.sentry('[WS socket] close', e);
-      });
+      provider = await createProvider(network);
     }
 
-    return provider;
+    const connectedProvider = await checkProviderConnection();
+
+    return connectedProvider;
   },
 };
 

--- a/cardstack/src/models/web3-provider.ts
+++ b/cardstack/src/models/web3-provider.ts
@@ -2,28 +2,57 @@ import {
   getConstantByNetwork,
   getWeb3ConfigByNetwork,
   HubConfig,
+  supportedChainsArray,
 } from '@cardstack/cardpay-sdk';
+import { ethers } from 'ethers';
 import Web3 from 'web3';
 import { WebsocketProvider } from 'web3-core';
 
 import { remoteFlags } from '@cardstack/services/remote-config';
 import { NetworkType } from '@cardstack/types';
 
+import { getNetwork } from '@rainbow-me/handlers/localstorage/globalSettings';
 import logger from 'logger';
 
+type NetworksMap = Record<NetworkType, string>;
+
+const networks = supportedChainsArray.reduce(
+  (chains, network) => ({ ...chains, [network]: '' }),
+  {} as NetworksMap
+);
+
+const nodeConfigCache = { current: networks };
+
+const getNodeConfig = async (network: NetworkType) => {
+  const currentNode = nodeConfigCache.current[network];
+
+  if (!currentNode) {
+    const hubConfig = new HubConfig(getConstantByNetwork('hubUrl', network));
+
+    const shouldUseSokolHttpNode =
+      network === NetworkType.sokol && remoteFlags().useHttpSokolNode;
+
+    const hubConfigResponse = await hubConfig.getConfig();
+
+    const { rpcNodeWssUrl } = getWeb3ConfigByNetwork(
+      hubConfigResponse,
+      network
+    );
+
+    const node = shouldUseSokolHttpNode
+      ? hubConfigResponse.web3.layer2RpcNodeHttpsUrl
+      : rpcNodeWssUrl;
+
+    nodeConfigCache.current = { ...nodeConfigCache.current, [network]: node };
+
+    return node;
+  }
+
+  return currentNode;
+};
+
 const createProvider = async (network: NetworkType) => {
-  const hubConfig = new HubConfig(getConstantByNetwork('hubUrl', network));
-
-  const shouldUseSokolHttpNode =
-    network === NetworkType.sokol && remoteFlags().useHttpSokolNode;
-
-  const hubConfigResponse = await hubConfig.getConfig();
-
-  const { rpcNodeWssUrl } = getWeb3ConfigByNetwork(hubConfigResponse, network);
-
-  const node = shouldUseSokolHttpNode
-    ? hubConfigResponse.web3.layer2RpcNodeHttpsUrl
-    : rpcNodeWssUrl;
+  const node = await getNodeConfig(network);
 
   const wssProvider = new Web3.providers.WebsocketProvider(node, {
     timeout: 30000,
@@ -67,9 +96,11 @@ const createProvider = async (network: NetworkType) => {
 };
 
 let provider: WebsocketProvider | null = null;
-
 // Flag to avoid creating multiple instances while connecting
 let isConnecting = false;
+
+let ethersProvider: ethers.providers.WebSocketProvider | null = null;
+let ethersReady: Promise<ethers.providers.Network>;
 
 const checkProviderConnection = () =>
   new Promise<WebsocketProvider>(resolve => {
@@ -93,6 +124,25 @@ const Web3WsProvider = {
     const connectedProvider = await checkProviderConnection();
 
     return connectedProvider;
+  },
+  getEthers: async (network?: NetworkType) => {
+    try {
+      const currentNetwork = network || (await getNetwork());
+
+      const node = await getNodeConfig(currentNetwork);
+
+      if (!ethersProvider) {
+        ethersProvider = new ethers.providers.WebSocketProvider(node);
+
+        ethersReady = ethersProvider.ready;
+      }
+    } catch (e) {
+      logger.log('[Ethers Wss]: Error setting provider');
+    }
+
+    await ethersReady;
+
+    return ethersProvider;
   },
 };
 

--- a/cardstack/src/redux/collectibles.ts
+++ b/cardstack/src/redux/collectibles.ts
@@ -1,12 +1,12 @@
 import assert from 'assert';
 
 import { captureException } from '@sentry/react-native';
-import { Contract } from 'ethers';
+import { Contract, ethers } from 'ethers';
 import { concat, isEmpty } from 'lodash';
 import { AnyAction } from 'redux';
 
 import { IPFS_HTTP_URL } from '@cardstack/constants';
-import Web3Instance from '@cardstack/models/web3-instance';
+import Web3WsProvider from '@cardstack/models/web3-provider';
 import { Asset } from '@cardstack/services/eoa-assets/eoa-assets-types';
 import {
   apiFetchCollectiblesForOwner,
@@ -182,7 +182,9 @@ const fetchNFTsViaRpcNode = () => async (
 
   // enhance them with metadata from the tokenURI so that they have a similar shape to what parseCollectiblesFromOpenSeaResponse creates
   try {
-    const web3Provider = await Web3Instance.getEthers(network);
+    const web3Provider = (await Web3WsProvider.getEthers(
+      network
+    )) as ethers.providers.Provider;
 
     const collectibles = (
       await Promise.all(

--- a/cardstack/src/redux/collectibles.ts
+++ b/cardstack/src/redux/collectibles.ts
@@ -6,6 +6,7 @@ import { concat, isEmpty } from 'lodash';
 import { AnyAction } from 'redux';
 
 import { IPFS_HTTP_URL } from '@cardstack/constants';
+import Web3Instance from '@cardstack/models/web3-instance';
 import { Asset } from '@cardstack/services/eoa-assets/eoa-assets-types';
 import {
   apiFetchCollectiblesForOwner,
@@ -22,8 +23,6 @@ import {
 import { AppDispatch, AppGetState } from '@rainbow-me/redux/store';
 import { erc721ABI } from '@rainbow-me/references';
 import logger from 'logger';
-
-import { getEtherWeb3Provider } from '../../../src/handlers/web3';
 
 // -- Constants ------------------------------------------------------------- //
 const COLLECTIBLES_LOAD_REQUEST = 'collectibles/COLLECTIBLES_LOAD_REQUEST';
@@ -183,7 +182,7 @@ const fetchNFTsViaRpcNode = () => async (
 
   // enhance them with metadata from the tokenURI so that they have a similar shape to what parseCollectiblesFromOpenSeaResponse creates
   try {
-    const web3Provider = await getEtherWeb3Provider();
+    const web3Provider = await Web3Instance.getEthers(network);
 
     const collectibles = (
       await Promise.all(

--- a/cardstack/src/services/eoa-assets/eoa-assets-services.ts
+++ b/cardstack/src/services/eoa-assets/eoa-assets-services.ts
@@ -198,7 +198,7 @@ export const getAccountAssets = async ({
     network
   );
 
-  await store.dispatch(collectiblesRefreshState());
+  store.dispatch(collectiblesRefreshState());
 
   return tokensInWallet;
 };

--- a/src/handlers/localstorage/globalSettings.js
+++ b/src/handlers/localstorage/globalSettings.js
@@ -2,6 +2,7 @@ import { isSupportedChain } from '@cardstack/cardpay-sdk';
 import { getGlobal, removeLocal, saveGlobal } from './common';
 
 import { NetworkType } from '@cardstack/types';
+import { logger } from 'logger';
 
 const IMAGE_METADATA = 'imageMetadata';
 const LANGUAGE = 'language';
@@ -38,13 +39,18 @@ export const saveLanguage = language => saveGlobal(LANGUAGE, language);
 export const getNetwork = async () => {
   const defaultNetwork = NetworkType.gnosis;
 
-  const network = await getGlobal(NETWORK, defaultNetwork);
+  try {
+    const network = await getGlobal(NETWORK, defaultNetwork);
 
-  if (isSupportedChain(network)) {
-    return network;
+    if (isSupportedChain(network)) {
+      return network;
+    }
+
+    await saveNetwork(defaultNetwork);
+  } catch (e) {
+    logger.sentry('[Storage]: Failed getting network, returning default');
   }
 
-  await saveNetwork(defaultNetwork);
   return defaultNetwork;
 };
 

--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -18,14 +18,14 @@ import Web3 from 'web3';
 import smartContractMethods from '../references/smartcontract-methods.json';
 import ethereumUtils from '../utils/ethereumUtils';
 
-import Web3Instance from '@cardstack/models/web3-instance';
+import Web3WsProvider from '@cardstack/models/web3-provider';
 import { AssetTypes, NetworkType } from '@cardstack/types';
 import { isNativeToken } from '@cardstack/utils/cardpay-utils';
 import { erc721ABI, ethUnits } from '@rainbow-me/references';
 import logger from 'logger';
 
 export const sendRpcCall = async payload => {
-  const web3ProviderInstance = await Web3Instance.getEthers();
+  const web3ProviderInstance = await Web3WsProvider.getEthers();
   return web3ProviderInstance.send(payload.method, payload.params);
 };
 
@@ -101,7 +101,7 @@ export const estimateTransferNFTGas = async (
   paddingFactor = 1.1
 ) => {
   try {
-    const provider = await Web3Instance.getEthers();
+    const provider = await Web3WsProvider.getEthers();
 
     const contract = new Contract(params.to, erc721ABI, provider);
     const contractEstGas = await contract.estimateGas.transferFrom(
@@ -127,7 +127,7 @@ export const estimateTransferNFTGas = async (
  */
 export const estimateGas = async estimateGasData => {
   try {
-    const web3ProviderInstance = await Web3Instance.getEthers();
+    const web3ProviderInstance = await Web3WsProvider.getEthers();
     const estimatedGas = await web3ProviderInstance.estimateGas(
       estimateGasData
     );
@@ -145,7 +145,7 @@ export const estimateGasWithPadding = async (
 ) => {
   try {
     const txPayloadToEstimate = { ...txPayload };
-    const web3ProviderInstance = await Web3Instance.getEthers(network);
+    const web3ProviderInstance = await Web3WsProvider.getEthers(network);
     const { gasLimit } = await web3ProviderInstance.getBlock();
     const { to, data } = txPayloadToEstimate;
     // 1 - Check if the receiver is a contract
@@ -185,7 +185,7 @@ export const estimateGasWithPadding = async (
  * @return {Promise}
  */
 export const getTransaction = async hash =>
-  await Web3Instance.getEthers()?.getTransaction(hash);
+  await Web3WsProvider.getEthers()?.getTransaction(hash);
 
 /**
  * @desc get address transaction count
@@ -193,7 +193,7 @@ export const getTransaction = async hash =>
  * @return {Promise}
  */
 export const getTransactionCount = async address =>
-  await Web3Instance.getEthers()?.getTransactionCount(address, 'pending');
+  await Web3WsProvider.getEthers()?.getTransactionCount(address, 'pending');
 
 /**
  * @desc get transaction details
@@ -248,7 +248,7 @@ const resolveNameOrAddress = async nameOrAddress => {
     if (/^([\w-]+\.)+(crypto)$/.test(nameOrAddress)) {
       return resolveUnstoppableDomain(nameOrAddress);
     }
-    const web3ProviderInstance = await Web3Instance.getEthers();
+    const web3ProviderInstance = await Web3WsProvider.getEthers();
     return web3ProviderInstance.resolveName(nameOrAddress);
   }
   return nameOrAddress;

--- a/src/handlers/web3.js
+++ b/src/handlers/web3.js
@@ -21,26 +21,11 @@ import ethereumUtils from '../utils/ethereumUtils';
 import Web3Instance from '@cardstack/models/web3-instance';
 import { AssetTypes, NetworkType } from '@cardstack/types';
 import { isNativeToken } from '@cardstack/utils/cardpay-utils';
-import { getNetwork } from '@rainbow-me/handlers/localstorage/globalSettings';
 import { erc721ABI, ethUnits } from '@rainbow-me/references';
 import logger from 'logger';
 
-/**
- * @desc returns connected web3Provider
- * @param {String} network
- */
-
-export const getEtherWeb3Provider = async (network = undefined) => {
-  const currentNetwork = network || (await getNetwork());
-  const web3 = await Web3Instance.getEthers(currentNetwork);
-
-  logger.log('[Web3-Ethers] ready!');
-
-  return web3;
-};
-
 export const sendRpcCall = async payload => {
-  const web3ProviderInstance = await getEtherWeb3Provider();
+  const web3ProviderInstance = await Web3Instance.getEthers();
   return web3ProviderInstance.send(payload.method, payload.params);
 };
 
@@ -116,7 +101,7 @@ export const estimateTransferNFTGas = async (
   paddingFactor = 1.1
 ) => {
   try {
-    const provider = await getEtherWeb3Provider();
+    const provider = await Web3Instance.getEthers();
 
     const contract = new Contract(params.to, erc721ABI, provider);
     const contractEstGas = await contract.estimateGas.transferFrom(
@@ -142,7 +127,7 @@ export const estimateTransferNFTGas = async (
  */
 export const estimateGas = async estimateGasData => {
   try {
-    const web3ProviderInstance = await getEtherWeb3Provider();
+    const web3ProviderInstance = await Web3Instance.getEthers();
     const estimatedGas = await web3ProviderInstance.estimateGas(
       estimateGasData
     );
@@ -160,7 +145,7 @@ export const estimateGasWithPadding = async (
 ) => {
   try {
     const txPayloadToEstimate = { ...txPayload };
-    const web3ProviderInstance = await getEtherWeb3Provider(network);
+    const web3ProviderInstance = await Web3Instance.getEthers(network);
     const { gasLimit } = await web3ProviderInstance.getBlock();
     const { to, data } = txPayloadToEstimate;
     // 1 - Check if the receiver is a contract
@@ -200,7 +185,7 @@ export const estimateGasWithPadding = async (
  * @return {Promise}
  */
 export const getTransaction = async hash =>
-  await getEtherWeb3Provider()?.getTransaction(hash);
+  await Web3Instance.getEthers()?.getTransaction(hash);
 
 /**
  * @desc get address transaction count
@@ -208,7 +193,7 @@ export const getTransaction = async hash =>
  * @return {Promise}
  */
 export const getTransactionCount = async address =>
-  await getEtherWeb3Provider()?.getTransactionCount(address, 'pending');
+  await Web3Instance.getEthers()?.getTransactionCount(address, 'pending');
 
 /**
  * @desc get transaction details
@@ -263,7 +248,7 @@ const resolveNameOrAddress = async nameOrAddress => {
     if (/^([\w-]+\.)+(crypto)$/.test(nameOrAddress)) {
       return resolveUnstoppableDomain(nameOrAddress);
     }
-    const web3ProviderInstance = await getEtherWeb3Provider();
+    const web3ProviderInstance = await Web3Instance.getEthers();
     return web3ProviderInstance.resolveName(nameOrAddress);
   }
   return nameOrAddress;

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -1,6 +1,6 @@
 import { isValidAddress } from 'ethereumjs-util';
 import { utils as ethersUtils } from 'ethers';
-import Web3Instance from '@cardstack/models/web3-instance';
+import Web3WsProvider from '@cardstack/models/web3-provider';
 import {
   isHexStringIgnorePrefix,
   resolveUnstoppableDomain,
@@ -44,7 +44,7 @@ export const isUnstoppableAddressFormat = address => {
 export const checkIsValidAddressOrDomain = async address => {
   if (isENSAddressFormat(address)) {
     try {
-      const web3Provider = await Web3Instance.getEthers();
+      const web3Provider = await Web3WsProvider.getEthers();
       const resolvedAddress = await web3Provider.resolveName(address);
       return !!resolvedAddress;
     } catch (error) {

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -1,7 +1,7 @@
 import { isValidAddress } from 'ethereumjs-util';
 import { utils as ethersUtils } from 'ethers';
+import Web3Instance from '@cardstack/models/web3-instance';
 import {
-  getEtherWeb3Provider,
   isHexStringIgnorePrefix,
   resolveUnstoppableDomain,
 } from '@rainbow-me/handlers/web3';
@@ -44,7 +44,7 @@ export const isUnstoppableAddressFormat = address => {
 export const checkIsValidAddressOrDomain = async address => {
   if (isENSAddressFormat(address)) {
     try {
-      const web3Provider = await getEtherWeb3Provider();
+      const web3Provider = await Web3Instance.getEthers();
       const resolvedAddress = await web3Provider.resolveName(address);
       return !!resolvedAddress;
     } catch (error) {

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -17,11 +17,7 @@ import {
   DEPRECATED_authenticateWithPIN,
   DEPRECATED_getExistingPIN,
 } from '../handlers/authentication';
-import {
-  addHexPrefix,
-  getEtherWeb3Provider,
-  isHexStringIgnorePrefix,
-} from '../handlers/web3';
+import { addHexPrefix, isHexStringIgnorePrefix } from '../handlers/web3';
 import showWalletErrorAlert from '../helpers/support';
 import { isValidSeed } from '../helpers/validators';
 import { EthereumWalletType } from '../helpers/walletTypes';
@@ -48,6 +44,7 @@ import {
   updateSecureStorePin,
   wipeSecureStorage,
 } from '@cardstack/models/secure-storage';
+import Web3Instance from '@cardstack/models/web3-instance';
 import { clearFlags } from '@cardstack/redux/persistedFlagsSlice';
 import { restartApp } from '@cardstack/utils';
 import { Device } from '@cardstack/utils/device';
@@ -172,7 +169,7 @@ export const loadWallet = async (): Promise<null | ethers.Wallet> => {
   const privateKey = await loadPrivateKey();
 
   if (privateKey) {
-    const web3Provider = await getEtherWeb3Provider();
+    const web3Provider = await Web3Instance.getEthers();
     return new ethers.Wallet(privateKey, web3Provider);
   }
   if (Device.isIOS) {

--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -44,7 +44,7 @@ import {
   updateSecureStorePin,
   wipeSecureStorage,
 } from '@cardstack/models/secure-storage';
-import Web3Instance from '@cardstack/models/web3-instance';
+import Web3WsProvider from '@cardstack/models/web3-provider';
 import { clearFlags } from '@cardstack/redux/persistedFlagsSlice';
 import { restartApp } from '@cardstack/utils';
 import { Device } from '@cardstack/utils/device';
@@ -169,7 +169,8 @@ export const loadWallet = async (): Promise<null | ethers.Wallet> => {
   const privateKey = await loadPrivateKey();
 
   if (privateKey) {
-    const web3Provider = await Web3Instance.getEthers();
+    const web3Provider = (await Web3WsProvider.getEthers()) as ethers.providers.Provider;
+
     return new ethers.Wallet(privateKey, web3Provider);
   }
   if (Device.isIOS) {

--- a/src/redux/settings.js
+++ b/src/redux/settings.js
@@ -6,7 +6,6 @@ import {
   saveNativeCurrency,
   saveNetwork,
 } from '../handlers/localstorage/globalSettings';
-import { etherWeb3SetHttpProvider } from '../handlers/web3';
 import { updateLanguage } from '../languages';
 
 import { dataResetState } from './data';
@@ -59,9 +58,6 @@ export const settingsLoadNetwork = () => async dispatch => {
       payload: { chainId, network },
       type: SETTINGS_UPDATE_NETWORK_SUCCESS,
     });
-
-    // Set ethersProdiver on end to avoid locking app on gnosis state in error case
-    etherWeb3SetHttpProvider(network);
   } catch (error) {
     logger.error('Error loading network settings', error);
   }

--- a/src/utils/contract.js
+++ b/src/utils/contract.js
@@ -2,10 +2,11 @@ import { captureException } from '@sentry/react-native';
 
 import { constants, Contract } from 'ethers';
 
-import { getEtherWeb3Provider, toHex } from '../handlers/web3';
+import { toHex } from '../handlers/web3';
 import { loadWallet } from '../model/wallet';
 import { ethUnits } from '../references';
 import erc20ABI from '../references/erc20-abi.json';
+import Web3Instance from '@cardstack/models/web3-instance';
 import logger from 'logger';
 
 const estimateApproveWithExchange = async (owner, spender, exchange) => {
@@ -27,7 +28,7 @@ const estimateApproveWithExchange = async (owner, spender, exchange) => {
 
 const estimateApprove = async (owner, tokenAddress, spender) => {
   logger.sentry('exchange estimate approve', { owner, spender, tokenAddress });
-  const web3Provider = await getEtherWeb3Provider();
+  const web3Provider = await Web3Instance.getEthers();
   const exchange = new Contract(tokenAddress, erc20ABI, web3Provider);
   return await estimateApproveWithExchange(owner, spender, exchange);
 };
@@ -55,7 +56,7 @@ const approve = async (
 const getRawAllowance = async (owner, token, spender) => {
   try {
     const { address: tokenAddress } = token;
-    const web3Provider = await getEtherWeb3Provider();
+    const web3Provider = await Web3Instance.getEthers();
     const tokenContract = new Contract(tokenAddress, erc20ABI, web3Provider);
     const allowance = await tokenContract.allowance(owner, spender);
     return allowance.toString();

--- a/src/utils/contract.js
+++ b/src/utils/contract.js
@@ -6,7 +6,7 @@ import { toHex } from '../handlers/web3';
 import { loadWallet } from '../model/wallet';
 import { ethUnits } from '../references';
 import erc20ABI from '../references/erc20-abi.json';
-import Web3Instance from '@cardstack/models/web3-instance';
+import Web3WsProvider from '@cardstack/models/web3-provider';
 import logger from 'logger';
 
 const estimateApproveWithExchange = async (owner, spender, exchange) => {
@@ -28,7 +28,7 @@ const estimateApproveWithExchange = async (owner, spender, exchange) => {
 
 const estimateApprove = async (owner, tokenAddress, spender) => {
   logger.sentry('exchange estimate approve', { owner, spender, tokenAddress });
-  const web3Provider = await Web3Instance.getEthers();
+  const web3Provider = await Web3WsProvider.getEthers();
   const exchange = new Contract(tokenAddress, erc20ABI, web3Provider);
   return await estimateApproveWithExchange(owner, spender, exchange);
 };
@@ -56,7 +56,7 @@ const approve = async (
 const getRawAllowance = async (owner, token, spender) => {
   try {
     const { address: tokenAddress } = token;
-    const web3Provider = await Web3Instance.getEthers();
+    const web3Provider = await Web3WsProvider.getEthers();
     const tokenContract = new Contract(tokenAddress, erc20ABI, web3Provider);
     const allowance = await tokenContract.allowance(owner, spender);
     return allowance.toString();

--- a/src/utils/methodRegistry.js
+++ b/src/utils/methodRegistry.js
@@ -1,12 +1,12 @@
 import { Contract } from 'ethers';
 import namesOverrides from '../references/method-names-overrides.json';
 import methodRegistryABI from '../references/method-registry-abi.json';
-import Web3Instance from '@cardstack/models/web3-instance';
+import Web3WsProvider from '@cardstack/models/web3-provider';
 
 const METHOD_REGISTRY_ADDRESS = '0x44691B39d1a75dC4E0A0346CBB15E310e6ED1E86';
 
 export const methodRegistryLookupAndParse = async methodSignatureBytes => {
-  const web3Provider = await Web3Instance.getEthers();
+  const web3Provider = await Web3WsProvider.getEthers();
 
   const registry = new Contract(
     METHOD_REGISTRY_ADDRESS,

--- a/src/utils/methodRegistry.js
+++ b/src/utils/methodRegistry.js
@@ -1,12 +1,13 @@
 import { Contract } from 'ethers';
-import { getEtherWeb3Provider } from '../handlers/web3';
 import namesOverrides from '../references/method-names-overrides.json';
 import methodRegistryABI from '../references/method-registry-abi.json';
+import Web3Instance from '@cardstack/models/web3-instance';
 
 const METHOD_REGISTRY_ADDRESS = '0x44691B39d1a75dC4E0A0346CBB15E310e6ED1E86';
 
 export const methodRegistryLookupAndParse = async methodSignatureBytes => {
-  const web3Provider = await getEtherWeb3Provider();
+  const web3Provider = await Web3Instance.getEthers();
+
   const registry = new Contract(
     METHOD_REGISTRY_ADDRESS,
     methodRegistryABI,


### PR DESCRIPTION
### Description
This PR checks if a ws already exists before creating a new one, it also moves the ethers provider to the new webwss model. and a bit out of scope it removes the loading of rewards from assets since there's no reward displayed on the main list. Ideally we should use the web3 ws or ethers ws, but it seems the sdk doesn't support ethers for all functions, so we'd need to migrate that first.
