### PR TITLE
[CS-5114]: Improve transactions list performance

### DIFF
--- a/cardstack/src/components/TransactionList/TransactionList.tsx
+++ b/cardstack/src/components/TransactionList/TransactionList.tsx
@@ -1,4 +1,4 @@
-import { useRoute, useMemo } from '@react-navigation/native';
+import { useRoute } from '@react-navigation/native';
 import React, { memo, useCallback, useEffect } from 'react';
 import { RefreshControl, SectionList, ActivityIndicator } from 'react-native';
 
@@ -9,10 +9,8 @@ import {
   TransactionItem,
   TransactionItemProps,
 } from '@cardstack/components';
-import { useFullTransactionList } from '@cardstack/hooks';
+import { useCardPayCompatible } from '@cardstack/hooks';
 import { RouteType } from '@cardstack/navigation/types';
-
-import { useAccountSettings } from '@rainbow-me/hooks';
 
 import { TransactionListLoading } from './TransactionListLoading';
 import { strings } from './strings';
@@ -28,7 +26,6 @@ interface NavParams {
 }
 
 export const TransactionList = memo(({ Header }: TransactionListProps) => {
-  const { isOnCardPayNetwork, network } = useAccountSettings();
   const { params } = useRoute<RouteType<NavParams>>();
 
   const {
@@ -38,7 +35,7 @@ export const TransactionList = memo(({ Header }: TransactionListProps) => {
     sections,
     refetch,
     refetchLoading,
-  } = useFullTransactionList();
+  } = useCardPayCompatible();
 
   const onRefresh = useCallback(() => {
     if (!isLoadingTransactions || !refetchLoading) {
@@ -77,14 +74,6 @@ export const TransactionList = memo(({ Header }: TransactionListProps) => {
     return `${key}-${index}`;
   }, []);
 
-  const title = useMemo(
-    () =>
-      isOnCardPayNetwork
-        ? strings.emptyComponent
-        : strings.nonCardPayNetwork(network),
-    [isOnCardPayNetwork, network]
-  );
-
   return (
     <SectionList
       ListEmptyComponent={
@@ -92,7 +81,11 @@ export const TransactionList = memo(({ Header }: TransactionListProps) => {
           <TransactionListLoading />
         ) : (
           <Container paddingTop={4}>
-            <ListEmptyComponent text={title} textColor="blueText" hasRoundBox />
+            <ListEmptyComponent
+              text={strings.emptyComponent}
+              textColor="blueText"
+              hasRoundBox
+            />
           </Container>
         )
       }

--- a/cardstack/src/hooks/transactions/use-full-transaction-list.tsx
+++ b/cardstack/src/hooks/transactions/use-full-transaction-list.tsx
@@ -1,19 +1,15 @@
 import { NetworkStatus } from '@apollo/client';
-import { isCardPaySupportedNetwork } from '@cardstack/cardpay-sdk';
 
 import { useGetAccountTransactionHistoryDataQuery } from '@cardstack/graphql';
-import { NetworkType } from '@cardstack/types';
-import { isLayer1 } from '@cardstack/utils';
 
-import { useAccountSettings, useAccountTransactions } from '@rainbow-me/hooks';
+import { useAccountSettings } from '@rainbow-me/hooks';
 import logger from 'logger';
 
-import { useRainbowSelector } from '../../../../src/redux/hooks';
 import { TRANSACTION_PAGE_SIZE } from '../../constants';
 
 import { useTransactionSections } from './use-transaction-sections';
 
-const useCardPayCompatible = () => {
+export const useCardPayCompatible = () => {
   const { accountAddress, network, noCardPayAccount } = useAccountSettings();
 
   const {
@@ -60,35 +56,5 @@ const useCardPayCompatible = () => {
     refetch,
     refetchLoading: networkStatus === NetworkStatus.refetch,
     sections: sections,
-  };
-};
-
-export const useFullTransactionList = () => {
-  const network = useRainbowSelector(
-    state => state.settings.network
-  ) as NetworkType;
-
-  const layer1Data = useAccountTransactions();
-  const cardPayCompatibledata = useCardPayCompatible();
-
-  if (isCardPaySupportedNetwork(network)) {
-    return cardPayCompatibledata;
-  }
-
-  if (isLayer1(network)) {
-    return {
-      ...layer1Data,
-      refetch: () => ({}),
-      refetchLoading: false,
-    };
-  }
-
-  return {
-    onEndReached: () => ({}),
-    isLoadingTransactions: false,
-    isFetchingMore: false,
-    sections: [],
-    refetch: () => ({}),
-    refetchLoading: false,
   };
 };

--- a/cardstack/src/screens/HomeScreen/HomeScreen.tsx
+++ b/cardstack/src/screens/HomeScreen/HomeScreen.tsx
@@ -1,17 +1,34 @@
 import React from 'react';
 
-import { Container, MainHeader, TransactionList } from '@cardstack/components';
+import {
+  Container,
+  ListEmptyComponent,
+  MainHeader,
+  TransactionList,
+} from '@cardstack/components';
+import { strings } from '@cardstack/components/TransactionList/strings';
 
 import { useAccountSettings } from '@rainbow-me/hooks';
 
 const HomeScreen = () => {
-  const { accountAddress } = useAccountSettings();
+  const { accountAddress, isOnCardPayNetwork, network } = useAccountSettings();
 
   return (
     <Container backgroundColor="backgroundDarkPurple" flex={1}>
       <MainHeader title="ACTIVITY" />
       <Container flex={1}>
-        <TransactionList accountAddress={accountAddress} />
+        {isOnCardPayNetwork ? (
+          <TransactionList accountAddress={accountAddress} />
+        ) : (
+          <Container paddingTop={4}>
+            <ListEmptyComponent
+              text={strings.nonCardPayNetwork(network)}
+              textColor="blueText"
+              hasRoundBox
+              flex={0}
+            />
+          </Container>
+        )}
       </Container>
     </Container>
   );

--- a/cardstack/src/screens/PayMerchant/usePayMerchant.ts
+++ b/cardstack/src/screens/PayMerchant/usePayMerchant.ts
@@ -94,7 +94,7 @@ const usePayMerchantRequest = ({
     dismissLoadingOverlay();
 
     // Navigate to Transaction screen
-    navigate(Routes.HOME_SCREEN);
+    navigate(Routes.HOME_SCREEN, { forceRefresh: true });
 
     // Wait goBack action to navigate
     InteractionManager.runAfterInteractions(() => {


### PR DESCRIPTION
### Description
This PR adds some props on Transaction list to improve its performance, like the custom keyExtractor and the amount of items to render, unfortunately we cannot use getItemLayout, giving each transaction has a different size in our layout.
I've noticed the RefetchOnFocus, was added to handle a single case after paying a merchant so in order to make the render less expensive I've replaced the on focus event with a navigation param for that screen, this way it won't be refetching on every navigation, and the manual refresh is also available.
The useFullTransactions hook was removed in favor of useCardPayCompatible since we are not showing txs on any other networks, it didn't make much sense to keep using both hooks, which was never the ideal approach since both hooks were being triggered on networks they didn't need to. I've moved the message of nonCarpay networks to the main component and we just render the transaction list now for gnosis. If we want to re-add transaction list for other networks we should make TransactionList a reusable component and use a hook in each of the components. e.g. CardPayTransactions component uses `useCardPayCompatible` and renders a `TransactionList` and NonCardPayTransactions, uses `useAccountTransactions` and also renders a `TransactionList`,  based on the network we choose which component should be render. 

`useTransactionSections` is a legacy code that's been a nightmare, I've tried to improve it's readability and avoid unnecessary renders but the ideal scenario would to be refactor it. Unfortunately we don't have the time for that.
