### PR TITLE
[CS-5018] Clear async storage to reset WC pairings/sessions

### DIFF
--- a/src/model/wallet.ts
+++ b/src/model/wallet.ts
@@ -1,3 +1,4 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { captureException } from '@sentry/react-native';
 import { generateMnemonic } from 'bip39';
 import { signTypedData_v4, signTypedDataLegacy } from 'eth-sig-util';
@@ -860,12 +861,25 @@ export const updateWalletWithNewPIN = async (newPin: string) => {
   }
 };
 
+const wipeAsyncStorage = async () => {
+  try {
+    const allKeys = await AsyncStorage.getAllKeys();
+
+    await AsyncStorage.multiRemove(allKeys);
+    logger.log('Async Storage cleared!');
+  } catch (e) {
+    logger.sentry('Error clearing async storage', e);
+    captureException(e);
+  }
+};
+
 export const resetWallet = async () => {
   try {
     const allWallets = await getAllWallets();
 
     // clearing secure storage and keychain
     if (allWallets) {
+      await wipeAsyncStorage();
       await wipeSecureStorage(allWallets);
       await keychain.wipeKeychain();
 


### PR DESCRIPTION
### Description
This PR adds a new step to the `resetWallet` function in order to also clear the async storage. With this approach, we handle not only the WalletConnect sessions and pairing, but also all the other things saved on the async storage that should be deleted after resetting a wallet.

- [x] Completes #CS-5018

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

