### PR TITLE
[CS-5026] Fix selecting coin inside SendSheetEOA component

### DIFF
--- a/cardstack/src/hooks/gas-prices/types.ts
+++ b/cardstack/src/hooks/gas-prices/types.ts
@@ -1,11 +1,12 @@
+import { BalanceType } from '@cardstack/types';
+
 export interface ParseTxFeeParams {
   gasLimit?: string;
 }
 
-export type TxFee = Record<
-  string,
-  {
-    native: { amount: string; display: string };
-    value: { amount: string; display: string };
-  }
->;
+export interface TxFeeValue {
+  native: BalanceType;
+  value: BalanceType;
+}
+
+export type TxFee = Record<string, TxFeeValue>;

--- a/src/hooks/useMaxInputBalance.ts
+++ b/src/hooks/useMaxInputBalance.ts
@@ -1,13 +1,21 @@
 import { fromWei, greaterThan, subtract } from '@cardstack/cardpay-sdk';
 import { useCallback, useState } from 'react';
+import { TxFeeValue } from '@cardstack/hooks/gas-prices/types';
+import { AssetWithNativeType, NetworkType } from '@cardstack/types';
 import { isNativeToken } from '@cardstack/utils';
+
+interface UpdateMaxInputBalanceParams {
+  selectedAsset: AssetWithNativeType;
+  selectedFee: TxFeeValue;
+  network: NetworkType;
+}
 
 export default function useMaxInputBalance() {
   const [maxInputBalance, setMaxInputBalance] = useState('0');
 
   const updateMaxInputBalance = useCallback(
-    ({ selectedAsset, selectedFee, network }) => {
-      const assetAmount = selectedAsset.balance.amount ?? '0';
+    ({ selectedAsset, selectedFee, network }: UpdateMaxInputBalanceParams) => {
+      const assetAmount = selectedAsset.balance?.amount ?? '0';
 
       if (!isNativeToken(selectedAsset?.symbol, network)) {
         setMaxInputBalance(assetAmount);


### PR DESCRIPTION
### Description
The bug was caused by not taking into consideration that, when opening the coin selector, the `selectedAsset` is reset to `{}`. Not having the optional operator on the `balance` was breaking the app. 

While on the area, we've decided to add types to the `updateMaxInputBalance` function arguments.

- [x] Completes #CS-5026

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

https://user-images.githubusercontent.com/690904/208949919-141ffd0b-af6a-4ce1-a9d8-e67c4de8f46a.mp4

