### PR TITLE
[CS-5054]: Fix flicker on auto polling

### DIFF
--- a/cardstack/src/components/AssetList/AssetList.tsx
+++ b/cardstack/src/components/AssetList/AssetList.tsx
@@ -27,7 +27,7 @@ export const AssetList = () => {
     isLoading,
     goToBuyPrepaidCard,
     onRefresh,
-    refreshing,
+    isRefetchingEoaAssets,
     networkName,
     hasClaimableRewards,
   } = useAssetList({ sectionListRef });
@@ -50,14 +50,15 @@ export const AssetList = () => {
   );
 
   const renderSectionFooter = useCallback(
-    ({ section: { timestamp, data } }) =>
+    ({ section: { timestamp, data, type } }) =>
       timestamp && !!data.length ? (
         <Container
           paddingHorizontal={4}
           alignItems="flex-end"
           justifyContent="center"
         >
-          {isFetchingSafes ? (
+          {(type === 'safe' && isFetchingSafes) ||
+          (type === 'eoaAsset' && isRefetchingEoaAssets) ? (
             <ActivityIndicator size={15} color="white" />
           ) : (
             <Text color="white" size="xs">
@@ -66,7 +67,7 @@ export const AssetList = () => {
           )}
         </Container>
       ) : null,
-    [isFetchingSafes]
+    [isFetchingSafes, isRefetchingEoaAssets]
   );
 
   const renderListHeaderComponent = useMemo(
@@ -93,8 +94,9 @@ export const AssetList = () => {
         refreshControl={
           <RefreshControl
             tintColor="white"
-            refreshing={refreshing}
             onRefresh={onRefresh}
+            // This is a required prop, but we are handling the visual feedback in another way
+            refreshing={false}
           />
         }
         sections={sections}

--- a/cardstack/src/components/AssetList/types.ts
+++ b/cardstack/src/components/AssetList/types.ts
@@ -31,6 +31,7 @@ export type AssetListSectionItem<ComponentProps> = {
   header: HeaderItem;
   data: ComponentProps[];
   timestamp?: string;
+  type: 'collectible' | 'safe' | 'eoaAsset';
 };
 
 export type SectionType =

--- a/cardstack/src/components/AssetList/useAssetList.ts
+++ b/cardstack/src/components/AssetList/useAssetList.ts
@@ -42,18 +42,26 @@ export const useAssetList = ({
   );
 
   // Handle refresh
-  const { refresh, isRefetching: isRefetchingEoaAssets } = useAssets();
+  const {
+    refresh: refreshAssets,
+    isRefetching: isRefetchingEoaAssets,
+  } = useAssets();
+
   const { refetch: refetchServiceStatus } = useGetServiceStatusQuery();
 
-  const onRefresh = useCallback(async () => {
-    refetchSafes();
+  const { network, isOnCardPayNetwork } = useAccountSettings();
+
+  const onRefresh = useCallback(() => {
+    if (isOnCardPayNetwork) {
+      refetchSafes();
+    }
 
     // Refresh Service Status Notice
     refetchServiceStatus();
 
     // Refresh Account Data
-    refresh();
-  }, [refetchSafes, refetchServiceStatus, refresh]);
+    refreshAssets();
+  }, [isOnCardPayNetwork, refetchSafes, refetchServiceStatus, refreshAssets]);
 
   useEffect(() => {
     if (params?.forceRefreshOnce) {
@@ -95,9 +103,6 @@ export const useAssetList = ({
 
     navigate(Routes.BUY_PREPAID_CARD);
   }, [isDamaged, navigate]);
-
-  // Extra component props
-  const { network } = useAccountSettings();
 
   const networkName = useMemo(() => getConstantByNetwork('name', network), [
     network,

--- a/cardstack/src/components/AssetList/useAssetList.ts
+++ b/cardstack/src/components/AssetList/useAssetList.ts
@@ -32,7 +32,6 @@ export const useAssetList = ({
   const {
     sections,
     isLoadingAssets,
-    isEmpty,
     refetchSafes,
     isFetchingSafes,
   } = useAssetListData();
@@ -43,7 +42,7 @@ export const useAssetList = ({
   );
 
   // Handle refresh
-  const { refresh, isRefetching } = useAssets();
+  const { refresh, isRefetching: isRefetchingEoaAssets } = useAssets();
   const { refetch: refetchServiceStatus } = useGetServiceStatusQuery();
 
   const onRefresh = useCallback(async () => {
@@ -107,9 +106,8 @@ export const useAssetList = ({
   return {
     isLoading: isLoadingAssets || isLoadingSafesDiffAccount,
     isFetchingSafes,
-    refreshing: isRefetching,
+    isRefetchingEoaAssets,
     sections,
-    isEmpty,
     goToBuyPrepaidCard,
     onRefresh,
     networkName,

--- a/cardstack/src/hooks/assets/useAssets.ts
+++ b/cardstack/src/hooks/assets/useAssets.ts
@@ -18,6 +18,7 @@ import {
 } from '@cardstack/services/eoa-assets/eoa-assets-api';
 import { AssetsDictionary } from '@cardstack/services/eoa-assets/eoa-assets-types';
 import { AssetWithNativeType } from '@cardstack/types';
+import { jsTimestampToUnixString } from '@cardstack/utils';
 
 import { useAccountSettings } from '@rainbow-me/hooks';
 
@@ -43,6 +44,7 @@ const useAssets = () => {
     isLoading: isLoadingAssets,
     isFetching: isRefetchingAssets,
     refetch: refetchAssets,
+    fulfilledTimeStamp: assetsFulfilledTimeStamp = 0,
   } = useGetEOAAssetsQuery(
     {
       accountAddress,
@@ -58,7 +60,6 @@ const useAssets = () => {
   const {
     data: prices,
     isLoading: isLoadingPrices,
-    isFetching: isRefetchingPrices,
     refetch: refetchPrices,
   } = useGetAssetsPriceByContractQuery(
     { addresses: ids, nativeCurrency, network },
@@ -68,7 +69,6 @@ const useAssets = () => {
   const {
     data: gnosisPrices,
     isLoading: isLoadingGnosisPrices,
-    isFetching: isRefetchingGnosisPrices,
     refetch: refetchGnosisPrices,
   } = useGetCardPayTokensPricesQuery(
     { nativeCurrency },
@@ -81,7 +81,6 @@ const useAssets = () => {
   const {
     data: nativeTokenPrice,
     refetch: refetchNativePrice,
-    isFetching: isRefetchingNativePrice,
     isLoading: isLoadingNativePrice,
   } = useGetNativeTokensPriceQuery(
     {
@@ -96,6 +95,7 @@ const useAssets = () => {
     isLoading: isLoadingBalances,
     refetch: refetchBalances,
     isFetching: isRefetchingBalances,
+    fulfilledTimeStamp: balancesFullfiledTimestamp = 0,
   } = useGetOnChainTokenBalancesQuery(
     { assets, accountAddress, network },
     {
@@ -205,20 +205,16 @@ const useAssets = () => {
   );
 
   const isRefetching = useMemo(
-    () =>
-      isRefetchingPrices ||
-      isRefetchingBalances ||
-      isRefetchingGnosisPrices ||
-      isRefetchingAssets ||
-      isRefetchingNativePrice,
-    [
-      isRefetchingAssets,
-      isRefetchingBalances,
-      isRefetchingGnosisPrices,
-      isRefetchingNativePrice,
-      isRefetchingPrices,
-    ]
+    () => isRefetchingBalances || isRefetchingAssets,
+    [isRefetchingAssets, isRefetchingBalances]
   );
+
+  const unixFulfilledTimestamp = useMemo(() => {
+    const timestamps = [balancesFullfiledTimestamp, assetsFulfilledTimeStamp];
+    const latestTimestamp = Math.max(...timestamps);
+
+    return jsTimestampToUnixString(latestTimestamp);
+  }, [assetsFulfilledTimeStamp, balancesFullfiledTimestamp]);
 
   return {
     assetsIdWithoutNfts,
@@ -227,6 +223,7 @@ const useAssets = () => {
     legacyAssetsStruct,
     isLoading,
     isRefetching,
+    unixFulfilledTimestamp,
     refresh,
     refetchBalances,
     getAsset,

--- a/cardstack/src/hooks/assets/useAssets.ts
+++ b/cardstack/src/hooks/assets/useAssets.ts
@@ -175,12 +175,16 @@ const useAssets = () => {
   );
 
   const refresh = useCallback(() => {
+    if (isOnCardPayNetwork) {
+      refetchGnosisPrices();
+    }
+
     refetchAssets();
     refetchBalances();
     refetchPrices();
-    refetchGnosisPrices();
     refetchNativePrice();
   }, [
+    isOnCardPayNetwork,
     refetchAssets,
     refetchBalances,
     refetchGnosisPrices,

--- a/cardstack/src/services/gnosis-service.ts
+++ b/cardstack/src/services/gnosis-service.ts
@@ -13,7 +13,10 @@ import { captureException } from '@sentry/react-native';
 
 import { getSafesInstance } from '@cardstack/models/safes-providers';
 import Web3Instance from '@cardstack/models/web3-instance';
-import { updateMerchantSafeWithCustomization } from '@cardstack/utils';
+import {
+  jsTimestampToUnixString,
+  updateMerchantSafeWithCustomization,
+} from '@cardstack/utils';
 
 import {
   getDepots,
@@ -82,14 +85,11 @@ export const fetchSafes = async (
       extendAllDepotSafes,
     ]);
 
-    // Unix timestamp
-    const timestamp = Math.ceil(Date.now() / 1000).toString();
-
     const data = {
       depots: extendedDepots,
       prepaidCards: extendedPrepaidCards,
       merchantSafes: extendedMerchantSafes,
-      timestamp,
+      timestamp: jsTimestampToUnixString(Date.now()),
     };
 
     const network = await getNetwork();
@@ -98,21 +98,21 @@ export const fetchSafes = async (
       data.prepaidCards,
       accountAddress,
       network,
-      timestamp
+      data.timestamp
     );
 
     const saveDepts = saveDepots(
       data.depots,
       accountAddress,
       network,
-      timestamp
+      data.timestamp
     );
 
     const saveMerchant = saveMerchantSafes(
       data.merchantSafes,
       accountAddress,
       network,
-      timestamp
+      data.timestamp
     );
 
     await Promise.all([saveCards, saveDepts, saveMerchant]);

--- a/cardstack/src/utils/date-utils.ts
+++ b/cardstack/src/utils/date-utils.ts
@@ -114,13 +114,24 @@ export const groupAccumulations = (
   return '0';
 };
 
+// Unix timestamp measures time as a number of seconds,
+// whereas in JavaScript  measures  time as number of milliseconds
+const MS = 1000;
+
+export const jsTimestampToUnixString = (ts?: number) =>
+  ts ? Math.floor(ts / MS).toString() : '';
+
+const unixTimestampToJs = (ts: number) => ts * MS;
+
+// The default timestamp is in unix because all the services
+// return this format
 export const dateFormatter = (
-  ts: number,
+  unixTimestamp: number,
   dateTimeFormat = 'MMM-dd-yyyy',
   timeFormat = 'h:mm:ss a',
   delimitation = '\n'
 ) => {
-  const timestamp = new Date(ts * 1000);
+  const timestamp = new Date(unixTimestampToJs(unixTimestamp));
 
   return `${format(timestamp, dateTimeFormat)}${delimitation}${format(
     timestamp,

--- a/src/hooks/useAssetListData.tsx
+++ b/src/hooks/useAssetListData.tsx
@@ -51,6 +51,7 @@ const usePrepaidCardSection = (
     data: prepaidCards,
     timestamp,
     Component: PrepaidCard,
+    type: 'safe',
   };
 };
 
@@ -64,6 +65,7 @@ const useDepotSection = (
   data: depots,
   timestamp,
   Component: Depot,
+  type: 'safe',
 });
 
 const useMerchantSafeSection = (
@@ -77,10 +79,15 @@ const useMerchantSafeSection = (
   data: merchantSafes,
   timestamp,
   Component: MerchantSafe,
+  type: 'safe',
 });
 
 const useOtherTokensSection = (): AssetListSectionItem<AssetWithNativeType> => {
-  const { legacyAssetsStruct, getTotalAssetNativeBalance } = useAssets();
+  const {
+    legacyAssetsStruct,
+    getTotalAssetNativeBalance,
+    unixFulfilledTimestamp,
+  } = useAssets();
 
   const { hidden } = usePinnedAndHiddenItemOptions();
 
@@ -98,6 +105,8 @@ const useOtherTokensSection = (): AssetListSectionItem<AssetWithNativeType> => {
     },
     data: assets,
     Component: BalanceCoinRowWrapper,
+    timestamp: unixFulfilledTimestamp,
+    type: 'eoaAsset',
   };
 };
 
@@ -113,6 +122,7 @@ const useCollectiblesSection = (): AssetListSectionItem<CollectibleType> => {
     },
     data: collectibles,
     Component: CollectibleRow,
+    type: 'collectible',
   };
 };
 
@@ -178,10 +188,8 @@ export const useAssetListData = () => {
         isOnCardPayNetwork)
   );
 
-  const isEmpty = !sections.length;
   return {
     isLoadingAssets,
-    isEmpty,
     sections,
     refetchSafes,
     isFetchingSafes,


### PR DESCRIPTION
### Description

This PR adds the same behavior for other tokens as we have on safes while refreshing by showing a timestamp of the last updated value, or a loading indicator while refreshing. I've removed the prices from the refetch loading flag since it updates every 10s, and it doesn't seem valuable for the user to have a feedback about that, but I'm open to discussions.  I've also add timestamp handling functions, to avoid any confusions, we mostly use unix timestamp because the sdk uses it, so we need a way to handle js-to-unix and unix-to-js. Anyways, these implementations fixes the flickering since now the refresh feedback is different. It also fixes a refresh error I've found on non cardpay networks.

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

### Screenshots

<!-- Use tag bellow to format image size -->

<!--
<img width="300" alt="Screenshot" src="URL_GOES_HERE">
-->


https://user-images.githubusercontent.com/20520102/210862054-953de470-c10b-482b-abf3-01428e732270.mp4

