### PR TITLE
[CS-5033] Improves denied state UX in notifications settings.

### DIFF
--- a/src/components/settings-menu/NotificationsSection.tsx
+++ b/src/components/settings-menu/NotificationsSection.tsx
@@ -1,5 +1,5 @@
 import messaging from '@react-native-firebase/messaging';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   FlatList,
   Linking,
@@ -9,7 +9,13 @@ import {
 } from 'react-native';
 
 import { strings } from './strings';
-import { Button, Container, Skeleton, Text } from '@cardstack/components';
+import {
+  Button,
+  CenteredContainer,
+  Container,
+  Skeleton,
+  Text,
+} from '@cardstack/components';
 import {
   useAppState,
   useUpdateNotificationPreferences,
@@ -38,24 +44,21 @@ const showPermissionAlert = () =>
     message: strings.alert.message,
   });
 
-const PermissionDeniedPrompt = () => (
-  <Container
-    alignItems="center"
-    flex={0.9}
-    justifyContent="center"
-    marginHorizontal={10}
-  >
-    <Text paddingBottom={2} textAlign="center" variant="bold">
-      {strings.alert.handleDeniedPermission.title}
-    </Text>
-    <Text paddingBottom={6} textAlign="center">
-      {strings.alert.message}
-    </Text>
-    <Button onPress={Linking.openSettings}>
-      {strings.alert.handleDeniedPermission.actionButton}
-    </Button>
-  </Container>
-);
+const PermissionDeniedPrompt = memo(function PermissionDeniedPrompt() {
+  return (
+    <CenteredContainer flex={0.9} marginHorizontal={10}>
+      <Text paddingBottom={2} textAlign="center" variant="bold">
+        {strings.alert.handleDeniedPermission.title}
+      </Text>
+      <Text paddingBottom={6} textAlign="center">
+        {strings.alert.message}
+      </Text>
+      <Button onPress={Linking.openSettings}>
+        {strings.alert.handleDeniedPermission.actionButton}
+      </Button>
+    </CenteredContainer>
+  );
+});
 
 const NotificationsSection = () => {
   const { justBecameActive } = useAppState();

--- a/src/components/settings-menu/NotificationsSection.tsx
+++ b/src/components/settings-menu/NotificationsSection.tsx
@@ -1,5 +1,5 @@
 import messaging from '@react-native-firebase/messaging';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   FlatList,
   Linking,
@@ -9,8 +9,11 @@ import {
 } from 'react-native';
 
 import { strings } from './strings';
-import { Container, Skeleton, Text } from '@cardstack/components';
-import { useUpdateNotificationPreferences } from '@cardstack/hooks';
+import { Button, Container, Skeleton, Text } from '@cardstack/components';
+import {
+  useAppState,
+  useUpdateNotificationPreferences,
+} from '@cardstack/hooks';
 import {
   checkPushPermissionAndRegisterToken,
   getPermissionStatus,
@@ -19,31 +22,53 @@ import { NotificationsOptionsType } from '@cardstack/types';
 
 import { Alert } from '@rainbow-me/components/alerts';
 
-const showAlert = (
-  alertType: 'askPermission' | 'handleDeniedPermission',
-  onSuccessCallback: () => void
-) =>
+const showPermissionAlert = () =>
   Alert({
     buttons: [
       {
-        onPress: onSuccessCallback,
-        text: strings.alert[alertType].actionButton,
+        onPress: checkPushPermissionAndRegisterToken,
+        text: strings.alert.askPermission.actionButton,
       },
       {
         style: 'cancel',
         text: strings.alert.dismissButton,
       },
     ],
-    title: strings.alert[alertType].title,
+    title: strings.alert.askPermission.title,
     message: strings.alert.message,
   });
 
+const PermissionDeniedPrompt = () => (
+  <Container
+    alignItems="center"
+    flex={0.9}
+    justifyContent="center"
+    marginHorizontal={10}
+  >
+    <Text paddingBottom={2} textAlign="center" variant="bold">
+      {strings.alert.handleDeniedPermission.title}
+    </Text>
+    <Text paddingBottom={6} textAlign="center">
+      {strings.alert.message}
+    </Text>
+    <Button onPress={Linking.openSettings}>
+      {strings.alert.handleDeniedPermission.actionButton}
+    </Button>
+  </Container>
+);
+
 const NotificationsSection = () => {
+  const { justBecameActive } = useAppState();
+
   const {
     options,
     onUpdateOptionStatus,
     isError,
   } = useUpdateNotificationPreferences();
+
+  const [showPermissionDeniedPrompt, setShowPermissionDeniedPrompt] = useState(
+    false
+  );
 
   // In case user has skipped this check during Notifications Permissions onboarding step
   // we need to present them again to opt-in notifications.
@@ -53,14 +78,11 @@ const NotificationsSection = () => {
     try {
       const permissionStatus = await getPermissionStatus();
 
-      switch (permissionStatus) {
-        case NOT_DETERMINED:
-          showAlert('askPermission', checkPushPermissionAndRegisterToken);
-          break;
-        case DENIED:
-          showAlert('handleDeniedPermission', Linking.openSettings);
-          break;
+      if (permissionStatus === NOT_DETERMINED) {
+        showPermissionAlert();
       }
+
+      setShowPermissionDeniedPrompt(permissionStatus === DENIED);
     } catch (error) {
       console.log(
         'Error checking if a user has push notifications permission',
@@ -71,7 +93,7 @@ const NotificationsSection = () => {
 
   useEffect(() => {
     pushPermissionCheck();
-  }, [pushPermissionCheck]);
+  }, [pushPermissionCheck, justBecameActive]);
 
   const renderItem = useCallback(
     ({ item }: ListRenderItemInfo<NotificationsOptionsType>) => {
@@ -128,6 +150,10 @@ const NotificationsSection = () => {
   );
 
   const keyExtractor = (item: NotificationsOptionsType) => item.type;
+
+  if (showPermissionDeniedPrompt) {
+    return <PermissionDeniedPrompt />;
+  }
 
   return (
     <FlatList

--- a/src/components/settings-menu/strings.ts
+++ b/src/components/settings-menu/strings.ts
@@ -8,7 +8,7 @@ export const strings = {
       actionButton: 'Okay',
     },
     handleDeniedPermission: {
-      title: 'You have notifications disabled',
+      title: 'Notifications are disabled',
       actionButton: 'Open Settings',
     },
   },


### PR DESCRIPTION
### Description

This PR improves the notifications settings section UX by avoiding to show notification options when the user hasn't agreed on getting them. Instead of the usual alert, users are presented with a "declined state" UI.

- [x] Completes #(CS-5033)

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

#### iOS

https://user-images.githubusercontent.com/129619/209870837-f9e63889-2369-4a77-871c-3a2241addd1c.mp4

#### Android

https://user-images.githubusercontent.com/129619/209872622-fb0f8cc9-33ed-4d30-94e1-72bd13d1cbcf.mp4

#### iOS SE

<img src="https://user-images.githubusercontent.com/129619/209871690-5807cf46-008d-478c-827a-762e43e05a20.png" width="300">

