### PR TITLE
[CS-5115] Rename app to Card Pay/Card Pay Wallet

### DIFF
--- a/android/app/src/main/debug/res/values/strings.xml
+++ b/android/app/src/main/debug/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Card Wallet Debug</string>
+    <string name="app_name">Card Pay Wallet Debug</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Cardstack</string>
+    <string name="app_name">Card Pay</string>
 </resources>

--- a/android/app/src/main/staging/res/values/strings.xml
+++ b/android/app/src/main/staging/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Card Wallet Staging</string>
+    <string name="app_name">Card Pay Wallet Staging</string>
 </resources>

--- a/cardstack/src/constants.ts
+++ b/cardstack/src/constants.ts
@@ -27,5 +27,5 @@ export const defaultErrorAlert = {
 
 export const cardSpaceSuffix = 'card.xyz';
 export const cardSpaceDomain = `.${cardSpaceSuffix}`;
-export const appName = 'Cardstack Wallet';
+export const appName = 'Card Pay Wallet';
 export const appVersion = `${DeviceInfo.getVersion()} (${DeviceInfo.getBuildNumber()})`;

--- a/ios/Rainbow/Info.plist
+++ b/ios/Rainbow/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Cardstack</string>
+	<string>Card Pay</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/src/components/settings-menu/strings.ts
+++ b/src/components/settings-menu/strings.ts
@@ -1,10 +1,12 @@
+import { appName } from '@cardstack/constants';
+
 export const strings = {
   errorMessage: 'Failed to get notification preferences',
   alert: {
     message: 'Please enable push notifications to be notified of transactions',
     dismissButton: 'Dismiss',
     askPermission: {
-      title: 'Cardstack Wallet would like to send you push notifications',
+      title: `${appName} would like to send you push notifications`,
       actionButton: 'Okay',
     },
     handleDeniedPermission: {


### PR DESCRIPTION
### Description
The app name on the user's phone will be Card Pay for brevity, but everywhere else on the app we will refer to it as "Card Pay Wallet" like we were doing before (Cardstack for app name and Cardstack Wallet inside the app).

- [x] Completes #CS-5115

### Checklist

- [x] Tested on a small device
- [x] Tested on iOS
- [x] Tested on Android

