### PR TITLE
[CS-5032, CS-5027] Notification Preferences Navigation Issues

### DIFF
--- a/cardstack/src/hooks/onboarding/__tests__/useShowOnboarding.test.ts
+++ b/cardstack/src/hooks/onboarding/__tests__/useShowOnboarding.test.ts
@@ -84,8 +84,6 @@ describe('useShowOnboarding', () => {
   });
 
   it('should navigate to notification permission flow when still not granted and has not skipped', async () => {
-    mockNeedsNotificationPermission(true);
-
     const { result } = renderHook(useShowOnboarding);
 
     act(() => {
@@ -114,22 +112,13 @@ describe('useShowOnboarding', () => {
     );
   });
 
-  it('should NOT navigate to notification permission when permissions already fullfilled', async () => {
-    mockNeedsNotificationPermission(false);
-
-    const { result } = renderHook(useShowOnboarding);
-
-    act(() => {
-      result.current.navigateToNextOnboardingStep();
-    });
-
-    await waitFor(() =>
-      expect(mockedNavigate).not.toBeCalledWith(Routes.NOTIFICATIONS_PERMISSION)
-    );
-  });
-
   it('should NOT navigate to profile flow when profile hasnt been fetched', async () => {
     mockPrimarySafeHelper({ hasProfile: false, isLoadingOnInit: true });
+
+    mockUsePersistedFlagsSelector({
+      hasSkippedBackup: true,
+      hasSkippedNotificationPermission: true,
+    });
 
     const { result } = renderHook(useShowOnboarding);
 
@@ -167,6 +156,11 @@ describe('useShowOnboarding', () => {
       isLoadingOnInit: true,
     });
 
+    mockUsePersistedFlagsSelector({
+      hasSkippedBackup: true,
+      hasSkippedNotificationPermission: true,
+    });
+
     const { result } = renderHook(useShowOnboarding);
 
     act(() => {
@@ -180,6 +174,11 @@ describe('useShowOnboarding', () => {
     mockPrimarySafeHelper({
       hasProfile: true,
       isLoadingOnInit: false,
+    });
+
+    mockUsePersistedFlagsSelector({
+      hasSkippedBackup: true,
+      hasSkippedNotificationPermission: true,
     });
 
     const { result } = renderHook(useShowOnboarding);
@@ -199,6 +198,11 @@ describe('useShowOnboarding', () => {
     mockPrimarySafeHelper({
       hasProfile: false,
       isLoadingOnInit: false,
+    });
+
+    mockUsePersistedFlagsSelector({
+      hasSkippedBackup: true,
+      hasSkippedNotificationPermission: true,
     });
 
     const { result } = renderHook(useShowOnboarding);
@@ -230,6 +234,10 @@ describe('useShowOnboarding', () => {
     mockPrimarySafeHelper({
       hasProfile: true,
       isLoadingOnInit: false,
+    });
+
+    mockUsePersistedFlagsSelector({
+      hasSkippedNotificationPermission: true,
     });
 
     const { result } = renderHook(useShowOnboarding);

--- a/cardstack/src/hooks/onboarding/__tests__/useShowOnboarding.test.ts
+++ b/cardstack/src/hooks/onboarding/__tests__/useShowOnboarding.test.ts
@@ -216,6 +216,8 @@ describe('useShowOnboarding', () => {
 
   it('should NOT navigate to profile creation flow if "Skip" was pressed', async () => {
     mockUsePersistedFlagsSelector({
+      hasSkippedBackup: true,
+      hasSkippedNotificationPermission: true,
       hasSkippedProfileCreation: true,
     });
 

--- a/cardstack/src/hooks/onboarding/useShowOnboarding.ts
+++ b/cardstack/src/hooks/onboarding/useShowOnboarding.ts
@@ -2,7 +2,6 @@ import { useNavigation } from '@react-navigation/native';
 import { RouteNames } from 'globals';
 import { useMemo, useCallback } from 'react';
 
-import { needsNotificationPermission } from '@cardstack/models/firebase';
 import { Routes } from '@cardstack/navigation/routes';
 import { useAuthSelector } from '@cardstack/redux/authSlice';
 import { usePrimarySafe } from '@cardstack/redux/hooks/usePrimarySafe';
@@ -40,9 +39,7 @@ export const useShowOnboarding = () => {
   // Calling this right after updating a store value will not have the dependencies updated,
   // so in some cases is necessary to call `navigateOnboardingTo` directly.
   const getNextOnboardingStep = useCallback(async () => {
-    const askForNotificationsPermissions = await needsNotificationPermission();
-
-    if (askForNotificationsPermissions && !hasSkippedNotificationPermission) {
+    if (!hasSkippedNotificationPermission) {
       return Routes.NOTIFICATIONS_PERMISSION;
     }
 
@@ -62,14 +59,17 @@ export const useShowOnboarding = () => {
   // Will navigate imperactively to provided route.
   const navigateOnboardingTo = useCallback(
     (route: RouteNames) => {
-      // Avoid showing profile flow when not wanted.
-      if (route === Routes.PROFILE_SLUG && !shouldShowProfileCreationFlow) {
+      // Avoid showing already completed flow.
+      if (
+        (route === Routes.PROFILE_SLUG && !shouldShowProfileCreationFlow) ||
+        (route === Routes.BACKUP_EXPLANATION && !shouldShowBackupFlow)
+      ) {
         return;
       }
 
       navigate(route);
     },
-    [navigate, shouldShowProfileCreationFlow]
+    [navigate, shouldShowProfileCreationFlow, shouldShowBackupFlow]
   );
 
   // Gets next onboarding step and tries to navigate.

--- a/cardstack/src/hooks/onboarding/useShowOnboarding.ts
+++ b/cardstack/src/hooks/onboarding/useShowOnboarding.ts
@@ -38,7 +38,7 @@ export const useShowOnboarding = () => {
   // Will check next possible onboarding step.
   // Calling this right after updating a store value will not have the dependencies updated,
   // so in some cases is necessary to call `navigateOnboardingTo` directly.
-  const getNextOnboardingStep = useCallback(async () => {
+  const getNextOnboardingStep = useCallback(() => {
     if (!hasSkippedNotificationPermission) {
       return Routes.NOTIFICATIONS_PERMISSION;
     }
@@ -60,10 +60,15 @@ export const useShowOnboarding = () => {
   const navigateOnboardingTo = useCallback(
     (route: RouteNames) => {
       // Avoid showing already completed flow.
-      if (
-        (route === Routes.PROFILE_SLUG && !shouldShowProfileCreationFlow) ||
-        (route === Routes.BACKUP_EXPLANATION && !shouldShowBackupFlow)
-      ) {
+      if (route === Routes.BACKUP_EXPLANATION && !shouldShowBackupFlow) {
+        navigateOnboardingTo(Routes.PROFILE_SLUG);
+
+        return;
+      }
+
+      if (route === Routes.PROFILE_SLUG && !shouldShowProfileCreationFlow) {
+        navigate(Routes.WALLET_SCREEN);
+
         return;
       }
 
@@ -73,8 +78,8 @@ export const useShowOnboarding = () => {
   );
 
   // Gets next onboarding step and tries to navigate.
-  const navigateToNextOnboardingStep = useCallback(async () => {
-    const nextStep = await getNextOnboardingStep();
+  const navigateToNextOnboardingStep = useCallback(() => {
+    const nextStep = getNextOnboardingStep();
 
     if (nextStep) {
       navigateOnboardingTo(nextStep);

--- a/cardstack/src/screens/NotificationsPermissionScreen/useNotificationsPermissionScreen.ts
+++ b/cardstack/src/screens/NotificationsPermissionScreen/useNotificationsPermissionScreen.ts
@@ -17,16 +17,15 @@ export const useNotificationsPermissionScreen = () => {
     onUpdateOptionStatus,
   } = useUpdateNotificationPreferences();
 
-  const handleEnableNotificationsOnPress = useCallback(async () => {
-    await checkPushPermissionAndRegisterToken();
-
-    navigateOnboardingTo(Routes.BACKUP_EXPLANATION);
-  }, [navigateOnboardingTo]);
-
   const handleSkipPress = useCallback(() => {
     triggerSkipNotificationPermission();
     navigateOnboardingTo(Routes.BACKUP_EXPLANATION);
   }, [triggerSkipNotificationPermission, navigateOnboardingTo]);
+
+  const handleEnableNotificationsOnPress = useCallback(async () => {
+    await checkPushPermissionAndRegisterToken();
+    handleSkipPress();
+  }, [handleSkipPress]);
 
   return {
     options,


### PR DESCRIPTION
### Description

This PR fixes two issues found in Notifications Preferences onboarding navigation:

- It wasn't showing on Android because Android has notifications enabled by default. Now the notification permission status is ignored so the permissions screen is always shown once.
- After notifications permissions step, it was showing the backup step regardless if users had or not a backup in place.

- [x] Completes #(CS-5032)
- [x] Completes #(CS-5027)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

#### iOS
https://user-images.githubusercontent.com/129619/209823004-3801fab0-b608-4ccb-b497-33cedf109c02.mp4

#### Android
https://user-images.githubusercontent.com/129619/209823193-9f69c846-3c3a-4fa0-95d4-c3b68d864092.mp4


