### PR TITLE
[CS-5056]: Fix pay tab crashing

### DIFF
--- a/patches/react-native-camera+3.44.3.patch
+++ b/patches/react-native-camera+3.44.3.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/react-native-camera/src/RNCamera.js b/node_modules/react-native-camera/src/RNCamera.js
+index b241b19..b215c45 100644
+--- a/node_modules/react-native-camera/src/RNCamera.js
++++ b/node_modules/react-native-camera/src/RNCamera.js
+@@ -5,7 +5,6 @@ import {
+   findNodeHandle,
+   Platform,
+   NativeModules,
+-  ViewPropTypes,
+   requireNativeComponent,
+   View,
+   ActivityIndicator,
+@@ -394,7 +393,6 @@ export default class Camera extends React.Component<PropsType, StateType> {
+   };
+ 
+   static propTypes = {
+-    ...ViewPropTypes,
+     zoom: PropTypes.number,
+     useNativeZoom: PropTypes.bool,
+     maxZoom: PropTypes.number,


### PR DESCRIPTION
### Description

With RN upgrade `ViewPropTypes` has been removed, but our camera package still uses it, so the app was crashing. For now I'm patching the package but we should move to use expo-camera, since RNCamera is deprecated.


### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->
<img width="300" alt="image" src="https://user-images.githubusercontent.com/20520102/209868371-5549f732-6289-4bad-b640-65cfafe71dcd.png">

